### PR TITLE
Make ADRs evidence-bearing: link ADRs ↔ claims ↔ requirements and add verification metadata

### DIFF
--- a/development/adrs/ADR-001-core-decomposition-boundaries.md
+++ b/development/adrs/ADR-001-core-decomposition-boundaries.md
@@ -40,6 +40,11 @@ Rules:
 - Utilities layer must not depend on higher-level packages.
 - Schema validation lives separately to avoid heavy imports where not needed.
 
+
+## Governed claims
+
+- `CE-CAP-CORE-001` — Core package boundaries preserve stable separation between core, calibration, explanations, schema, plugins, cache, and parallel services.
+
 ## Alternatives Considered
 
 1. Flat module namespace (simpler, but scaling pain and import cycles risk).

--- a/development/adrs/ADR-002-validation-and-exception-design.md
+++ b/development/adrs/ADR-002-validation-and-exception-design.md
@@ -53,6 +53,11 @@ Logging & surfacing:
 - Optionally attach last validation errors summary to a debug report generation utility.
 - Provide `explain_exception(e)` helper to produce human-oriented multi-line message.
 
+
+## Governed claims
+
+- `CE-CAP-VALID-001` — Public validation failures use the CE exception taxonomy rather than ad-hoc generic exceptions where ADR-002 scope applies.
+
 ## Alternatives Considered
 
 1. Keep ad-hoc exceptions (low effort, inconsistent quality).

--- a/development/adrs/ADR-003-caching-key-and-eviction.md
+++ b/development/adrs/ADR-003-caching-key-and-eviction.md
@@ -1,6 +1,6 @@
 > **Active scope:** Governing architectural decision for the explanation cache key design and eviction policy. Remains active as long as the cache key contract governs performance-sensitive explain paths; superseded when the caching strategy is revised.
 
-> **Status note (2025-11-29):** Last edited 2025-11-29 · Archive after: v1.0.0 GA · Implementation: Fully completed in v0.10.0 · All ADR-003 gates satisfied per `docs/improvement/adr\ mending/ADR-003/COMPLETION_REPORT.md`.
+> **Status note (2025-11-29):** Last edited 2025-11-29 · Archive after: v1.0.0 GA · Implementation: Fully completed in v0.10.0 · All ADR-003 gates are tracked in `development/current-work/RELEASE_PLAN_status_appendix.md`.
 
 # ADR-003: Caching Key & Eviction Strategy
 
@@ -45,6 +45,11 @@ Adopt a lightweight, opt-in in-process cache with simple, deterministic keys and
 
 - Update README and release notes with configuration tables, tuning guidance, and the support policy for the cache namespace taxonomy.
 - Record STRATEGY_REV identifiers in the ADR appendix and reference them from the release checklist to ensure invalidation discipline.
+
+
+## Governed claims
+
+- `CE-CAP-CACHE-001` — Caching is opt-in, transparent to public APIs, and governed by deterministic key and fallback visibility constraints.
 
 ## Alternatives Considered
 

--- a/development/adrs/ADR-004-parallel-backend-abstraction.md
+++ b/development/adrs/ADR-004-parallel-backend-abstraction.md
@@ -50,6 +50,11 @@ The following clarifications capture the guardrails for explicit, opt-in paralle
 - Extend configuration docs and release notes with the explicit opt-in model, environment variable controls, and troubleshooting tips for common platforms (macOS spawn, Windows spawn).
 - Ship an upgrade guide snippet covering interaction with plugin-provided executors and guidance for opting out when running within user-managed pools.
 
+
+## Governed claims
+
+- `CE-CAP-PARALLEL-001` — Parallel execution remains explicit and opt-in, with deterministic result ordering and serial-by-default behavior.
+
 ## Alternatives Considered
 
 1. Hard-code joblib everywhere (adds dependency, hides heuristics, less explicit control).

--- a/development/adrs/ADR-005-explanation-json-schema-versioning.md
+++ b/development/adrs/ADR-005-explanation-json-schema-versioning.md
@@ -122,6 +122,11 @@ must come with:
   elementwise for vector predictions as well as scalars.
 - Envelope validation is **out of scope** for v1.0.0.
 
+
+## Governed claims
+
+- `CE-CAP-SCHEMA-001` — Explanation payloads use a versioned CE-first schema contract with explicit metadata and governed extension surfaces.
+
 ## Alternatives Considered
 
 1. **Full envelope now** — Rejected for v1.0.0 because it is not implemented in the

--- a/development/adrs/ADR-006-plugin-registry-trust-model.md
+++ b/development/adrs/ADR-006-plugin-registry-trust-model.md
@@ -40,6 +40,11 @@ Implement a conservative, opt-in plugin registry with explicit trust policy hook
 - Isolation: no sandboxing initially (document risk); future ADR may explore subprocess / WASM.
 - **Delegation & Ownership:** The `PluginManager` serves as the single source of truth for plugin resolution and defaults. `CalibratedExplainer` delegates all explanation requests to this manager, ensuring that trust and opt-in rules are consistently enforced regardless of the entry point.
 
+
+## Governed claims
+
+- `CE-CAP-PLUGIN-001` — calibrated_explanations exposes an extensible plugin system through the   calibrated_explanations.plugins module: ExplainerPlugin defines the protocol for   custom explanation backends, and IntervalCalibratorPlugin defines the protocol for   custom interval calibrators, enabling replacement of default internal implementations.
+
 ## Alternatives Considered
 
 1. Auto-load all entry points (simpler, higher risk).

--- a/development/adrs/ADR-008-explanation-domain-model-and-compat.md
+++ b/development/adrs/ADR-008-explanation-domain-model-and-compat.md
@@ -74,6 +74,15 @@ explanations.
 - Positive: simpler iteration/filtering, safer invariants, clearer ownership of fields, smoother future schema migration.
 - Negative: adds an adapter layer; requires adapter parity tests and slight maintenance.
 
+
+## Governed claims
+
+- `CE-CAP-EXPL-001` — calibrated_explanations produces calibrated factual explanations for individual   instances via WrapCalibratedExplainer.explain_factual, returning feature   contributions with calibrated probability uncertainty for the predicted class.
+- `CE-CAP-EXPL-002` — calibrated_explanations produces calibrated alternative (counterfactual-style)   explanations for individual instances via WrapCalibratedExplainer.explore_alternatives,   identifying feature changes that would shift the prediction toward an alternative outcome.
+- `CE-CAP-EXPL-CONJ-001` — calibrated_explanations supports conjunctive multi-feature explanation rules via   add_conjunctions(), which extends any explanation collection or individual explanation   to include rules combining up to max_rule_size features, returning an updated   object of the same type. The method is available on CalibratedExplanations,   AlternativeExplanations, FactualExplanation, and AlternativeExplanation.
+- `CE-CAP-NARR-001` — calibrated_explanations generates human-readable natural language narratives for   factual and alternative explanations via CalibratedExplanations.to_narrative(),   returning non-None output (string, DataFrame, HTML, or dict) suitable for consumption   by downstream text pipelines.
+- `CE-CAP-SCHEMA-001` — Explanation payloads use a versioned CE-first schema contract with explicit metadata and governed extension surfaces.
+
 ## Alternatives
 
 - Keep dict-only approach (status quo): continues complexity and duplication in consumers.

--- a/development/adrs/ADR-009-input-preprocessing-and-mapping-policy.md
+++ b/development/adrs/ADR-009-input-preprocessing-and-mapping-policy.md
@@ -37,6 +37,11 @@ usability and reproducibility.
 - Positive: greatly improved ergonomics; deterministic mappings in predict/online; clearer provenance.
 - Negative: additional complexity in wrapper; need to document behavior and storage.
 
+
+## Governed claims
+
+- `CE-CAP-PREPROC-001` — Wrapper preprocessing learns and reuses deterministic feature mappings while keeping the core numeric and preserving provenance boundaries.
+
 ## Alternatives
 
 - Enforce user-supplied preprocessing only (status quo), which is less friendly and harder to reproduce.

--- a/development/adrs/ADR-010-core-vs-evaluation-split-and-distribution.md
+++ b/development/adrs/ADR-010-core-vs-evaluation-split-and-distribution.md
@@ -80,6 +80,11 @@ Pending:
 - Optional evaluation workflow that installs `[eval]` and runs benchmarks.
 - Add compatibility checks confirming optional packages do not change core outputs unless explicitly enabled.
 
+
+## Governed claims
+
+- `CE-CAP-DIST-001` — The core package and evaluation tooling remain separately distributed and independently governed.
+
 ## Alternatives Considered
 
 1. Split into multiple pip distributions immediately (core, viz, eval). Deferred to reduce maintenance overhead; extras provide a simpler first step.

--- a/development/adrs/ADR-011-deprecation-and-migration-policy.md
+++ b/development/adrs/ADR-011-deprecation-and-migration-policy.md
@@ -44,6 +44,11 @@ No deprecation-removal work may be deferred to `v1.0.0`, `v1.0.0-rc`, or any pos
 
 When default-policy timing conflicts with the v1.0 finalization exception, **the v1.0 finalization exception wins**.
 
+
+## Governed claims
+
+- `CE-CAP-DEPREC-001` — Deprecations follow the accepted migration lifecycle, including visible warnings and documented removal windows.
+
 ## Alternatives Considered
 
 1. Immediate breaking changes with major version bumps for every cleanup (too disruptive for existing users).

--- a/development/adrs/ADR-012-documentation-and-gallery-build-policy.md
+++ b/development/adrs/ADR-012-documentation-and-gallery-build-policy.md
@@ -38,6 +38,11 @@ readiness:
   datasets (<30s per example on CI hardware).
 - Publishing: artifacts uploaded as workflow artifacts; optional GitHub Pages later.
 
+
+## Governed claims
+
+- `CE-CAP-DOCS-001` — Documentation and gallery builds use maintained source pages and documented build policy rather than obsolete improvement paths.
+
 ## Alternatives Considered
 
 1. Keep docs informal in README only (insufficient for scale and stability goals).

--- a/development/adrs/ADR-013-interval-calibrator-plugin-strategy.md
+++ b/development/adrs/ADR-013-interval-calibrator-plugin-strategy.md
@@ -138,6 +138,13 @@ Each alternative scenario is evaluated with the same interval calibrator:
   distribution changes are required.【F:src/calibrated_explanations/plugins/intervals.py†L1-L80】【F:src/calibrated_explanations/plugins/builtins.py†L120-L183】
 - **2026-06-02 (v0.11.3 Task 9 Workstream D):** ADR-013 §4 Lifecycle previously cited `src/calibrated_explanations/plugins/interval_wrappers.py` as the FAST wrapper location. That file does not exist. The wrapper is at `src/calibrated_explanations/calibration/interval_wrappers.py`. §4 text has been corrected. This is a documentation-only fix; no code change required.
 
+
+## Governed claims
+
+- `CE-CAP-PLUGIN-001` — calibrated_explanations exposes an extensible plugin system through the   calibrated_explanations.plugins module: ExplainerPlugin defines the protocol for   custom explanation backends, and IntervalCalibratorPlugin defines the protocol for   custom interval calibrators, enabling replacement of default internal implementations.
+- `CE-CAP-PRED-001` — calibrated_explanations returns calibrated uncertainty intervals for predictions   via WrapCalibratedExplainer.predict with uq_interval=True (or predict_proba with   uq_interval=True for classification). The returned low and high bounds represent   calibrated uncertainty around the point prediction.
+- `CE-CAP-MOND-001` — calibrated_explanations supports Mondrian (class-conditional) calibration: passing   a MondrianCategorizer callable to WrapCalibratedExplainer.calibrate produces separate   internal calibrators per category, enabling conditional validity guarantees within   each Mondrian group.
+
 ## Consequences
 
 Positive:

--- a/development/adrs/ADR-015-explanation-plugin.md
+++ b/development/adrs/ADR-015-explanation-plugin.md
@@ -366,6 +366,13 @@ custom containers; it is the plugin author’s responsibility to ensure
 downstream tooling can consume those results.
 No mandatory JSON contract is imposed by the plugin interface.
 
+
+## Governed claims
+
+- `CE-CAP-PLUGIN-001` — calibrated_explanations exposes an extensible plugin system through the   calibrated_explanations.plugins module: ExplainerPlugin defines the protocol for   custom explanation backends, and IntervalCalibratorPlugin defines the protocol for   custom interval calibrators, enabling replacement of default internal implementations.
+- `CE-CAP-EXPL-001` — calibrated_explanations produces calibrated factual explanations for individual   instances via WrapCalibratedExplainer.explain_factual, returning feature   contributions with calibrated probability uncertainty for the predicted class.
+- `CE-CAP-EXPL-002` — calibrated_explanations produces calibrated alternative (counterfactual-style)   explanations for individual instances via WrapCalibratedExplainer.explore_alternatives,   identifying feature changes that would shift the prediction toward an alternative outcome.
+
 ## Consequences
 
 - **Backward compatibility:** Public APIs and explanation outputs remain

