### PR TITLE
Harden planning precedence and minimal-diff reconciliation rules

### DIFF
--- a/CONTRIBUTOR_INSTRUCTIONS.md
+++ b/CONTRIBUTOR_INSTRUCTIONS.md
@@ -225,6 +225,10 @@ The repository planning/control hierarchy is authoritative and must be preserved
 2. Concrete implementation plans in `vX.Y.Z_plan.md`
 3. Governance via ADRs (`docs/improvement/adrs/`) and Standards (`docs/standards/`)
 
+Conflict rule: ADRs and Standards govern design, behavior, architecture, and
+engineering standards. If any plan text conflicts with an ADR/Standard, the
+ADR/Standard is authoritative and must win.
+
 Do not redesign, replace, or create a parallel planning hierarchy unless one of these
 is true:
 
@@ -238,6 +242,17 @@ When a shared instruction must be added or updated, `CONTRIBUTOR_INSTRUCTIONS.md
 is the primary location. Platform-specific files (`AGENTS.md`, `CLAUDE.md`,
 `GEMINI.md`, `.github/copilot-instructions.md`) must not become the main source of
 repository-wide engineering rules.
+
+Default execution posture for plan/instruction edits:
+
+- If no concrete contradiction, missing required rule, or execution blocker
+  exists, make no structural documentation changes.
+- Apply minimum-diff edits only; preserve existing headings, numbering,
+  milestone-plan structure, and future-milestone detail unless a concrete
+  conflict requires local clarification.
+- Do not create new plan/policy/checklist files by default; prefer resolving
+  shared guidance in this file with short cross-references from plans only when
+  necessary.
 
 ---
 

--- a/docs/improvement/RELEASE_PLAN_v1.md
+++ b/docs/improvement/RELEASE_PLAN_v1.md
@@ -57,7 +57,8 @@ A milestone cannot close while any of the following remains open:
   - **Next action:** Re-baseline future milestone statuses only when the active milestone boundary is reached.
 - **Boundary-update policy**
   - **Status:** Governance/planning docs are updated at milestone boundaries, not on every PR.
-  - **Next action:** Apply batched updates at milestone close/open checkpoints to keep process overhead low.
+  - **Next action:** Apply batched plan-grooming updates at milestone close/open checkpoints to keep process overhead low.
+  - **Scope clarification:** This boundary policy applies to milestone plan grooming only; it does not override required same-PR updates to `CONTRIBUTOR_INSTRUCTIONS.md` or other mandated control/checklist files when code/API/governance changes require them.
 - **Traceability of completed work**
   - **Status:** Completed items remain in plan/checklist artifacts and are marked complete rather than removed.
   - **Next action:** Continue preserving completed entries for release audit traceability.


### PR DESCRIPTION
### Motivation
- Final reconciliation pass to remove residual cross-category ambiguity by making ADR/Standards precedence explicit and enforcing a no-change-by-default, minimal-diff posture for planning/agent instruction edits so plans, contributor guidance, and ADRs remain consistent.

### Description
- Add an explicit conflict-precedence clause and a compact default execution posture (no-change-by-default, minimum-diff edits, and no casual new plan/policy files) to `CONTRIBUTOR_INSTRUCTIONS.md`, and clarify that the `RELEASE_PLAN_v1.md` boundary-update policy applies to plan-grooming only and does not override required same-PR updates to mandated control/checklist files; only these two files were changed.

### Testing
- Ran `make local-checks-pr` (which executes the repository local checks and core test suite); the command completed successfully and unit/integration checks passed (core tests ran successfully in this environment).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69d40d21fb6883298d1e172ca553f9bb)