--- a/development/adrs/ADR-020-legacy-user-api-stability.md
+++ b/development/adrs/ADR-020-legacy-user-api-stability.md
@@ -46,6 +46,11 @@ Adopt a layered guardrail strategy that freezes the documented legacy API:
    formal decision record (ADR) approving the specific removal.
 
    **Note:** This override constitutes an explicit exception to the deprecation policy defined in ADR-011. ADR-011 should be updated to reference this exception to ensure all contributors are aware of the special handling for the legacy API.
+
+## Governed claims
+
+- `CE-CAP-LEGACY-001` — Legacy user APIs remain stable within the documented major-version compatibility boundary.
+
 ## Alternatives Considered
 
 1. **Rely solely on documentation.** Rejected because prose alone does not fail

--- a/development/adrs/ADR-021-calibrated-interval-semantics.md
+++ b/development/adrs/ADR-021-calibrated-interval-semantics.md
@@ -216,6 +216,13 @@ ADR constrains *how* those plugins behave when implementing the protocols.
   tests showing the same payload fields (`low_high_percentiles` or
   `y_threshold`) are populated with the expected meaning.
 
+
+## Governed claims
+
+- `CE-CAP-PRED-001` — calibrated_explanations returns calibrated uncertainty intervals for predictions   via WrapCalibratedExplainer.predict with uq_interval=True (or predict_proba with   uq_interval=True for classification). The returned low and high bounds represent   calibrated uncertainty around the point prediction.
+- `CE-CAP-PRED-CLASS-001` — calibrated_explanations produces Venn-Abers calibrated class probabilities for   binary and multiclass classification tasks via WrapCalibratedExplainer.predict_proba,   returning a probability array bounded in [0, 1] with shape matching the input, and   class label arrays via WrapCalibratedExplainer.predict.
+- `CE-CAP-PRED-PROB-001` — calibrated_explanations supports probabilistic regression queries: given a scalar   threshold, WrapCalibratedExplainer.predict_proba(X, threshold=y_threshold) returns   the empirical probability that the regression target exceeds the threshold,   P(Y > threshold | X), as an array bounded in [0, 1] with shape matching the input.
+
 ## Consequences
 
 Positive:

--- a/development/adrs/ADR-023-matplotlib-coverage-exemption.md
+++ b/development/adrs/ADR-023-matplotlib-coverage-exemption.md
@@ -96,6 +96,12 @@ omit =
 - **Maintenance**: Document split test workflow in contributor guide and CI configuration
 - **Testing**: Run `pytest --no-cov -m viz` to validate viz tests; run `pytest` for coverage on remaining modules
 
+
+## Governed claims
+
+- `CE-CAP-VIZ-001` — calibrated_explanations provides visualization output for explanations via   WrapCalibratedExplainer.plot and CalibratedExplanations.plot, supporting   multiple output styles ('regular', 'triangular') and optional file saving,   without raising exceptions for standard single-instance and batch inputs   when a non-interactive rendering backend is available.
+- `CE-CAP-TEST-001` — Tests follow the repository quality policy for naming, coverage gates, and justified coverage exemptions.
+
 ## Alternatives Considered
 
 1. **Further matplotlib downgrade (3.8.4 → 3.7.x)**: Risk of breaking API compatibility; 3.7.x EOL status

--- a/development/adrs/ADR-026-explanation-plugin-semantics.md
+++ b/development/adrs/ADR-026-explanation-plugin-semantics.md
@@ -237,6 +237,13 @@ The validator must check:
   surface — are governed by ADR-032 and apply regardless of whether the guarded path
   runs through a built-in plugin or a third-party plugin that opts in.
 
+
+## Governed claims
+
+- `CE-CAP-PLUGIN-001` — calibrated_explanations exposes an extensible plugin system through the   calibrated_explanations.plugins module: ExplainerPlugin defines the protocol for   custom explanation backends, and IntervalCalibratorPlugin defines the protocol for   custom interval calibrators, enabling replacement of default internal implementations.
+- `CE-CAP-EXPL-001` — calibrated_explanations produces calibrated factual explanations for individual   instances via WrapCalibratedExplainer.explain_factual, returning feature   contributions with calibrated probability uncertainty for the predicted class.
+- `CE-CAP-EXPL-002` — calibrated_explanations produces calibrated alternative (counterfactual-style)   explanations for individual instances via WrapCalibratedExplainer.explore_alternatives,   identifying feature changes that would shift the prediction toward an alternative outcome.
+
 ## Consequences
 
 Positive:

--- a/development/adrs/ADR-027-fast-feature-filtering.md
+++ b/development/adrs/ADR-027-fast-feature-filtering.md
@@ -81,6 +81,11 @@ for configuration, failure behavior, and observability.
 - When telemetry is configured, the resolved feature-filter configuration is
   emitted as a single “effective config” event to support traceability.
 
+
+## Governed claims
+
+- `CE-CAP-EXPL-FILTER-001` — calibrated_explanations supports rule-type filtering on alternative explanations via five   filter operations: super_explanations (rules with higher probability supporting the   predicted class), semi_explanations (rules with lower probability supporting the   predicted class), counter_explanations (rules not supporting the predicted class),   ensured_explanations (rules with narrow uncertainty intervals), and pareto_explanations   (Pareto-optimal rules by probability shift and uncertainty width). Each operation is   available on both AlternativeExplanations (collection) and AlternativeExplanation   (individual), with short-form aliases (.super(), .semi(), .counter(), .ensured(),   .pareto()) that delegate to the canonical long-form methods.
+
 ## Consequences
 
 ### Positive

--- a/development/adrs/ADR-028-logging-and-governance-observability.md
+++ b/development/adrs/ADR-028-logging-and-governance-observability.md
@@ -112,6 +112,11 @@ Standard-005, *Logging and Observability*, captures the contributor-facing rules
 that implement this decision (logger naming, level usage, data minimisation,
 testing expectations).
 
+
+## Governed claims
+
+- `CE-CAP-OBS-001` — Governance and operational observability use visible warnings and structured logging where ADR-governed fallbacks or events occur.
+
 ## Alternatives Considered
 
 1. **Ad-hoc, module-local logging without domains or context helpers.**
@@ -222,5 +227,5 @@ Migration guidelines:
 - `docs/foundations/governance/optional_telemetry.md` — Existing telemetry
   guidance; should be updated to reference the new logging hierarchy and
   context helper where appropriate.
-- `docs/improvement/ignore/Logging_Analysis.md` — Detailed analysis of current
-  logging usage and recommendations that informed this ADR.
+- `development/standards/STD-005-logging-and-observability-standard.md` — Current
+  logging usage policy and checks that implement this ADR.

--- a/development/adrs/ADR-029-reject-integration-strategy.md
+++ b/development/adrs/ADR-029-reject-integration-strategy.md
@@ -84,6 +84,11 @@ Defined `RejectPolicy` members (implemented in `core.reject.policy`):
 ### Visualization
 - If visualization is revisited, should it be a dedicated plugin or an overlay?
 
+
+## Governed claims
+
+- `CE-CAP-REJECT-001` — calibrated_explanations supports reject/defer policies: passing a RejectPolicySpec   to WrapCalibratedExplainer.explain_factual or explore_alternatives tags each   instance's explanation envelope with a rejection status (FLAG, ONLY_REJECTED,   ONLY_ACCEPTED) based on the calibrated uncertainty score.
+
 ## Alternatives Considered
 
 ### 1) Invocation model alternatives
@@ -208,7 +213,7 @@ Defined `RejectPolicy` members (implemented in `core.reject.policy`):
 		- Operational rule: Selecting any non-`NONE` `RejectPolicy` MUST implicitly enable the reject orchestration (equivalent to `reject=True`) for the affected call(s) or explainer-level default. In practice this means that supplying `reject_policy != RejectPolicy.NONE` (per-call or via explainer default) triggers `RejectOrchestrator` initialization and evaluation even if the legacy `reject` flag was `False`.
 6. Implement a default built-in reject strategy (the current behaviour) that preserves existing semantics and is registered under the orchestrator's registry as `builtin.default`.
 7. Add CI tests that exercise each `RejectPolicy` member, ensuring return schemas and interactions with existing explanation consumers remain backward compatible when `NONE` is used.
-8. Update documentation and examples: `docs/improvement/` release plan, add `docs/reject.md`, and user-facing examples demonstrating the common policies.
+8. Update documentation and examples under the current `development/` planning structure and user-facing docs (for example, `docs/practitioner/advanced/reject-policy.md`) demonstrating the common policies.
 9. Defer visualization integration until a separate ADR or plugin is proposed.
 
 ## Verification checklist (recommended additions)

--- a/development/adrs/ADR-030-test-quality-priorities-and-enforcement.md
+++ b/development/adrs/ADR-030-test-quality-priorities-and-enforcement.md
@@ -185,6 +185,11 @@ guard, then writes observational timing evidence to
 `reports/anti-pattern-analysis/adr030_ratification_timing.json`. Timing
 evidence is informational only and must not introduce a duration threshold.
 
+
+## Governed claims
+
+- `CE-CAP-TEST-001` — Tests follow the repository quality policy for naming, coverage gates, and justified coverage exemptions.
+
 ## Alternatives Considered
 
 1. **Keep coverage as the only required gate.**

--- a/development/adrs/ADR-031-calibrator-serialization-and-state-persistence.md
+++ b/development/adrs/ADR-031-calibrator-serialization-and-state-persistence.md
@@ -55,6 +55,11 @@ semantics while allowing future migrations.
      (probability bounds, interval ordering, and monotonicity expectations).
    - Mapping primitives must remain JSON-safe and deterministic per ADR-009.
 
+
+## Governed claims
+
+- `CE-CAP-SERIAL-001` — Calibrator and explainer persistence use versioned primitive state and fail fast on incompatible schema versions.
+
 ## Consequences
 
 Positive:

--- a/development/adrs/ADR-032-guarded-explanation-semantics.md
+++ b/development/adrs/ADR-032-guarded-explanation-semantics.md
@@ -117,6 +117,11 @@ This ADR therefore defines guarded mode as a CE-compatible extension with a sing
    - Calling any guarded entrypoint (`explain_factual(..., guarded_options=GuardedOptions())`, `explore_alternatives(..., guarded_options=GuardedOptions())`) on a fast explainer must hard-fail with `ConfigurationError` before any calibration-alignment check proceeds.
    - This prohibition is enforced in `_require_guarded_calibration_alignment` and is not subject to configuration or opt-out.
 
+
+## Governed claims
+
+- `CE-CAP-GUARD-001` — calibrated_explanations supports guarded explanations: passing a GuardedOptions   instance to WrapCalibratedExplainer.explain_factual or explore_alternatives restricts   explanation output to instances that lie within the support of the calibration data,   returning a CalibratedExplanations collection.
+
 ## Consequences
 
 Positive:

--- a/development/adrs/ADR-033-modality-extension-plugin-contract-and-packaging.md
+++ b/development/adrs/ADR-033-modality-extension-plugin-contract-and-packaging.md
@@ -94,6 +94,12 @@ Release split:
 6. Aligns release content with a breaking-first / additive-follow-up cadence to reduce release risk.
 7. **Timeseries is excluded from this ADR's scope.** Time-ordered data requires ordered-input semantics, temporal feature indexing, and perturbation strategies that are fundamentally incompatible with the tabular/non-tabular extension contract modelled here. A separate ADR will govern timeseries modality support if and when it is needed.
 
+
+## Governed claims
+
+- `CE-CAP-PLUGIN-001` — calibrated_explanations exposes an extensible plugin system through the   calibrated_explanations.plugins module: ExplainerPlugin defines the protocol for   custom explanation backends, and IntervalCalibratorPlugin defines the protocol for   custom interval calibrators, enabling replacement of default internal implementations.
+- `CE-CAP-MODALITY-001` — Non-tabular modality extensions use plugin metadata and external packages rather than entering the core tabular implementation.
+
 ## Alternatives Considered
 
 1. No metadata extension; use existing `capabilities` only.

--- a/development/adrs/ADR-034-centralized-configuration-management.md
+++ b/development/adrs/ADR-034-centralized-configuration-management.md
@@ -121,6 +121,11 @@ CI enforcement must fail new direct runtime reads outside sanctioned boundaries.
 Temporary exceptions must be explicitly allowlisted with justification and
 target-release ownership.
 
+
+## Governed claims
+
+- `CE-CAP-CONFIG-001` — Runtime and call-time configuration use governed tiers, centralized reads, and suffix conventions for Config, Spec, and Options objects.
+
 ## Alternatives Considered
 
 1. **Keep distributed readers.** Rejected: preserves precedence drift and scattered

--- a/development/adrs/ADR-035-ci-workflow-governance.md
+++ b/development/adrs/ADR-035-ci-workflow-governance.md
@@ -68,6 +68,11 @@ Changes to `.github/actions/ci-policy/**` are high-integrity and require two cor
 2. Tune false positives and document accepted equivalent patterns.
 3. Flip `ci-policy/validate-workflows` to required status check in branch protection.
 
+
+## Governed claims
+
+- `CE-CAP-CI-001` — CI workflow changes comply with reusable workflow, least-privilege, pinning, constraints, and local reproducibility policy.
+
 ## Consequences
 
 **Positive**

--- a/development/adrs/ADR-036-plot-spec-canonical-contract-and-validation-boundary.md
+++ b/development/adrs/ADR-036-plot-spec-canonical-contract-and-validation-boundary.md
@@ -105,6 +105,12 @@ Additional optional fields **MAY** be defined, but required semantics **MUST** r
 - This ADR does not define release sequencing or implementation journaling.
 - This ADR does not authorize runtime plot-kind extension.
 
+
+## Governed claims
+
+- `CE-CAP-PLOTSPEC-001` — PlotSpec-enabled visualization paths preserve backend-independent semantic plot intent through canonical PlotSpec objects and validated renderer boundaries.
+- `CE-CAP-VIZ-001` — calibrated_explanations provides visualization output for explanations via   WrapCalibratedExplainer.plot and CalibratedExplanations.plot, supporting   multiple output styles ('regular', 'triangular') and optional file saving,   without raising exceptions for standard single-instance and batch inputs   when a non-interactive rendering backend is available.
+
 ## Consequences
 
 ### Positive

--- a/development/adrs/ADR-037-visualization-extension-and-rendering-governance.md
+++ b/development/adrs/ADR-037-visualization-extension-and-rendering-governance.md
@@ -94,6 +94,12 @@ at v1.0.0. New plugins must use the semantic names.
 - This ADR does not prescribe pixel-level parity requirements.
 - This ADR does not serve as a release plan.
 
+
+## Governed claims
+
+- `CE-CAP-VIZ-001` — calibrated_explanations provides visualization output for explanations via   WrapCalibratedExplainer.plot and CalibratedExplanations.plot, supporting   multiple output styles ('regular', 'triangular') and optional file saving,   without raising exceptions for standard single-instance and batch inputs   when a non-interactive rendering backend is available.
+- `CE-CAP-PLOTSPEC-001` — PlotSpec-enabled visualization paths preserve backend-independent semantic plot intent through canonical PlotSpec objects and validated renderer boundaries.
+
 ## Consequences
 
 ### Positive

--- a/development/adrs/ADR-038-call-time-configuration-taxonomy.md
+++ b/development/adrs/ADR-038-call-time-configuration-taxonomy.md
@@ -184,6 +184,13 @@ coverage sense, consistent with the established `reject_confidence` convention.
 Both express the same conformity threshold; the coverage convention makes the
 relationship with `reject_confidence` immediately readable.
 
+
+## Governed claims
+
+- `CE-CAP-CONFIG-001` — Runtime and call-time configuration use governed tiers, centralized reads, and suffix conventions for Config, Spec, and Options objects.
+- `CE-CAP-REJECT-001` — calibrated_explanations supports reject/defer policies: passing a RejectPolicySpec   to WrapCalibratedExplainer.explain_factual or explore_alternatives tags each   instance's explanation envelope with a rejection status (FLAG, ONLY_REJECTED,   ONLY_ACCEPTED) based on the calibrated uncertainty score.
+- `CE-CAP-GUARD-001` — calibrated_explanations supports guarded explanations: passing a GuardedOptions   instance to WrapCalibratedExplainer.explain_factual or explore_alternatives restricts   explanation output to instances that lie within the support of the calibration data,   returning a CalibratedExplanations collection.
+
 ## Alternatives Considered
 
 1. **Use `*Config` for all grouped parameter bundles (session and per-call alike).**

--- a/development/capabilities/claims/CE-CAP-CACHE-001.yaml
+++ b/development/capabilities/claims/CE-CAP-CACHE-001.yaml
@@ -1,0 +1,33 @@
+claim_id: CE-CAP-CACHE-001
+claim_type: capability
+owner: calibrated_explanations
+status: current
+adr_links:
+  - ADR-003
+
+claim_text: >
+  Caching is opt-in, transparent to public APIs, and governed by deterministic key and fallback visibility constraints.
+
+public_api: []
+
+task_types:
+  - governance
+
+requirements:
+  - CE-REQ-CACHE-GOV-001
+
+verification:
+  proves:
+    - documentation_boundary
+    - governance_linkage
+  verification_type: automated_metadata_check
+
+assumptions:
+  - This governance capability is verified by ADR, claim, requirement, and test-link consistency checks.
+  - Behavioral enforcement remains scoped to the implementation and tests named by the linked requirement.
+
+evidence_required:
+  - commit_sha
+  - package_version
+  - test_id
+  - result

--- a/development/capabilities/claims/CE-CAP-CI-001.yaml
+++ b/development/capabilities/claims/CE-CAP-CI-001.yaml
@@ -1,0 +1,33 @@
+claim_id: CE-CAP-CI-001
+claim_type: capability
+owner: calibrated_explanations
+status: current
+adr_links:
+  - ADR-035
+
+claim_text: >
+  CI workflow changes comply with reusable workflow, least-privilege, pinning, constraints, and local reproducibility policy.
+
+public_api: []
+
+task_types:
+  - governance
+
+requirements:
+  - CE-REQ-CI-GOV-001
+
+verification:
+  proves:
+    - documentation_boundary
+    - governance_linkage
+  verification_type: automated_metadata_check
+
+assumptions:
+  - This governance capability is verified by ADR, claim, requirement, and test-link consistency checks.
+  - Behavioral enforcement remains scoped to the implementation and tests named by the linked requirement.
+
+evidence_required:
+  - commit_sha
+  - package_version
+  - test_id
+  - result

--- a/development/capabilities/claims/CE-CAP-CONFIG-001.yaml
+++ b/development/capabilities/claims/CE-CAP-CONFIG-001.yaml
@@ -1,0 +1,34 @@
+claim_id: CE-CAP-CONFIG-001
+claim_type: capability
+owner: calibrated_explanations
+status: current
+adr_links:
+  - ADR-034
+  - ADR-038
+
+claim_text: >
+  Runtime and call-time configuration use governed tiers, centralized reads, and suffix conventions for Config, Spec, and Options objects.
+
+public_api: []
+
+task_types:
+  - governance
+
+requirements:
+  - CE-REQ-CONFIG-GOV-001
+
+verification:
+  proves:
+    - documentation_boundary
+    - governance_linkage
+  verification_type: automated_metadata_check
+
+assumptions:
+  - This governance capability is verified by ADR, claim, requirement, and test-link consistency checks.
+  - Behavioral enforcement remains scoped to the implementation and tests named by the linked requirement.
+
+evidence_required:
+  - commit_sha
+  - package_version
+  - test_id
+  - result

--- a/development/capabilities/claims/CE-CAP-CORE-001.yaml
+++ b/development/capabilities/claims/CE-CAP-CORE-001.yaml
@@ -1,0 +1,33 @@
+claim_id: CE-CAP-CORE-001
+claim_type: capability
+owner: calibrated_explanations
+status: current
+adr_links:
+  - ADR-001
+
+claim_text: >
+  Core package boundaries preserve stable separation between core, calibration, explanations, schema, plugins, cache, and parallel services.
+
+public_api: []
+
+task_types:
+  - governance
+
+requirements:
+  - CE-REQ-CORE-BOUNDARY-001
+
+verification:
+  proves:
+    - documentation_boundary
+    - governance_linkage
+  verification_type: automated_metadata_check
+
+assumptions:
+  - This governance capability is verified by ADR, claim, requirement, and test-link consistency checks.
+  - Behavioral enforcement remains scoped to the implementation and tests named by the linked requirement.
+
+evidence_required:
+  - commit_sha
+  - package_version
+  - test_id
+  - result

--- a/development/capabilities/claims/CE-CAP-DEPREC-001.yaml
+++ b/development/capabilities/claims/CE-CAP-DEPREC-001.yaml
@@ -1,0 +1,33 @@
+claim_id: CE-CAP-DEPREC-001
+claim_type: capability
+owner: calibrated_explanations
+status: current
+adr_links:
+  - ADR-011
+
+claim_text: >
+  Deprecations follow the accepted migration lifecycle, including visible warnings and documented removal windows.
+
+public_api: []
+
+task_types:
+  - governance
+
+requirements:
+  - CE-REQ-DEPREC-GOV-001
+
+verification:
+  proves:
+    - documentation_boundary
+    - governance_linkage
+  verification_type: automated_metadata_check
+
+assumptions:
+  - This governance capability is verified by ADR, claim, requirement, and test-link consistency checks.
+  - Behavioral enforcement remains scoped to the implementation and tests named by the linked requirement.
+
+evidence_required:
+  - commit_sha
+  - package_version
+  - test_id
+  - result

--- a/development/capabilities/claims/CE-CAP-DIST-001.yaml
+++ b/development/capabilities/claims/CE-CAP-DIST-001.yaml
@@ -1,0 +1,33 @@
+claim_id: CE-CAP-DIST-001
+claim_type: capability
+owner: calibrated_explanations
+status: current
+adr_links:
+  - ADR-010
+
+claim_text: >
+  The core package and evaluation tooling remain separately distributed and independently governed.
+
+public_api: []
+
+task_types:
+  - governance
+
+requirements:
+  - CE-REQ-DIST-GOV-001
+
+verification:
+  proves:
+    - documentation_boundary
+    - governance_linkage
+  verification_type: automated_metadata_check
+
+assumptions:
+  - This governance capability is verified by ADR, claim, requirement, and test-link consistency checks.
+  - Behavioral enforcement remains scoped to the implementation and tests named by the linked requirement.
+
+evidence_required:
+  - commit_sha
+  - package_version
+  - test_id
+  - result

--- a/development/capabilities/claims/CE-CAP-DOCS-001.yaml
+++ b/development/capabilities/claims/CE-CAP-DOCS-001.yaml
@@ -1,0 +1,33 @@
+claim_id: CE-CAP-DOCS-001
+claim_type: capability
+owner: calibrated_explanations
+status: current
+adr_links:
+  - ADR-012
+
+claim_text: >
+  Documentation and gallery builds use maintained source pages and documented build policy rather than obsolete improvement paths.
+
+public_api: []
+
+task_types:
+  - governance
+
+requirements:
+  - CE-REQ-DOCS-GOV-001
+
+verification:
+  proves:
+    - documentation_boundary
+    - governance_linkage
+  verification_type: automated_metadata_check
+
+assumptions:
+  - This governance capability is verified by ADR, claim, requirement, and test-link consistency checks.
+  - Behavioral enforcement remains scoped to the implementation and tests named by the linked requirement.
+
+evidence_required:
+  - commit_sha
+  - package_version
+  - test_id
+  - result

--- a/development/capabilities/claims/CE-CAP-EXPL-001.yaml
+++ b/development/capabilities/claims/CE-CAP-EXPL-001.yaml
@@ -3,6 +3,11 @@ claim_type: capability
 owner: calibrated_explanations
 status: current
 
+adr_links:
+  - ADR-008
+  - ADR-015
+  - ADR-026
+
 claim_text: >
   calibrated_explanations produces calibrated factual explanations for individual
   instances via WrapCalibratedExplainer.explain_factual, returning feature

--- a/development/capabilities/claims/CE-CAP-EXPL-002.yaml
+++ b/development/capabilities/claims/CE-CAP-EXPL-002.yaml
@@ -3,6 +3,11 @@ claim_type: capability
 owner: calibrated_explanations
 status: current
 
+adr_links:
+  - ADR-008
+  - ADR-015
+  - ADR-026
+
 claim_text: >
   calibrated_explanations produces calibrated alternative (counterfactual-style)
   explanations for individual instances via WrapCalibratedExplainer.explore_alternatives,

--- a/development/capabilities/claims/CE-CAP-EXPL-CONJ-001.yaml
+++ b/development/capabilities/claims/CE-CAP-EXPL-CONJ-001.yaml
@@ -3,6 +3,9 @@ claim_type: capability
 owner: calibrated_explanations
 status: current
 
+adr_links:
+  - ADR-008
+
 claim_text: >
   calibrated_explanations supports conjunctive multi-feature explanation rules via
   add_conjunctions(), which extends any explanation collection or individual explanation

--- a/development/capabilities/claims/CE-CAP-EXPL-FILTER-001.yaml
+++ b/development/capabilities/claims/CE-CAP-EXPL-FILTER-001.yaml
@@ -3,6 +3,9 @@ claim_type: capability
 owner: calibrated_explanations
 status: current
 
+adr_links:
+  - ADR-027
+
 claim_text: >
   calibrated_explanations supports rule-type filtering on alternative explanations via five
   filter operations: super_explanations (rules with higher probability supporting the

--- a/development/capabilities/claims/CE-CAP-GUARD-001.yaml
+++ b/development/capabilities/claims/CE-CAP-GUARD-001.yaml
@@ -3,6 +3,10 @@ claim_type: capability
 owner: calibrated_explanations
 status: current
 
+adr_links:
+  - ADR-032
+  - ADR-038
+
 claim_text: >
   calibrated_explanations supports guarded explanations: passing a GuardedOptions
   instance to WrapCalibratedExplainer.explain_factual or explore_alternatives restricts

--- a/development/capabilities/claims/CE-CAP-LEGACY-001.yaml
+++ b/development/capabilities/claims/CE-CAP-LEGACY-001.yaml
@@ -1,0 +1,33 @@
+claim_id: CE-CAP-LEGACY-001
+claim_type: capability
+owner: calibrated_explanations
+status: current
+adr_links:
+  - ADR-020
+
+claim_text: >
+  Legacy user APIs remain stable within the documented major-version compatibility boundary.
+
+public_api: []
+
+task_types:
+  - governance
+
+requirements:
+  - CE-REQ-LEGACY-GOV-001
+
+verification:
+  proves:
+    - documentation_boundary
+    - governance_linkage
+  verification_type: automated_metadata_check
+
+assumptions:
+  - This governance capability is verified by ADR, claim, requirement, and test-link consistency checks.
+  - Behavioral enforcement remains scoped to the implementation and tests named by the linked requirement.
+
+evidence_required:
+  - commit_sha
+  - package_version
+  - test_id
+  - result

--- a/development/capabilities/claims/CE-CAP-MODALITY-001.yaml
+++ b/development/capabilities/claims/CE-CAP-MODALITY-001.yaml
@@ -1,0 +1,33 @@
+claim_id: CE-CAP-MODALITY-001
+claim_type: capability
+owner: calibrated_explanations
+status: current
+adr_links:
+  - ADR-033
+
+claim_text: >
+  Non-tabular modality extensions use plugin metadata and external packages rather than entering the core tabular implementation.
+
+public_api: []
+
+task_types:
+  - governance
+
+requirements:
+  - CE-REQ-MODALITY-GOV-001
+
+verification:
+  proves:
+    - documentation_boundary
+    - governance_linkage
+  verification_type: automated_metadata_check
+
+assumptions:
+  - This governance capability is verified by ADR, claim, requirement, and test-link consistency checks.
+  - Behavioral enforcement remains scoped to the implementation and tests named by the linked requirement.
+
+evidence_required:
+  - commit_sha
+  - package_version
+  - test_id
+  - result

--- a/development/capabilities/claims/CE-CAP-MOND-001.yaml
+++ b/development/capabilities/claims/CE-CAP-MOND-001.yaml
@@ -3,6 +3,9 @@ claim_type: capability
 owner: calibrated_explanations
 status: current
 
+adr_links:
+  - ADR-013
+
 claim_text: >
   calibrated_explanations supports Mondrian (class-conditional) calibration: passing
   a MondrianCategorizer callable to WrapCalibratedExplainer.calibrate produces separate

--- a/development/capabilities/claims/CE-CAP-NARR-001.yaml
+++ b/development/capabilities/claims/CE-CAP-NARR-001.yaml
@@ -3,6 +3,9 @@ claim_type: capability
 owner: calibrated_explanations
 status: current
 
+adr_links:
+  - ADR-008
+
 claim_text: >
   calibrated_explanations generates human-readable natural language narratives for
   factual and alternative explanations via CalibratedExplanations.to_narrative(),

--- a/development/capabilities/claims/CE-CAP-OBS-001.yaml
+++ b/development/capabilities/claims/CE-CAP-OBS-001.yaml
@@ -1,0 +1,33 @@
+claim_id: CE-CAP-OBS-001
+claim_type: capability
+owner: calibrated_explanations
+status: current
+adr_links:
+  - ADR-028
+
+claim_text: >
+  Governance and operational observability use visible warnings and structured logging where ADR-governed fallbacks or events occur.
+
+public_api: []
+
+task_types:
+  - governance
+
+requirements:
+  - CE-REQ-OBS-GOV-001
+
+verification:
+  proves:
+    - documentation_boundary
+    - governance_linkage
+  verification_type: automated_metadata_check
+
+assumptions:
+  - This governance capability is verified by ADR, claim, requirement, and test-link consistency checks.
+  - Behavioral enforcement remains scoped to the implementation and tests named by the linked requirement.
+
+evidence_required:
+  - commit_sha
+  - package_version
+  - test_id
+  - result

--- a/development/capabilities/claims/CE-CAP-PARALLEL-001.yaml
+++ b/development/capabilities/claims/CE-CAP-PARALLEL-001.yaml
@@ -1,0 +1,33 @@
+claim_id: CE-CAP-PARALLEL-001
+claim_type: capability
+owner: calibrated_explanations
+status: current
+adr_links:
+  - ADR-004
+
+claim_text: >
+  Parallel execution remains explicit and opt-in, with deterministic result ordering and serial-by-default behavior.
+
+public_api: []
+
+task_types:
+  - governance
+
+requirements:
+  - CE-REQ-PARALLEL-GOV-001
+
+verification:
+  proves:
+    - documentation_boundary
+    - governance_linkage
+  verification_type: automated_metadata_check
+
+assumptions:
+  - This governance capability is verified by ADR, claim, requirement, and test-link consistency checks.
+  - Behavioral enforcement remains scoped to the implementation and tests named by the linked requirement.
+
+evidence_required:
+  - commit_sha
+  - package_version
+  - test_id
+  - result

--- a/development/capabilities/claims/CE-CAP-PLOTSPEC-001.yaml
+++ b/development/capabilities/claims/CE-CAP-PLOTSPEC-001.yaml
@@ -1,0 +1,34 @@
+claim_id: CE-CAP-PLOTSPEC-001
+claim_type: capability
+owner: calibrated_explanations
+status: current
+adr_links:
+  - ADR-036
+  - ADR-037
+
+claim_text: >
+  PlotSpec-enabled visualization paths preserve backend-independent semantic plot intent through canonical PlotSpec objects and validated renderer boundaries.
+
+public_api: []
+
+task_types:
+  - governance
+
+requirements:
+  - CE-REQ-PLOTSPEC-GOV-001
+
+verification:
+  proves:
+    - documentation_boundary
+    - governance_linkage
+  verification_type: automated_metadata_check
+
+assumptions:
+  - This governance capability is verified by ADR, claim, requirement, and test-link consistency checks.
+  - Behavioral enforcement remains scoped to the implementation and tests named by the linked requirement.
+
+evidence_required:
+  - commit_sha
+  - package_version
+  - test_id
+  - result

--- a/development/capabilities/claims/CE-CAP-PLUGIN-001.yaml
+++ b/development/capabilities/claims/CE-CAP-PLUGIN-001.yaml
@@ -3,6 +3,13 @@ claim_type: capability
 owner: calibrated_explanations
 status: current
 
+adr_links:
+  - ADR-006
+  - ADR-013
+  - ADR-015
+  - ADR-026
+  - ADR-033
+
 claim_text: >
   calibrated_explanations exposes an extensible plugin system through the
   calibrated_explanations.plugins module: ExplainerPlugin defines the protocol for

--- a/development/capabilities/claims/CE-CAP-PRED-001.yaml
+++ b/development/capabilities/claims/CE-CAP-PRED-001.yaml
@@ -3,6 +3,10 @@ claim_type: capability
 owner: calibrated_explanations
 status: current
 
+adr_links:
+  - ADR-013
+  - ADR-021
+
 claim_text: >
   calibrated_explanations returns calibrated uncertainty intervals for predictions
   via WrapCalibratedExplainer.predict with uq_interval=True (or predict_proba with

--- a/development/capabilities/claims/CE-CAP-PRED-CLASS-001.yaml
+++ b/development/capabilities/claims/CE-CAP-PRED-CLASS-001.yaml
@@ -3,6 +3,9 @@ claim_type: capability
 owner: calibrated_explanations
 status: current
 
+adr_links:
+  - ADR-021
+
 claim_text: >
   calibrated_explanations produces Venn-Abers calibrated class probabilities for
   binary and multiclass classification tasks via WrapCalibratedExplainer.predict_proba,

--- a/development/capabilities/claims/CE-CAP-PRED-PROB-001.yaml
+++ b/development/capabilities/claims/CE-CAP-PRED-PROB-001.yaml
@@ -3,6 +3,9 @@ claim_type: capability
 owner: calibrated_explanations
 status: current
 
+adr_links:
+  - ADR-021
+
 claim_text: >
   calibrated_explanations supports probabilistic regression queries: given a scalar
   threshold, WrapCalibratedExplainer.predict_proba(X, threshold=y_threshold) returns

--- a/development/capabilities/claims/CE-CAP-PREPROC-001.yaml
+++ b/development/capabilities/claims/CE-CAP-PREPROC-001.yaml
@@ -1,0 +1,33 @@
+claim_id: CE-CAP-PREPROC-001
+claim_type: capability
+owner: calibrated_explanations
+status: current
+adr_links:
+  - ADR-009
+
+claim_text: >
+  Wrapper preprocessing learns and reuses deterministic feature mappings while keeping the core numeric and preserving provenance boundaries.
+
+public_api: []
+
+task_types:
+  - governance
+
+requirements:
+  - CE-REQ-PREPROC-GOV-001
+
+verification:
+  proves:
+    - documentation_boundary
+    - governance_linkage
+  verification_type: automated_metadata_check
+
+assumptions:
+  - This governance capability is verified by ADR, claim, requirement, and test-link consistency checks.
+  - Behavioral enforcement remains scoped to the implementation and tests named by the linked requirement.
+
+evidence_required:
+  - commit_sha
+  - package_version
+  - test_id
+  - result

--- a/development/capabilities/claims/CE-CAP-REJECT-001.yaml
+++ b/development/capabilities/claims/CE-CAP-REJECT-001.yaml
@@ -3,6 +3,10 @@ claim_type: capability
 owner: calibrated_explanations
 status: current
 
+adr_links:
+  - ADR-029
+  - ADR-038
+
 claim_text: >
   calibrated_explanations supports reject/defer policies: passing a RejectPolicySpec
   to WrapCalibratedExplainer.explain_factual or explore_alternatives tags each

--- a/development/capabilities/claims/CE-CAP-SCHEMA-001.yaml
+++ b/development/capabilities/claims/CE-CAP-SCHEMA-001.yaml
@@ -1,0 +1,34 @@
+claim_id: CE-CAP-SCHEMA-001
+claim_type: capability
+owner: calibrated_explanations
+status: current
+adr_links:
+  - ADR-005
+  - ADR-008
+
+claim_text: >
+  Explanation payloads use a versioned CE-first schema contract with explicit metadata and governed extension surfaces.
+
+public_api: []
+
+task_types:
+  - governance
+
+requirements:
+  - CE-REQ-SCHEMA-GOV-001
+
+verification:
+  proves:
+    - documentation_boundary
+    - governance_linkage
+  verification_type: automated_metadata_check
+
+assumptions:
+  - This governance capability is verified by ADR, claim, requirement, and test-link consistency checks.
+  - Behavioral enforcement remains scoped to the implementation and tests named by the linked requirement.
+
+evidence_required:
+  - commit_sha
+  - package_version
+  - test_id
+  - result

--- a/development/capabilities/claims/CE-CAP-SERIAL-001.yaml
+++ b/development/capabilities/claims/CE-CAP-SERIAL-001.yaml
@@ -1,0 +1,33 @@
+claim_id: CE-CAP-SERIAL-001
+claim_type: capability
+owner: calibrated_explanations
+status: current
+adr_links:
+  - ADR-031
+
+claim_text: >
+  Calibrator and explainer persistence use versioned primitive state and fail fast on incompatible schema versions.
+
+public_api: []
+
+task_types:
+  - governance
+
+requirements:
+  - CE-REQ-SERIAL-GOV-001
+
+verification:
+  proves:
+    - documentation_boundary
+    - governance_linkage
+  verification_type: automated_metadata_check
+
+assumptions:
+  - This governance capability is verified by ADR, claim, requirement, and test-link consistency checks.
+  - Behavioral enforcement remains scoped to the implementation and tests named by the linked requirement.
+
+evidence_required:
+  - commit_sha
+  - package_version
+  - test_id
+  - result

--- a/development/capabilities/claims/CE-CAP-TEST-001.yaml
+++ b/development/capabilities/claims/CE-CAP-TEST-001.yaml
@@ -1,0 +1,34 @@
+claim_id: CE-CAP-TEST-001
+claim_type: capability
+owner: calibrated_explanations
+status: current
+adr_links:
+  - ADR-023
+  - ADR-030
+
+claim_text: >
+  Tests follow the repository quality policy for naming, coverage gates, and justified coverage exemptions.
+
+public_api: []
+
+task_types:
+  - governance
+
+requirements:
+  - CE-REQ-TEST-GOV-001
+
+verification:
+  proves:
+    - documentation_boundary
+    - governance_linkage
+  verification_type: automated_metadata_check
+
+assumptions:
+  - This governance capability is verified by ADR, claim, requirement, and test-link consistency checks.
+  - Behavioral enforcement remains scoped to the implementation and tests named by the linked requirement.
+
+evidence_required:
+  - commit_sha
+  - package_version
+  - test_id
+  - result

--- a/development/capabilities/claims/CE-CAP-VALID-001.yaml
+++ b/development/capabilities/claims/CE-CAP-VALID-001.yaml
@@ -1,0 +1,33 @@
+claim_id: CE-CAP-VALID-001
+claim_type: capability
+owner: calibrated_explanations
+status: current
+adr_links:
+  - ADR-002
+
+claim_text: >
+  Public validation failures use the CE exception taxonomy rather than ad-hoc generic exceptions where ADR-002 scope applies.
+
+public_api: []
+
+task_types:
+  - governance
+
+requirements:
+  - CE-REQ-VALID-EXCEPTION-001
+
+verification:
+  proves:
+    - documentation_boundary
+    - governance_linkage
+  verification_type: automated_metadata_check
+
+assumptions:
+  - This governance capability is verified by ADR, claim, requirement, and test-link consistency checks.
+  - Behavioral enforcement remains scoped to the implementation and tests named by the linked requirement.
+
+evidence_required:
+  - commit_sha
+  - package_version
+  - test_id
+  - result

--- a/development/capabilities/claims/CE-CAP-VIZ-001.yaml
+++ b/development/capabilities/claims/CE-CAP-VIZ-001.yaml
@@ -3,6 +3,11 @@ claim_type: capability
 owner: calibrated_explanations
 status: current
 
+adr_links:
+  - ADR-023
+  - ADR-036
+  - ADR-037
+
 claim_text: >
   calibrated_explanations provides visualization output for explanations via
   WrapCalibratedExplainer.plot and CalibratedExplanations.plot, supporting

--- a/development/capabilities/requirements/CE-REQ-CACHE-GOV-001.md
+++ b/development/capabilities/requirements/CE-REQ-CACHE-GOV-001.md
@@ -1,0 +1,55 @@
+# CE-REQ-CACHE-GOV-001 — ADR Governance Linkage Contract
+
+## Metadata
+
+| Field | Value |
+|---|---|
+| requirement_id | CE-REQ-CACHE-GOV-001 |
+| obligation_type | documentation_boundary |
+| claim_refs | CE-CAP-CACHE-001 |
+| adr_refs | ADR-003 |
+| status | active |
+
+## Scope
+
+Development governance artifacts under `development/adrs/` and
+`development/capabilities/` for ADR-003.
+
+## Observable behavior
+
+The governed ADR claim chain MUST remain navigable in-place:
+
+1. Each owning ADR MUST list `CE-CAP-CACHE-001` in its `## Governed claims` section.
+2. `CE-CAP-CACHE-001` MUST list its owning ADRs in `adr_links`.
+3. `CE-CAP-CACHE-001` MUST list `CE-REQ-CACHE-GOV-001` in `requirements`.
+4. This requirement MUST list `CE-CAP-CACHE-001` in `claim_refs`.
+5. Linked test references MUST point to existing tests or explicit metadata checks.
+
+## Acceptance criterion
+
+The capability traceability validation test passes for this ADR/claim/requirement
+chain without relying on a standalone traceability table or generated matrix.
+
+## Verification method
+
+Automated pytest test in `tests/capabilities/`.
+
+Test ID:
+- `test_should_validate_adr_capability_links_when_metadata_changes`
+
+(in `tests/capabilities/test_adr_capability_links.py`)
+
+## Evidence required
+
+| Field | Required |
+|---|---|
+| commit_sha | yes |
+| package_version | yes |
+| test_id | yes |
+| result | yes (pass/fail) |
+
+## Assumption boundary
+
+This requirement verifies governance linkage and metadata consistency. It does not
+prove every runtime behavior implied by the owning ADR; runtime behavior remains
+covered by the specific implementation tests referenced by feature requirements.

--- a/development/capabilities/requirements/CE-REQ-CI-GOV-001.md
+++ b/development/capabilities/requirements/CE-REQ-CI-GOV-001.md
@@ -1,0 +1,55 @@
+# CE-REQ-CI-GOV-001 — ADR Governance Linkage Contract
+
+## Metadata
+
+| Field | Value |
+|---|---|
+| requirement_id | CE-REQ-CI-GOV-001 |
+| obligation_type | documentation_boundary |
+| claim_refs | CE-CAP-CI-001 |
+| adr_refs | ADR-035 |
+| status | active |
+
+## Scope
+
+Development governance artifacts under `development/adrs/` and
+`development/capabilities/` for ADR-035.
+
+## Observable behavior
+
+The governed ADR claim chain MUST remain navigable in-place:
+
+1. Each owning ADR MUST list `CE-CAP-CI-001` in its `## Governed claims` section.
+2. `CE-CAP-CI-001` MUST list its owning ADRs in `adr_links`.
+3. `CE-CAP-CI-001` MUST list `CE-REQ-CI-GOV-001` in `requirements`.
+4. This requirement MUST list `CE-CAP-CI-001` in `claim_refs`.
+5. Linked test references MUST point to existing tests or explicit metadata checks.
+
+## Acceptance criterion
+
+The capability traceability validation test passes for this ADR/claim/requirement
+chain without relying on a standalone traceability table or generated matrix.
+
+## Verification method
+
+Automated pytest test in `tests/capabilities/`.
+
+Test ID:
+- `test_should_validate_adr_capability_links_when_metadata_changes`
+
+(in `tests/capabilities/test_adr_capability_links.py`)
+
+## Evidence required
+
+| Field | Required |
+|---|---|
+| commit_sha | yes |
+| package_version | yes |
+| test_id | yes |
+| result | yes (pass/fail) |
+
+## Assumption boundary
+
+This requirement verifies governance linkage and metadata consistency. It does not
+prove every runtime behavior implied by the owning ADR; runtime behavior remains
+covered by the specific implementation tests referenced by feature requirements.

--- a/development/capabilities/requirements/CE-REQ-CONFIG-GOV-001.md
+++ b/development/capabilities/requirements/CE-REQ-CONFIG-GOV-001.md
@@ -1,0 +1,55 @@
+# CE-REQ-CONFIG-GOV-001 — ADR Governance Linkage Contract
+
+## Metadata
+
+| Field | Value |
+|---|---|
+| requirement_id | CE-REQ-CONFIG-GOV-001 |
+| obligation_type | documentation_boundary |
+| claim_refs | CE-CAP-CONFIG-001 |
+| adr_refs | ADR-034, ADR-038 |
+| status | active |
+
+## Scope
+
+Development governance artifacts under `development/adrs/` and
+`development/capabilities/` for ADR-034, ADR-038.
+
+## Observable behavior
+
+The governed ADR claim chain MUST remain navigable in-place:
+
+1. Each owning ADR MUST list `CE-CAP-CONFIG-001` in its `## Governed claims` section.
+2. `CE-CAP-CONFIG-001` MUST list its owning ADRs in `adr_links`.
+3. `CE-CAP-CONFIG-001` MUST list `CE-REQ-CONFIG-GOV-001` in `requirements`.
+4. This requirement MUST list `CE-CAP-CONFIG-001` in `claim_refs`.
+5. Linked test references MUST point to existing tests or explicit metadata checks.
+
+## Acceptance criterion
+
+The capability traceability validation test passes for this ADR/claim/requirement
+chain without relying on a standalone traceability table or generated matrix.
+
+## Verification method
+
+Automated pytest test in `tests/capabilities/`.
+
+Test ID:
+- `test_should_validate_adr_capability_links_when_metadata_changes`
+
+(in `tests/capabilities/test_adr_capability_links.py`)
+
+## Evidence required
+
+| Field | Required |
+|---|---|
+| commit_sha | yes |
+| package_version | yes |
+| test_id | yes |
+| result | yes (pass/fail) |
+
+## Assumption boundary
+
+This requirement verifies governance linkage and metadata consistency. It does not
+prove every runtime behavior implied by the owning ADR; runtime behavior remains
+covered by the specific implementation tests referenced by feature requirements.

--- a/development/capabilities/requirements/CE-REQ-CORE-BOUNDARY-001.md
+++ b/development/capabilities/requirements/CE-REQ-CORE-BOUNDARY-001.md
@@ -1,0 +1,55 @@
+# CE-REQ-CORE-BOUNDARY-001 — ADR Governance Linkage Contract
+
+## Metadata
+
+| Field | Value |
+|---|---|
+| requirement_id | CE-REQ-CORE-BOUNDARY-001 |
+| obligation_type | documentation_boundary |
+| claim_refs | CE-CAP-CORE-001 |
+| adr_refs | ADR-001 |
+| status | active |
+
+## Scope
+
+Development governance artifacts under `development/adrs/` and
+`development/capabilities/` for ADR-001.
+
+## Observable behavior
+
+The governed ADR claim chain MUST remain navigable in-place:
+
+1. Each owning ADR MUST list `CE-CAP-CORE-001` in its `## Governed claims` section.
+2. `CE-CAP-CORE-001` MUST list its owning ADRs in `adr_links`.
+3. `CE-CAP-CORE-001` MUST list `CE-REQ-CORE-BOUNDARY-001` in `requirements`.
+4. This requirement MUST list `CE-CAP-CORE-001` in `claim_refs`.
+5. Linked test references MUST point to existing tests or explicit metadata checks.
+
+## Acceptance criterion
+
+The capability traceability validation test passes for this ADR/claim/requirement
+chain without relying on a standalone traceability table or generated matrix.
+
+## Verification method
+
+Automated pytest test in `tests/capabilities/`.
+
+Test ID:
+- `test_should_validate_adr_capability_links_when_metadata_changes`
+
+(in `tests/capabilities/test_adr_capability_links.py`)
+
+## Evidence required
+
+| Field | Required |
+|---|---|
+| commit_sha | yes |
+| package_version | yes |
+| test_id | yes |
+| result | yes (pass/fail) |
+
+## Assumption boundary
+
+This requirement verifies governance linkage and metadata consistency. It does not
+prove every runtime behavior implied by the owning ADR; runtime behavior remains
+covered by the specific implementation tests referenced by feature requirements.

--- a/development/capabilities/requirements/CE-REQ-DEPREC-GOV-001.md
+++ b/development/capabilities/requirements/CE-REQ-DEPREC-GOV-001.md
@@ -1,0 +1,55 @@
+# CE-REQ-DEPREC-GOV-001 — ADR Governance Linkage Contract
+
+## Metadata
+
+| Field | Value |
+|---|---|
+| requirement_id | CE-REQ-DEPREC-GOV-001 |
+| obligation_type | documentation_boundary |
+| claim_refs | CE-CAP-DEPREC-001 |
+| adr_refs | ADR-011 |
+| status | active |
+
+## Scope
+
+Development governance artifacts under `development/adrs/` and
+`development/capabilities/` for ADR-011.
+
+## Observable behavior
+
+The governed ADR claim chain MUST remain navigable in-place:
+
+1. Each owning ADR MUST list `CE-CAP-DEPREC-001` in its `## Governed claims` section.
+2. `CE-CAP-DEPREC-001` MUST list its owning ADRs in `adr_links`.
+3. `CE-CAP-DEPREC-001` MUST list `CE-REQ-DEPREC-GOV-001` in `requirements`.
+4. This requirement MUST list `CE-CAP-DEPREC-001` in `claim_refs`.
+5. Linked test references MUST point to existing tests or explicit metadata checks.
+
+## Acceptance criterion
+
+The capability traceability validation test passes for this ADR/claim/requirement
+chain without relying on a standalone traceability table or generated matrix.
+
+## Verification method
+
+Automated pytest test in `tests/capabilities/`.
+
+Test ID:
+- `test_should_validate_adr_capability_links_when_metadata_changes`
+
+(in `tests/capabilities/test_adr_capability_links.py`)
+
+## Evidence required
+
+| Field | Required |
+|---|---|
+| commit_sha | yes |
+| package_version | yes |
+| test_id | yes |
+| result | yes (pass/fail) |
+
+## Assumption boundary
+
+This requirement verifies governance linkage and metadata consistency. It does not
+prove every runtime behavior implied by the owning ADR; runtime behavior remains
+covered by the specific implementation tests referenced by feature requirements.

--- a/development/capabilities/requirements/CE-REQ-DIST-GOV-001.md
+++ b/development/capabilities/requirements/CE-REQ-DIST-GOV-001.md
@@ -1,0 +1,55 @@
+# CE-REQ-DIST-GOV-001 — ADR Governance Linkage Contract
+
+## Metadata
+
+| Field | Value |
+|---|---|
+| requirement_id | CE-REQ-DIST-GOV-001 |
+| obligation_type | documentation_boundary |
+| claim_refs | CE-CAP-DIST-001 |
+| adr_refs | ADR-010 |
+| status | active |
+
+## Scope
+
+Development governance artifacts under `development/adrs/` and
+`development/capabilities/` for ADR-010.
+
+## Observable behavior
+
+The governed ADR claim chain MUST remain navigable in-place:
+
+1. Each owning ADR MUST list `CE-CAP-DIST-001` in its `## Governed claims` section.
+2. `CE-CAP-DIST-001` MUST list its owning ADRs in `adr_links`.
+3. `CE-CAP-DIST-001` MUST list `CE-REQ-DIST-GOV-001` in `requirements`.
+4. This requirement MUST list `CE-CAP-DIST-001` in `claim_refs`.
+5. Linked test references MUST point to existing tests or explicit metadata checks.
+
+## Acceptance criterion
+
+The capability traceability validation test passes for this ADR/claim/requirement
+chain without relying on a standalone traceability table or generated matrix.
+
+## Verification method
+
+Automated pytest test in `tests/capabilities/`.
+
+Test ID:
+- `test_should_validate_adr_capability_links_when_metadata_changes`
+
+(in `tests/capabilities/test_adr_capability_links.py`)
+
+## Evidence required
+
+| Field | Required |
+|---|---|
+| commit_sha | yes |
+| package_version | yes |
+| test_id | yes |
+| result | yes (pass/fail) |
+
+## Assumption boundary
+
+This requirement verifies governance linkage and metadata consistency. It does not
+prove every runtime behavior implied by the owning ADR; runtime behavior remains
+covered by the specific implementation tests referenced by feature requirements.

--- a/development/capabilities/requirements/CE-REQ-DOCS-GOV-001.md
+++ b/development/capabilities/requirements/CE-REQ-DOCS-GOV-001.md
@@ -1,0 +1,55 @@
+# CE-REQ-DOCS-GOV-001 — ADR Governance Linkage Contract
+
+## Metadata
+
+| Field | Value |
+|---|---|
+| requirement_id | CE-REQ-DOCS-GOV-001 |
+| obligation_type | documentation_boundary |
+| claim_refs | CE-CAP-DOCS-001 |
+| adr_refs | ADR-012 |
+| status | active |
+
+## Scope
+
+Development governance artifacts under `development/adrs/` and
+`development/capabilities/` for ADR-012.
+
+## Observable behavior
+
+The governed ADR claim chain MUST remain navigable in-place:
+
+1. Each owning ADR MUST list `CE-CAP-DOCS-001` in its `## Governed claims` section.
+2. `CE-CAP-DOCS-001` MUST list its owning ADRs in `adr_links`.
+3. `CE-CAP-DOCS-001` MUST list `CE-REQ-DOCS-GOV-001` in `requirements`.
+4. This requirement MUST list `CE-CAP-DOCS-001` in `claim_refs`.
+5. Linked test references MUST point to existing tests or explicit metadata checks.
+
+## Acceptance criterion
+
+The capability traceability validation test passes for this ADR/claim/requirement
+chain without relying on a standalone traceability table or generated matrix.
+
+## Verification method
+
+Automated pytest test in `tests/capabilities/`.
+
+Test ID:
+- `test_should_validate_adr_capability_links_when_metadata_changes`
+
+(in `tests/capabilities/test_adr_capability_links.py`)
+
+## Evidence required
+
+| Field | Required |
+|---|---|
+| commit_sha | yes |
+| package_version | yes |
+| test_id | yes |
+| result | yes (pass/fail) |
+
+## Assumption boundary
+
+This requirement verifies governance linkage and metadata consistency. It does not
+prove every runtime behavior implied by the owning ADR; runtime behavior remains
+covered by the specific implementation tests referenced by feature requirements.

--- a/development/capabilities/requirements/CE-REQ-EXPL-API-001.md
+++ b/development/capabilities/requirements/CE-REQ-EXPL-API-001.md
@@ -7,6 +7,7 @@
 | requirement_id | CE-REQ-EXPL-API-001 |
 | obligation_type | api_contract |
 | claim_refs | CE-CAP-EXPL-001 |
+| adr_refs | ADR-008, ADR-015, ADR-026 |
 | status | active |
 
 ## Scope

--- a/development/capabilities/requirements/CE-REQ-EXPL-API-002.md
+++ b/development/capabilities/requirements/CE-REQ-EXPL-API-002.md
@@ -7,6 +7,7 @@
 | requirement_id | CE-REQ-EXPL-API-002 |
 | obligation_type | api_contract |
 | claim_refs | CE-CAP-EXPL-002 |
+| adr_refs | ADR-008, ADR-015, ADR-026 |
 | status | active |
 
 ## Scope

--- a/development/capabilities/requirements/CE-REQ-EXPL-CONJ-001.md
+++ b/development/capabilities/requirements/CE-REQ-EXPL-CONJ-001.md
@@ -7,6 +7,7 @@
 | requirement_id | CE-REQ-EXPL-CONJ-001 |
 | obligation_type | api_contract |
 | claim_refs | CE-CAP-EXPL-CONJ-001 |
+| adr_refs | ADR-008 |
 | status | active |
 | applicable_on | collection (CalibratedExplanations, AlternativeExplanations) and individual (FactualExplanation, AlternativeExplanation) |
 | supersedes | CE-REQ-EXPL-CONJ-COL-001, CE-REQ-EXPL-CONJ-IND-001, CE-REQ-EXPL-CONJ-API-001 |

--- a/development/capabilities/requirements/CE-REQ-EXPL-FILTER-COUNTER-001.md
+++ b/development/capabilities/requirements/CE-REQ-EXPL-FILTER-COUNTER-001.md
@@ -7,6 +7,7 @@
 | requirement_id | CE-REQ-EXPL-FILTER-COUNTER-001 |
 | obligation_type | api_contract |
 | claim_refs | CE-CAP-EXPL-FILTER-001 |
+| adr_refs | ADR-027 |
 | status | active |
 | applicable_on | collection (AlternativeExplanations) and individual (AlternativeExplanation) |
 

--- a/development/capabilities/requirements/CE-REQ-EXPL-FILTER-ENSURED-001.md
+++ b/development/capabilities/requirements/CE-REQ-EXPL-FILTER-ENSURED-001.md
@@ -7,6 +7,7 @@
 | requirement_id | CE-REQ-EXPL-FILTER-ENSURED-001 |
 | obligation_type | api_contract |
 | claim_refs | CE-CAP-EXPL-FILTER-001 |
+| adr_refs | ADR-027 |
 | status | active |
 | applicable_on | collection (AlternativeExplanations) and individual (AlternativeExplanation) |
 

--- a/development/capabilities/requirements/CE-REQ-EXPL-FILTER-PARETO-001.md
+++ b/development/capabilities/requirements/CE-REQ-EXPL-FILTER-PARETO-001.md
@@ -7,6 +7,7 @@
 | requirement_id | CE-REQ-EXPL-FILTER-PARETO-001 |
 | obligation_type | api_contract |
 | claim_refs | CE-CAP-EXPL-FILTER-001 |
+| adr_refs | ADR-027 |
 | status | active |
 | applicable_on | collection (AlternativeExplanations) and individual (AlternativeExplanation) |
 

--- a/development/capabilities/requirements/CE-REQ-EXPL-FILTER-SEMI-001.md
+++ b/development/capabilities/requirements/CE-REQ-EXPL-FILTER-SEMI-001.md
@@ -7,6 +7,7 @@
 | requirement_id | CE-REQ-EXPL-FILTER-SEMI-001 |
 | obligation_type | api_contract |
 | claim_refs | CE-CAP-EXPL-FILTER-001 |
+| adr_refs | ADR-027 |
 | status | active |
 | applicable_on | collection (AlternativeExplanations) and individual (AlternativeExplanation) |
 

--- a/development/capabilities/requirements/CE-REQ-EXPL-FILTER-SUPER-001.md
+++ b/development/capabilities/requirements/CE-REQ-EXPL-FILTER-SUPER-001.md
@@ -7,6 +7,7 @@
 | requirement_id | CE-REQ-EXPL-FILTER-SUPER-001 |
 | obligation_type | api_contract |
 | claim_refs | CE-CAP-EXPL-FILTER-001 |
+| adr_refs | ADR-027 |
 | status | active |
 | applicable_on | collection (AlternativeExplanations) and individual (AlternativeExplanation) |
 | supersedes | CE-REQ-EXPL-ENSURED-API-001 (partial) |

--- a/development/capabilities/requirements/CE-REQ-GUARD-API-001.md
+++ b/development/capabilities/requirements/CE-REQ-GUARD-API-001.md
@@ -7,6 +7,7 @@
 | requirement_id | CE-REQ-GUARD-API-001 |
 | obligation_type | api_contract |
 | claim_refs | CE-CAP-GUARD-001 |
+| adr_refs | ADR-032, ADR-038 |
 | status | active |
 
 ## Scope

--- a/development/capabilities/requirements/CE-REQ-LEGACY-GOV-001.md
+++ b/development/capabilities/requirements/CE-REQ-LEGACY-GOV-001.md
@@ -1,0 +1,55 @@
+# CE-REQ-LEGACY-GOV-001 — ADR Governance Linkage Contract
+
+## Metadata
+
+| Field | Value |
+|---|---|
+| requirement_id | CE-REQ-LEGACY-GOV-001 |
+| obligation_type | documentation_boundary |
+| claim_refs | CE-CAP-LEGACY-001 |
+| adr_refs | ADR-020 |
+| status | active |
+
+## Scope
+
+Development governance artifacts under `development/adrs/` and
+`development/capabilities/` for ADR-020.
+
+## Observable behavior
+
+The governed ADR claim chain MUST remain navigable in-place:
+
+1. Each owning ADR MUST list `CE-CAP-LEGACY-001` in its `## Governed claims` section.
+2. `CE-CAP-LEGACY-001` MUST list its owning ADRs in `adr_links`.
+3. `CE-CAP-LEGACY-001` MUST list `CE-REQ-LEGACY-GOV-001` in `requirements`.
+4. This requirement MUST list `CE-CAP-LEGACY-001` in `claim_refs`.
+5. Linked test references MUST point to existing tests or explicit metadata checks.
+
+## Acceptance criterion
+
+The capability traceability validation test passes for this ADR/claim/requirement
+chain without relying on a standalone traceability table or generated matrix.
+
+## Verification method
+
+Automated pytest test in `tests/capabilities/`.
+
+Test ID:
+- `test_should_validate_adr_capability_links_when_metadata_changes`
+
+(in `tests/capabilities/test_adr_capability_links.py`)
+
+## Evidence required
+
+| Field | Required |
+|---|---|
+| commit_sha | yes |
+| package_version | yes |
+| test_id | yes |
+| result | yes (pass/fail) |
+
+## Assumption boundary
+
+This requirement verifies governance linkage and metadata consistency. It does not
+prove every runtime behavior implied by the owning ADR; runtime behavior remains
+covered by the specific implementation tests referenced by feature requirements.

--- a/development/capabilities/requirements/CE-REQ-MODALITY-GOV-001.md
+++ b/development/capabilities/requirements/CE-REQ-MODALITY-GOV-001.md
@@ -1,0 +1,55 @@
+# CE-REQ-MODALITY-GOV-001 — ADR Governance Linkage Contract
+
+## Metadata
+
+| Field | Value |
+|---|---|
+| requirement_id | CE-REQ-MODALITY-GOV-001 |
+| obligation_type | documentation_boundary |
+| claim_refs | CE-CAP-MODALITY-001 |
+| adr_refs | ADR-033 |
+| status | active |
+
+## Scope
+
+Development governance artifacts under `development/adrs/` and
+`development/capabilities/` for ADR-033.
+
+## Observable behavior
+
+The governed ADR claim chain MUST remain navigable in-place:
+
+1. Each owning ADR MUST list `CE-CAP-MODALITY-001` in its `## Governed claims` section.
+2. `CE-CAP-MODALITY-001` MUST list its owning ADRs in `adr_links`.
+3. `CE-CAP-MODALITY-001` MUST list `CE-REQ-MODALITY-GOV-001` in `requirements`.
+4. This requirement MUST list `CE-CAP-MODALITY-001` in `claim_refs`.
+5. Linked test references MUST point to existing tests or explicit metadata checks.
+
+## Acceptance criterion
+
+The capability traceability validation test passes for this ADR/claim/requirement
+chain without relying on a standalone traceability table or generated matrix.
+
+## Verification method
+
+Automated pytest test in `tests/capabilities/`.
+
+Test ID:
+- `test_should_validate_adr_capability_links_when_metadata_changes`
+
+(in `tests/capabilities/test_adr_capability_links.py`)
+
+## Evidence required
+
+| Field | Required |
+|---|---|
+| commit_sha | yes |
+| package_version | yes |
+| test_id | yes |
+| result | yes (pass/fail) |
+
+## Assumption boundary
+
+This requirement verifies governance linkage and metadata consistency. It does not
+prove every runtime behavior implied by the owning ADR; runtime behavior remains
+covered by the specific implementation tests referenced by feature requirements.

--- a/development/capabilities/requirements/CE-REQ-MOND-API-001.md
+++ b/development/capabilities/requirements/CE-REQ-MOND-API-001.md
@@ -7,6 +7,7 @@
 | requirement_id | CE-REQ-MOND-API-001 |
 | obligation_type | api_contract |
 | claim_refs | CE-CAP-MOND-001 |
+| adr_refs | ADR-013 |
 | status | active |
 
 ## Scope

--- a/development/capabilities/requirements/CE-REQ-NARR-API-001.md
+++ b/development/capabilities/requirements/CE-REQ-NARR-API-001.md
@@ -7,6 +7,7 @@
 | requirement_id | CE-REQ-NARR-API-001 |
 | obligation_type | api_contract |
 | claim_refs | CE-CAP-NARR-001 |
+| adr_refs | ADR-008 |
 | status | active |
 
 ## Scope

--- a/development/capabilities/requirements/CE-REQ-OBS-GOV-001.md
+++ b/development/capabilities/requirements/CE-REQ-OBS-GOV-001.md
@@ -1,0 +1,55 @@
+# CE-REQ-OBS-GOV-001 — ADR Governance Linkage Contract
+
+## Metadata
+
+| Field | Value |
+|---|---|
+| requirement_id | CE-REQ-OBS-GOV-001 |
+| obligation_type | documentation_boundary |
+| claim_refs | CE-CAP-OBS-001 |
+| adr_refs | ADR-028 |
+| status | active |
+
+## Scope
+
+Development governance artifacts under `development/adrs/` and
+`development/capabilities/` for ADR-028.
+
+## Observable behavior
+
+The governed ADR claim chain MUST remain navigable in-place:
+
+1. Each owning ADR MUST list `CE-CAP-OBS-001` in its `## Governed claims` section.
+2. `CE-CAP-OBS-001` MUST list its owning ADRs in `adr_links`.
+3. `CE-CAP-OBS-001` MUST list `CE-REQ-OBS-GOV-001` in `requirements`.
+4. This requirement MUST list `CE-CAP-OBS-001` in `claim_refs`.
+5. Linked test references MUST point to existing tests or explicit metadata checks.
+
+## Acceptance criterion
+
+The capability traceability validation test passes for this ADR/claim/requirement
+chain without relying on a standalone traceability table or generated matrix.
+
+## Verification method
+
+Automated pytest test in `tests/capabilities/`.
+
+Test ID:
+- `test_should_validate_adr_capability_links_when_metadata_changes`
+
+(in `tests/capabilities/test_adr_capability_links.py`)
+
+## Evidence required
+
+| Field | Required |
+|---|---|
+| commit_sha | yes |
+| package_version | yes |
+| test_id | yes |
+| result | yes (pass/fail) |
+
+## Assumption boundary
+
+This requirement verifies governance linkage and metadata consistency. It does not
+prove every runtime behavior implied by the owning ADR; runtime behavior remains
+covered by the specific implementation tests referenced by feature requirements.

--- a/development/capabilities/requirements/CE-REQ-PARALLEL-GOV-001.md
+++ b/development/capabilities/requirements/CE-REQ-PARALLEL-GOV-001.md
@@ -1,0 +1,55 @@
+# CE-REQ-PARALLEL-GOV-001 — ADR Governance Linkage Contract
+
+## Metadata
+
+| Field | Value |
+|---|---|
+| requirement_id | CE-REQ-PARALLEL-GOV-001 |
+| obligation_type | documentation_boundary |
+| claim_refs | CE-CAP-PARALLEL-001 |
+| adr_refs | ADR-004 |
+| status | active |
+
+## Scope
+
+Development governance artifacts under `development/adrs/` and
+`development/capabilities/` for ADR-004.
+
+## Observable behavior
+
+The governed ADR claim chain MUST remain navigable in-place:
+
+1. Each owning ADR MUST list `CE-CAP-PARALLEL-001` in its `## Governed claims` section.
+2. `CE-CAP-PARALLEL-001` MUST list its owning ADRs in `adr_links`.
+3. `CE-CAP-PARALLEL-001` MUST list `CE-REQ-PARALLEL-GOV-001` in `requirements`.
+4. This requirement MUST list `CE-CAP-PARALLEL-001` in `claim_refs`.
+5. Linked test references MUST point to existing tests or explicit metadata checks.
+
+## Acceptance criterion
+
+The capability traceability validation test passes for this ADR/claim/requirement
+chain without relying on a standalone traceability table or generated matrix.
+
+## Verification method
+
+Automated pytest test in `tests/capabilities/`.
+
+Test ID:
+- `test_should_validate_adr_capability_links_when_metadata_changes`
+
+(in `tests/capabilities/test_adr_capability_links.py`)
+
+## Evidence required
+
+| Field | Required |
+|---|---|
+| commit_sha | yes |
+| package_version | yes |
+| test_id | yes |
+| result | yes (pass/fail) |
+
+## Assumption boundary
+
+This requirement verifies governance linkage and metadata consistency. It does not
+prove every runtime behavior implied by the owning ADR; runtime behavior remains
+covered by the specific implementation tests referenced by feature requirements.

--- a/development/capabilities/requirements/CE-REQ-PLOTSPEC-GOV-001.md
+++ b/development/capabilities/requirements/CE-REQ-PLOTSPEC-GOV-001.md
@@ -1,0 +1,55 @@
+# CE-REQ-PLOTSPEC-GOV-001 — ADR Governance Linkage Contract
+
+## Metadata
+
+| Field | Value |
+|---|---|
+| requirement_id | CE-REQ-PLOTSPEC-GOV-001 |
+| obligation_type | documentation_boundary |
+| claim_refs | CE-CAP-PLOTSPEC-001 |
+| adr_refs | ADR-036, ADR-037 |
+| status | active |
+
+## Scope
+
+Development governance artifacts under `development/adrs/` and
+`development/capabilities/` for ADR-036, ADR-037.
+
+## Observable behavior
+
+The governed ADR claim chain MUST remain navigable in-place:
+
+1. Each owning ADR MUST list `CE-CAP-PLOTSPEC-001` in its `## Governed claims` section.
+2. `CE-CAP-PLOTSPEC-001` MUST list its owning ADRs in `adr_links`.
+3. `CE-CAP-PLOTSPEC-001` MUST list `CE-REQ-PLOTSPEC-GOV-001` in `requirements`.
+4. This requirement MUST list `CE-CAP-PLOTSPEC-001` in `claim_refs`.
+5. Linked test references MUST point to existing tests or explicit metadata checks.
+
+## Acceptance criterion
+
+The capability traceability validation test passes for this ADR/claim/requirement
+chain without relying on a standalone traceability table or generated matrix.
+
+## Verification method
+
+Automated pytest test in `tests/capabilities/`.
+
+Test ID:
+- `test_should_validate_adr_capability_links_when_metadata_changes`
+
+(in `tests/capabilities/test_adr_capability_links.py`)
+
+## Evidence required
+
+| Field | Required |
+|---|---|
+| commit_sha | yes |
+| package_version | yes |
+| test_id | yes |
+| result | yes (pass/fail) |
+
+## Assumption boundary
+
+This requirement verifies governance linkage and metadata consistency. It does not
+prove every runtime behavior implied by the owning ADR; runtime behavior remains
+covered by the specific implementation tests referenced by feature requirements.

--- a/development/capabilities/requirements/CE-REQ-PLUGIN-DOC-001.md
+++ b/development/capabilities/requirements/CE-REQ-PLUGIN-DOC-001.md
@@ -7,6 +7,7 @@
 | requirement_id | CE-REQ-PLUGIN-DOC-001 |
 | obligation_type | documentation_boundary |
 | claim_refs | CE-CAP-PLUGIN-001 |
+| adr_refs | ADR-006, ADR-013, ADR-015, ADR-026, ADR-033 |
 | status | active |
 
 ## Scope

--- a/development/capabilities/requirements/CE-REQ-PRED-API-001.md
+++ b/development/capabilities/requirements/CE-REQ-PRED-API-001.md
@@ -7,6 +7,7 @@
 | requirement_id | CE-REQ-PRED-API-001 |
 | obligation_type | api_contract |
 | claim_refs | CE-CAP-PRED-001 |
+| adr_refs | ADR-013, ADR-021 |
 | status | active |
 
 ## Scope

--- a/development/capabilities/requirements/CE-REQ-PRED-CLASS-API-001.md
+++ b/development/capabilities/requirements/CE-REQ-PRED-CLASS-API-001.md
@@ -7,6 +7,7 @@
 | requirement_id | CE-REQ-PRED-CLASS-API-001 |
 | obligation_type | api_contract |
 | claim_refs | CE-CAP-PRED-CLASS-001 |
+| adr_refs | ADR-021 |
 | status | active |
 
 ## Scope

--- a/development/capabilities/requirements/CE-REQ-PRED-INTERVAL-BOUNDS-001.md
+++ b/development/capabilities/requirements/CE-REQ-PRED-INTERVAL-BOUNDS-001.md
@@ -7,6 +7,7 @@
 | requirement_id | CE-REQ-PRED-INTERVAL-BOUNDS-001 |
 | obligation_type | api_contract |
 | claim_refs | CE-CAP-PRED-001 |
+| adr_refs | ADR-013, ADR-021 |
 | status | active |
 
 ## Scope

--- a/development/capabilities/requirements/CE-REQ-PRED-PROB-API-001.md
+++ b/development/capabilities/requirements/CE-REQ-PRED-PROB-API-001.md
@@ -7,6 +7,7 @@
 | requirement_id | CE-REQ-PRED-PROB-API-001 |
 | obligation_type | api_contract |
 | claim_refs | CE-CAP-PRED-PROB-001 |
+| adr_refs | ADR-021 |
 | status | active |
 
 ## Scope

--- a/development/capabilities/requirements/CE-REQ-PREPROC-GOV-001.md
+++ b/development/capabilities/requirements/CE-REQ-PREPROC-GOV-001.md
@@ -1,0 +1,55 @@
+# CE-REQ-PREPROC-GOV-001 — ADR Governance Linkage Contract
+
+## Metadata
+
+| Field | Value |
+|---|---|
+| requirement_id | CE-REQ-PREPROC-GOV-001 |
+| obligation_type | documentation_boundary |
+| claim_refs | CE-CAP-PREPROC-001 |
+| adr_refs | ADR-009 |
+| status | active |
+
+## Scope
+
+Development governance artifacts under `development/adrs/` and
+`development/capabilities/` for ADR-009.
+
+## Observable behavior
+
+The governed ADR claim chain MUST remain navigable in-place:
+
+1. Each owning ADR MUST list `CE-CAP-PREPROC-001` in its `## Governed claims` section.
+2. `CE-CAP-PREPROC-001` MUST list its owning ADRs in `adr_links`.
+3. `CE-CAP-PREPROC-001` MUST list `CE-REQ-PREPROC-GOV-001` in `requirements`.
+4. This requirement MUST list `CE-CAP-PREPROC-001` in `claim_refs`.
+5. Linked test references MUST point to existing tests or explicit metadata checks.
+
+## Acceptance criterion
+
+The capability traceability validation test passes for this ADR/claim/requirement
+chain without relying on a standalone traceability table or generated matrix.
+
+## Verification method
+
+Automated pytest test in `tests/capabilities/`.
+
+Test ID:
+- `test_should_validate_adr_capability_links_when_metadata_changes`
+
+(in `tests/capabilities/test_adr_capability_links.py`)
+
+## Evidence required
+
+| Field | Required |
+|---|---|
+| commit_sha | yes |
+| package_version | yes |
+| test_id | yes |
+| result | yes (pass/fail) |
+
+## Assumption boundary
+
+This requirement verifies governance linkage and metadata consistency. It does not
+prove every runtime behavior implied by the owning ADR; runtime behavior remains
+covered by the specific implementation tests referenced by feature requirements.

--- a/development/capabilities/requirements/CE-REQ-REJECT-API-001.md
+++ b/development/capabilities/requirements/CE-REQ-REJECT-API-001.md
@@ -7,6 +7,7 @@
 | requirement_id | CE-REQ-REJECT-API-001 |
 | obligation_type | api_contract |
 | claim_refs | CE-CAP-REJECT-001 |
+| adr_refs | ADR-029, ADR-038 |
 | status | active |
 
 ## Scope

--- a/development/capabilities/requirements/CE-REQ-SCHEMA-GOV-001.md
+++ b/development/capabilities/requirements/CE-REQ-SCHEMA-GOV-001.md
@@ -1,0 +1,55 @@
+# CE-REQ-SCHEMA-GOV-001 — ADR Governance Linkage Contract
+
+## Metadata
+
+| Field | Value |
+|---|---|
+| requirement_id | CE-REQ-SCHEMA-GOV-001 |
+| obligation_type | documentation_boundary |
+| claim_refs | CE-CAP-SCHEMA-001 |
+| adr_refs | ADR-005, ADR-008 |
+| status | active |
+
+## Scope
+
+Development governance artifacts under `development/adrs/` and
+`development/capabilities/` for ADR-005, ADR-008.
+
+## Observable behavior
+
+The governed ADR claim chain MUST remain navigable in-place:
+
+1. Each owning ADR MUST list `CE-CAP-SCHEMA-001` in its `## Governed claims` section.
+2. `CE-CAP-SCHEMA-001` MUST list its owning ADRs in `adr_links`.
+3. `CE-CAP-SCHEMA-001` MUST list `CE-REQ-SCHEMA-GOV-001` in `requirements`.
+4. This requirement MUST list `CE-CAP-SCHEMA-001` in `claim_refs`.
+5. Linked test references MUST point to existing tests or explicit metadata checks.
+
+## Acceptance criterion
+
+The capability traceability validation test passes for this ADR/claim/requirement
+chain without relying on a standalone traceability table or generated matrix.
+
+## Verification method
+
+Automated pytest test in `tests/capabilities/`.
+
+Test ID:
+- `test_should_validate_adr_capability_links_when_metadata_changes`
+
+(in `tests/capabilities/test_adr_capability_links.py`)
+
+## Evidence required
+
+| Field | Required |
+|---|---|
+| commit_sha | yes |
+| package_version | yes |
+| test_id | yes |
+| result | yes (pass/fail) |
+
+## Assumption boundary
+
+This requirement verifies governance linkage and metadata consistency. It does not
+prove every runtime behavior implied by the owning ADR; runtime behavior remains
+covered by the specific implementation tests referenced by feature requirements.

--- a/development/capabilities/requirements/CE-REQ-SERIAL-GOV-001.md
+++ b/development/capabilities/requirements/CE-REQ-SERIAL-GOV-001.md
@@ -1,0 +1,55 @@
+# CE-REQ-SERIAL-GOV-001 — ADR Governance Linkage Contract
+
+## Metadata
+
+| Field | Value |
+|---|---|
+| requirement_id | CE-REQ-SERIAL-GOV-001 |
+| obligation_type | documentation_boundary |
+| claim_refs | CE-CAP-SERIAL-001 |
+| adr_refs | ADR-031 |
+| status | active |
+
+## Scope
+
+Development governance artifacts under `development/adrs/` and
+`development/capabilities/` for ADR-031.
+
+## Observable behavior
+
+The governed ADR claim chain MUST remain navigable in-place:
+
+1. Each owning ADR MUST list `CE-CAP-SERIAL-001` in its `## Governed claims` section.
+2. `CE-CAP-SERIAL-001` MUST list its owning ADRs in `adr_links`.
+3. `CE-CAP-SERIAL-001` MUST list `CE-REQ-SERIAL-GOV-001` in `requirements`.
+4. This requirement MUST list `CE-CAP-SERIAL-001` in `claim_refs`.
+5. Linked test references MUST point to existing tests or explicit metadata checks.
+
+## Acceptance criterion
+
+The capability traceability validation test passes for this ADR/claim/requirement
+chain without relying on a standalone traceability table or generated matrix.
+
+## Verification method
+
+Automated pytest test in `tests/capabilities/`.
+
+Test ID:
+- `test_should_validate_adr_capability_links_when_metadata_changes`
+
+(in `tests/capabilities/test_adr_capability_links.py`)
+
+## Evidence required
+
+| Field | Required |
+|---|---|
+| commit_sha | yes |
+| package_version | yes |
+| test_id | yes |
+| result | yes (pass/fail) |
+
+## Assumption boundary
+
+This requirement verifies governance linkage and metadata consistency. It does not
+prove every runtime behavior implied by the owning ADR; runtime behavior remains
+covered by the specific implementation tests referenced by feature requirements.

--- a/development/capabilities/requirements/CE-REQ-TEST-GOV-001.md
+++ b/development/capabilities/requirements/CE-REQ-TEST-GOV-001.md
@@ -1,0 +1,55 @@
+# CE-REQ-TEST-GOV-001 — ADR Governance Linkage Contract
+
+## Metadata
+
+| Field | Value |
+|---|---|
+| requirement_id | CE-REQ-TEST-GOV-001 |
+| obligation_type | documentation_boundary |
+| claim_refs | CE-CAP-TEST-001 |
+| adr_refs | ADR-023, ADR-030 |
+| status | active |
+
+## Scope
+
+Development governance artifacts under `development/adrs/` and
+`development/capabilities/` for ADR-023, ADR-030.
+
+## Observable behavior
+
+The governed ADR claim chain MUST remain navigable in-place:
+
+1. Each owning ADR MUST list `CE-CAP-TEST-001` in its `## Governed claims` section.
+2. `CE-CAP-TEST-001` MUST list its owning ADRs in `adr_links`.
+3. `CE-CAP-TEST-001` MUST list `CE-REQ-TEST-GOV-001` in `requirements`.
+4. This requirement MUST list `CE-CAP-TEST-001` in `claim_refs`.
+5. Linked test references MUST point to existing tests or explicit metadata checks.
+
+## Acceptance criterion
+
+The capability traceability validation test passes for this ADR/claim/requirement
+chain without relying on a standalone traceability table or generated matrix.
+
+## Verification method
+
+Automated pytest test in `tests/capabilities/`.
+
+Test ID:
+- `test_should_validate_adr_capability_links_when_metadata_changes`
+
+(in `tests/capabilities/test_adr_capability_links.py`)
+
+## Evidence required
+
+| Field | Required |
+|---|---|
+| commit_sha | yes |
+| package_version | yes |
+| test_id | yes |
+| result | yes (pass/fail) |
+
+## Assumption boundary
+
+This requirement verifies governance linkage and metadata consistency. It does not
+prove every runtime behavior implied by the owning ADR; runtime behavior remains
+covered by the specific implementation tests referenced by feature requirements.

--- a/development/capabilities/requirements/CE-REQ-VALID-EXCEPTION-001.md
+++ b/development/capabilities/requirements/CE-REQ-VALID-EXCEPTION-001.md
@@ -1,0 +1,55 @@
+# CE-REQ-VALID-EXCEPTION-001 — ADR Governance Linkage Contract
+
+## Metadata
+
+| Field | Value |
+|---|---|
+| requirement_id | CE-REQ-VALID-EXCEPTION-001 |
+| obligation_type | documentation_boundary |
+| claim_refs | CE-CAP-VALID-001 |
+| adr_refs | ADR-002 |
+| status | active |
+
+## Scope
+
+Development governance artifacts under `development/adrs/` and
+`development/capabilities/` for ADR-002.
+
+## Observable behavior
+
+The governed ADR claim chain MUST remain navigable in-place:
+
+1. Each owning ADR MUST list `CE-CAP-VALID-001` in its `## Governed claims` section.
+2. `CE-CAP-VALID-001` MUST list its owning ADRs in `adr_links`.
+3. `CE-CAP-VALID-001` MUST list `CE-REQ-VALID-EXCEPTION-001` in `requirements`.
+4. This requirement MUST list `CE-CAP-VALID-001` in `claim_refs`.
+5. Linked test references MUST point to existing tests or explicit metadata checks.
+
+## Acceptance criterion
+
+The capability traceability validation test passes for this ADR/claim/requirement
+chain without relying on a standalone traceability table or generated matrix.
+
+## Verification method
+
+Automated pytest test in `tests/capabilities/`.
+
+Test ID:
+- `test_should_validate_adr_capability_links_when_metadata_changes`
+
+(in `tests/capabilities/test_adr_capability_links.py`)
+
+## Evidence required
+
+| Field | Required |
+|---|---|
+| commit_sha | yes |
+| package_version | yes |
+| test_id | yes |
+| result | yes (pass/fail) |
+
+## Assumption boundary
+
+This requirement verifies governance linkage and metadata consistency. It does not
+prove every runtime behavior implied by the owning ADR; runtime behavior remains
+covered by the specific implementation tests referenced by feature requirements.

--- a/development/capabilities/requirements/CE-REQ-VIZ-SMOKE-001.md
+++ b/development/capabilities/requirements/CE-REQ-VIZ-SMOKE-001.md
@@ -7,6 +7,7 @@
 | requirement_id | CE-REQ-VIZ-SMOKE-001 |
 | obligation_type | empirical_smoke |
 | claim_refs | CE-CAP-VIZ-001 |
+| adr_refs | ADR-023, ADR-036, ADR-037 |
 | status | active |
 
 ## Scope

--- a/tests/capabilities/test_adr_capability_links.py
+++ b/tests/capabilities/test_adr_capability_links.py
@@ -1,0 +1,79 @@
+"""Capability metadata checks for ADR evidence-bearing links."""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+
+def _repo_root() -> Path:
+    return Path(__file__).resolve().parents[2]
+
+
+def _yaml_list(text: str, key: str) -> list[str]:
+    match = re.search(rf"^{key}:\n((?:  - .+\n)+)", text, re.MULTILINE)
+    if not match:
+        return []
+    return [line.split("-", 1)[1].strip() for line in match.group(1).splitlines()]
+
+
+def _metadata_value(text: str, field: str) -> str:
+    match = re.search(rf"^\| {re.escape(field)} \| ([^|]+) \|", text, re.MULTILINE)
+    return match.group(1).strip() if match else ""
+
+
+def test_should_validate_adr_capability_links_when_metadata_changes() -> None:
+    """Verifies ADR-governed CE-CAP/CE-REQ link consistency."""
+    root = _repo_root()
+    adr_dir = root / "development" / "adrs"
+    claim_dir = root / "development" / "capabilities" / "claims"
+    req_dir = root / "development" / "capabilities" / "requirements"
+
+    claim_files = {path.stem: path for path in claim_dir.glob("CE-CAP-*.yaml")}
+    requirement_files = {path.stem: path for path in req_dir.glob("CE-REQ-*.md")}
+    active_adr_files = [path for path in adr_dir.glob("ADR-*.md")]
+
+    errors: list[str] = []
+
+    for adr_path in active_adr_files:
+        adr_id = re.search(r"ADR-\d+", adr_path.name).group(0)
+        adr_text = adr_path.read_text(encoding="utf-8")
+        governed_claims = re.findall(r"^- `(CE-CAP-[A-Z0-9-]+)`", adr_text, re.MULTILINE)
+        if not governed_claims:
+            errors.append(f"{adr_id} does not list governed claims")
+            continue
+        for claim_id in governed_claims:
+            claim_path = claim_files.get(claim_id)
+            if claim_path is None:
+                errors.append(f"{adr_id} references missing claim {claim_id}")
+                continue
+            claim_text = claim_path.read_text(encoding="utf-8")
+            if adr_id not in _yaml_list(claim_text, "adr_links"):
+                errors.append(f"{claim_id} does not link back to {adr_id}")
+
+    for claim_id, claim_path in claim_files.items():
+        claim_text = claim_path.read_text(encoding="utf-8")
+        adr_links = _yaml_list(claim_text, "adr_links")
+        requirements = _yaml_list(claim_text, "requirements")
+        if not adr_links:
+            errors.append(f"{claim_id} has no adr_links")
+        if not requirements:
+            errors.append(f"{claim_id} has no requirements")
+        for adr_id in adr_links:
+            matches = list(adr_dir.glob(f"{adr_id}-*.md"))
+            if not matches:
+                errors.append(f"{claim_id} references missing ADR {adr_id}")
+                continue
+            if f"`{claim_id}`" not in matches[0].read_text(encoding="utf-8"):
+                errors.append(f"{adr_id} does not list {claim_id}")
+        for req_id in requirements:
+            req_path = requirement_files.get(req_id)
+            if req_path is None:
+                errors.append(f"{claim_id} references missing requirement {req_id}")
+                continue
+            req_text = req_path.read_text(encoding="utf-8")
+            claim_refs = _metadata_value(req_text, "claim_refs")
+            if claim_id not in claim_refs:
+                errors.append(f"{req_id} does not link back to {claim_id}")
+
+    assert not errors, "\n".join(errors)


### PR DESCRIPTION
### Motivation

- Ensure every active ADR directly references the capability claims it governs so the ADR → claim → requirement → test → evidence chain is navigable in-place.  
- Surface missing governance-oriented capability claims and normative requirements needed to record ADR-backed obligations without introducing a parallel traceability artifact.  

### Description

- Added `## Governed claims` sections to all active ADR files under `development/adrs/` so each ADR lists the `CE-CAP-*` claims it governs.  
- Added 17 new governance-oriented capability claim files under `development/capabilities/claims/` and updated 13 existing claim YAMLs with machine-checkable `adr_links` metadata.  
- Added 17 new governance requirement documents under `development/capabilities/requirements/` and updated 18 existing requirement files with `adr_refs` metadata so claims and requirements are bidirectionally linked to ADRs.  
- Updated multiple ADR prose snippets to remove stale `docs/improvement/` references and point to current `development/` artefacts where relevant.  
- Added an automated metadata check `tests/capabilities/test_adr_capability_links.py` that verifies ADR → claim → requirement link consistency without creating any separate traceability table.  

### Testing

- Ran the capability metadata test: `pytest -q -o addopts='' tests/capabilities/test_adr_capability_links.py` — PASS (1 test).  
- Ran PR-local checks: `make local-checks-pr` — PASS; core test run summary reported `1883 passed, 12 skipped, 69 deselected`.  
- Attempted `python -m pip install -e '.[dev]'` but environment package index access failed (network/proxy returned `403 Forbidden`), so full dev install was not completed; this is an environmental issue and did not affect the metadata changes or the local-checks-pr outcome.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a377e28d8a4832987f01b28d2fc7939)