### PR TITLE
Add governance capability claims, requirements, and ADR linkage tests

### DIFF
--- a/development/adrs/ADR-001-core-decomposition-boundaries.md
+++ b/development/adrs/ADR-001-core-decomposition-boundaries.md
@@ -40,6 +40,11 @@ Rules:
 - Utilities layer must not depend on higher-level packages.
 - Schema validation lives separately to avoid heavy imports where not needed.
 
+
+## Governed claims
+
+- `CE-CAP-CORE-001` — Core package boundaries preserve stable separation between core, calibration, explanations, schema, plugins, cache, and parallel services.
+
 ## Alternatives Considered
 
 1. Flat module namespace (simpler, but scaling pain and import cycles risk).

--- a/development/adrs/ADR-002-validation-and-exception-design.md
+++ b/development/adrs/ADR-002-validation-and-exception-design.md
@@ -53,6 +53,11 @@ Logging & surfacing:
 - Optionally attach last validation errors summary to a debug report generation utility.
 - Provide `explain_exception(e)` helper to produce human-oriented multi-line message.
 
+
+## Governed claims
+
+- `CE-CAP-VALID-001` — Public validation failures use the CE exception taxonomy rather than ad-hoc generic exceptions where ADR-002 scope applies.
+
 ## Alternatives Considered
 
 1. Keep ad-hoc exceptions (low effort, inconsistent quality).

--- a/development/adrs/ADR-003-caching-key-and-eviction.md
+++ b/development/adrs/ADR-003-caching-key-and-eviction.md
@@ -1,6 +1,6 @@
 > **Active scope:** Governing architectural decision for the explanation cache key design and eviction policy. Remains active as long as the cache key contract governs performance-sensitive explain paths; superseded when the caching strategy is revised.
 
-> **Status note (2025-11-29):** Last edited 2025-11-29 · Archive after: v1.0.0 GA · Implementation: Fully completed in v0.10.0 · All ADR-003 gates satisfied per `docs/improvement/adr\ mending/ADR-003/COMPLETION_REPORT.md`.
+> **Status note (2025-11-29):** Last edited 2025-11-29 · Archive after: v1.0.0 GA · Implementation: Fully completed in v0.10.0 · All ADR-003 gates are tracked in `development/current-work/RELEASE_PLAN_status_appendix.md`.
 
 # ADR-003: Caching Key & Eviction Strategy
 
@@ -45,6 +45,11 @@ Adopt a lightweight, opt-in in-process cache with simple, deterministic keys and
 
 - Update README and release notes with configuration tables, tuning guidance, and the support policy for the cache namespace taxonomy.
 - Record STRATEGY_REV identifiers in the ADR appendix and reference them from the release checklist to ensure invalidation discipline.
+
+
+## Governed claims
+
+- `CE-CAP-CACHE-001` — Caching is opt-in, transparent to public APIs, and governed by deterministic key and fallback visibility constraints.
 
 ## Alternatives Considered
 

--- a/development/adrs/ADR-004-parallel-backend-abstraction.md
+++ b/development/adrs/ADR-004-parallel-backend-abstraction.md
@@ -50,6 +50,11 @@ The following clarifications capture the guardrails for explicit, opt-in paralle
 - Extend configuration docs and release notes with the explicit opt-in model, environment variable controls, and troubleshooting tips for common platforms (macOS spawn, Windows spawn).
 - Ship an upgrade guide snippet covering interaction with plugin-provided executors and guidance for opting out when running within user-managed pools.
 
+
+## Governed claims
+
+- `CE-CAP-PARALLEL-001` — Parallel execution remains explicit and opt-in, with deterministic result ordering and serial-by-default behavior.
+
 ## Alternatives Considered
 
 1. Hard-code joblib everywhere (adds dependency, hides heuristics, less explicit control).

--- a/development/adrs/ADR-005-explanation-json-schema-versioning.md
+++ b/development/adrs/ADR-005-explanation-json-schema-versioning.md
@@ -122,6 +122,14 @@ must come with:
   elementwise for vector predictions as well as scalars.
 - Envelope validation is **out of scope** for v1.0.0.
 
+
+## Governed claims
+
+- `CE-CAP-SCHEMA-EXTENSION-SURFACE-001` — Provenance and metadata are the governed optional extension surfaces; top-level envelope validation remains deferred.
+- `CE-CAP-SCHEMA-VALIDATION-001` — Schema validation enforces semver schema versions and interval invariants where payload validation is invoked.
+- `CE-CAP-SCHEMA-PAYLOAD-V1-001` — Explanation payload schema v1 defines the required CE-first fields for serialized instance-level explanations.
+- `CE-CAP-SCHEMA-001` — Explanation payloads use a versioned CE-first schema contract with explicit metadata and governed extension surfaces.
+
 ## Alternatives Considered
 
 1. **Full envelope now** — Rejected for v1.0.0 because it is not implemented in the

--- a/development/adrs/ADR-006-plugin-registry-trust-model.md
+++ b/development/adrs/ADR-006-plugin-registry-trust-model.md
@@ -40,6 +40,14 @@ Implement a conservative, opt-in plugin registry with explicit trust policy hook
 - Isolation: no sandboxing initially (document risk); future ADR may explore subprocess / WASM.
 - **Delegation & Ownership:** The `PluginManager` serves as the single source of truth for plugin resolution and defaults. `CalibratedExplainer` delegates all explanation requests to this manager, ensuring that trust and opt-in rules are consistently enforced regardless of the entry point.
 
+
+## Governed claims
+
+- `CE-CAP-PLUGIN-AUDIT-EVENTS-001` — Plugin trust and registration decisions emit warnings or governance audit events where ADR-006 requires visibility.
+- `CE-CAP-PLUGIN-DISCOVERY-REPORT-001` — Plugin discovery reports expose plugin metadata and trust status without executing untrusted plugin behavior.
+- `CE-CAP-PLUGIN-TRUST-POLICY-001` — Plugin loading follows explicit trust policy controls, allow and deny lists, and documented trust precedence.
+- `CE-CAP-PLUGIN-001` — calibrated_explanations exposes an extensible plugin system through the   calibrated_explanations.plugins module: ExplainerPlugin defines the protocol for   custom explanation backends, and IntervalCalibratorPlugin defines the protocol for   custom interval calibrators, enabling replacement of default internal implementations.
+
 ## Alternatives Considered
 
 1. Auto-load all entry points (simpler, higher risk).

--- a/development/adrs/ADR-008-explanation-domain-model-and-compat.md
+++ b/development/adrs/ADR-008-explanation-domain-model-and-compat.md
@@ -74,6 +74,19 @@ explanations.
 - Positive: simpler iteration/filtering, safer invariants, clearer ownership of fields, smoother future schema migration.
 - Negative: adds an adapter layer; requires adapter parity tests and slight maintenance.
 
+
+## Governed claims
+
+- `CE-CAP-EXPL-FILTER-001` — Alternative explanation rule filtering exposes super, semi, counter, ensured, and pareto views over alternative rule semantics.
+- `CE-CAP-EXPL-PAPER-SEMANTICS-001` — Factual and alternative explanations preserve the paper-aligned factual-condition and alternative-condition semantics.
+- `CE-CAP-DOMAIN-LEGACY-ADAPTER-001` — Legacy adapters preserve public and serialized shapes while internal explanation models evolve.
+- `CE-CAP-DOMAIN-MODEL-001` — The internal explanation domain model uses Explanation and FeatureRule concepts for rules, metadata, predicates, attribution, support, and uncertainty.
+- `CE-CAP-EXPL-001` — calibrated_explanations produces calibrated factual explanations for individual   instances via WrapCalibratedExplainer.explain_factual, returning feature   contributions with calibrated probability uncertainty for the predicted class.
+- `CE-CAP-EXPL-002` — calibrated_explanations produces calibrated alternative (counterfactual-style)   explanations for individual instances via WrapCalibratedExplainer.explore_alternatives,   identifying feature changes that would shift the prediction toward an alternative outcome.
+- `CE-CAP-EXPL-CONJ-001` — calibrated_explanations supports conjunctive multi-feature explanation rules via   add_conjunctions(), which extends any explanation collection or individual explanation   to include rules combining up to max_rule_size features, returning an updated   object of the same type. The method is available on CalibratedExplanations,   AlternativeExplanations, FactualExplanation, and AlternativeExplanation.
+- `CE-CAP-NARR-001` — calibrated_explanations generates human-readable natural language narratives for   factual and alternative explanations via CalibratedExplanations.to_narrative(),   returning non-None output (string, DataFrame, HTML, or dict) suitable for consumption   by downstream text pipelines.
+- `CE-CAP-SCHEMA-001` — Explanation payloads use a versioned CE-first schema contract with explicit metadata and governed extension surfaces.
+
 ## Alternatives
 
 - Keep dict-only approach (status quo): continues complexity and duplication in consumers.

--- a/development/adrs/ADR-009-input-preprocessing-and-mapping-policy.md
+++ b/development/adrs/ADR-009-input-preprocessing-and-mapping-policy.md
@@ -37,6 +37,11 @@ usability and reproducibility.
 - Positive: greatly improved ergonomics; deterministic mappings in predict/online; clearer provenance.
 - Negative: additional complexity in wrapper; need to document behavior and storage.
 
+
+## Governed claims
+
+- `CE-CAP-PREPROC-001` — Wrapper preprocessing learns and reuses deterministic feature mappings while keeping the core numeric and preserving provenance boundaries.
+
 ## Alternatives
 
 - Enforce user-supplied preprocessing only (status quo), which is less friendly and harder to reproduce.

--- a/development/adrs/ADR-010-core-vs-evaluation-split-and-distribution.md
+++ b/development/adrs/ADR-010-core-vs-evaluation-split-and-distribution.md
@@ -80,6 +80,11 @@ Pending:
 - Optional evaluation workflow that installs `[eval]` and runs benchmarks.
 - Add compatibility checks confirming optional packages do not change core outputs unless explicitly enabled.
 
+
+## Governed claims
+
+- `CE-CAP-DIST-001` — The core package and evaluation tooling remain separately distributed and independently governed.
+
 ## Alternatives Considered
 
 1. Split into multiple pip distributions immediately (core, viz, eval). Deferred to reduce maintenance overhead; extras provide a simpler first step.

--- a/development/adrs/ADR-011-deprecation-and-migration-policy.md
+++ b/development/adrs/ADR-011-deprecation-and-migration-policy.md
@@ -44,6 +44,11 @@ No deprecation-removal work may be deferred to `v1.0.0`, `v1.0.0-rc`, or any pos
 
 When default-policy timing conflicts with the v1.0 finalization exception, **the v1.0 finalization exception wins**.
 
+
+## Governed claims
+
+- `CE-CAP-DEPREC-001` — Deprecations follow the accepted migration lifecycle, including visible warnings and documented removal windows.
+
 ## Alternatives Considered
 
 1. Immediate breaking changes with major version bumps for every cleanup (too disruptive for existing users).

--- a/development/adrs/ADR-012-documentation-and-gallery-build-policy.md
+++ b/development/adrs/ADR-012-documentation-and-gallery-build-policy.md
@@ -38,6 +38,11 @@ readiness:
   datasets (<30s per example on CI hardware).
 - Publishing: artifacts uploaded as workflow artifacts; optional GitHub Pages later.
 
+
+## Governed claims
+
+- `CE-CAP-DOCS-001` — Documentation and gallery builds use maintained source pages and documented build policy rather than obsolete improvement paths.
+
 ## Alternatives Considered
 
 1. Keep docs informal in README only (insufficient for scale and stability goals).

--- a/development/adrs/ADR-013-interval-calibrator-plugin-strategy.md
+++ b/development/adrs/ADR-013-interval-calibrator-plugin-strategy.md
@@ -138,6 +138,18 @@ Each alternative scenario is evaluated with the same interval calibrator:
   distribution changes are required.【F:src/calibrated_explanations/plugins/intervals.py†L1-L80】【F:src/calibrated_explanations/plugins/builtins.py†L120-L183】
 - **2026-06-02 (v0.11.3 Task 9 Workstream D):** ADR-013 §4 Lifecycle previously cited `src/calibrated_explanations/plugins/interval_wrappers.py` as the FAST wrapper location. That file does not exist. The wrapper is at `src/calibrated_explanations/calibration/interval_wrappers.py`. §4 text has been corrected. This is a documentation-only fix; no code change required.
 
+
+## Governed claims
+
+- `CE-CAP-INTERVAL-PLUGIN-VALIDATION-001` — Interval plugin outputs are validated for shape, dtype, monotonicity, and protocol conformity; misconfiguration does not silently degrade calibration quality.
+- `CE-CAP-FAST-INTERVAL-PLUGIN-001` — core.interval.fast is opt-in and never part of the primary interval fallback chain.
+- `CE-CAP-INTERVAL-PLUGIN-FALLBACK-001` — core.interval.legacy remains the trusted mandatory interval calibrator fallback.
+- `CE-CAP-INTERVAL-CONTEXT-IMMUTABILITY-001` — IntervalCalibratorContext exposes frozen/read-only calibration state and plugin-local scratch state without mutating the explainer.
+- `CE-CAP-INTERVAL-PLUGIN-PROTOCOL-001` — Interval plugins satisfy classification and regression calibrator protocols and output shapes.
+- `CE-CAP-PLUGIN-001` — calibrated_explanations exposes an extensible plugin system through the   calibrated_explanations.plugins module: ExplainerPlugin defines the protocol for   custom explanation backends, and IntervalCalibratorPlugin defines the protocol for   custom interval calibrators, enabling replacement of default internal implementations.
+- `CE-CAP-PRED-001` — calibrated_explanations returns calibrated uncertainty intervals for predictions   via WrapCalibratedExplainer.predict with uq_interval=True (or predict_proba with   uq_interval=True for classification). The returned low and high bounds represent   calibrated uncertainty around the point prediction.
+- `CE-CAP-MOND-001` — calibrated_explanations supports Mondrian (class-conditional) calibration: passing   a MondrianCategorizer callable to WrapCalibratedExplainer.calibrate produces separate   internal calibrators per category, enabling conditional validity guarantees within   each Mondrian group.
+
 ## Consequences
 
 Positive:

--- a/development/adrs/ADR-015-explanation-plugin.md
+++ b/development/adrs/ADR-015-explanation-plugin.md
@@ -366,6 +366,13 @@ custom containers; it is the plugin author’s responsibility to ensure
 downstream tooling can consume those results.
 No mandatory JSON contract is imposed by the plugin interface.
 
+
+## Governed claims
+
+- `CE-CAP-PLUGIN-001` — calibrated_explanations exposes an extensible plugin system through the   calibrated_explanations.plugins module: ExplainerPlugin defines the protocol for   custom explanation backends, and IntervalCalibratorPlugin defines the protocol for   custom interval calibrators, enabling replacement of default internal implementations.
+- `CE-CAP-EXPL-001` — calibrated_explanations produces calibrated factual explanations for individual   instances via WrapCalibratedExplainer.explain_factual, returning feature   contributions with calibrated probability uncertainty for the predicted class.
+- `CE-CAP-EXPL-002` — calibrated_explanations produces calibrated alternative (counterfactual-style)   explanations for individual instances via WrapCalibratedExplainer.explore_alternatives,   identifying feature changes that would shift the prediction toward an alternative outcome.
+
 ## Consequences
 
 - **Backward compatibility:** Public APIs and explanation outputs remain

--- a/development/adrs/ADR-020-legacy-user-api-stability.md
+++ b/development/adrs/ADR-020-legacy-user-api-stability.md
@@ -46,6 +46,11 @@ Adopt a layered guardrail strategy that freezes the documented legacy API:
    formal decision record (ADR) approving the specific removal.
 
    **Note:** This override constitutes an explicit exception to the deprecation policy defined in ADR-011. ADR-011 should be updated to reference this exception to ensure all contributors are aware of the special handling for the legacy API.
+
+## Governed claims
+
+- `CE-CAP-LEGACY-001` — Legacy user APIs remain stable within the documented major-version compatibility boundary.
+
 ## Alternatives Considered
 
 1. **Rely solely on documentation.** Rejected because prose alone does not fail

--- a/development/adrs/ADR-021-calibrated-interval-semantics.md
+++ b/development/adrs/ADR-021-calibrated-interval-semantics.md
@@ -216,6 +216,13 @@ ADR constrains *how* those plugins behave when implementing the protocols.
   tests showing the same payload fields (`low_high_percentiles` or
   `y_threshold`) are populated with the expected meaning.
 
+
+## Governed claims
+
+- `CE-CAP-PRED-001` — calibrated_explanations returns calibrated uncertainty intervals for predictions   via WrapCalibratedExplainer.predict with uq_interval=True (or predict_proba with   uq_interval=True for classification). The returned low and high bounds represent   calibrated uncertainty around the point prediction.
+- `CE-CAP-PRED-CLASS-001` — calibrated_explanations produces Venn-Abers calibrated class probabilities for   binary and multiclass classification tasks via WrapCalibratedExplainer.predict_proba,   returning a probability array bounded in [0, 1] with shape matching the input, and   class label arrays via WrapCalibratedExplainer.predict.
+- `CE-CAP-PRED-PROB-001` — calibrated_explanations supports probabilistic regression queries: given a scalar   threshold, WrapCalibratedExplainer.predict_proba(X, threshold=y_threshold) returns   the empirical probability that the regression target exceeds the threshold,   P(Y > threshold | X), as an array bounded in [0, 1] with shape matching the input.
+
 ## Consequences
 
 Positive:

--- a/development/adrs/ADR-023-matplotlib-coverage-exemption.md
+++ b/development/adrs/ADR-023-matplotlib-coverage-exemption.md
@@ -96,6 +96,12 @@ omit =
 - **Maintenance**: Document split test workflow in contributor guide and CI configuration
 - **Testing**: Run `pytest --no-cov -m viz` to validate viz tests; run `pytest` for coverage on remaining modules
 
+
+## Governed claims
+
+- `CE-CAP-VIZ-001` — calibrated_explanations provides visualization output for explanations via   WrapCalibratedExplainer.plot and CalibratedExplanations.plot, supporting   multiple output styles ('regular', 'triangular') and optional file saving,   without raising exceptions for standard single-instance and batch inputs   when a non-interactive rendering backend is available.
+- `CE-CAP-TEST-001` — Tests follow the repository quality policy for naming, coverage gates, and justified coverage exemptions.
+
 ## Alternatives Considered
 
 1. **Further matplotlib downgrade (3.8.4 → 3.7.x)**: Risk of breaking API compatibility; 3.7.x EOL status

--- a/development/adrs/ADR-026-explanation-plugin-semantics.md
+++ b/development/adrs/ADR-026-explanation-plugin-semantics.md
@@ -237,6 +237,13 @@ The validator must check:
   surface — are governed by ADR-032 and apply regardless of whether the guarded path
   runs through a built-in plugin or a third-party plugin that opts in.
 
+
+## Governed claims
+
+- `CE-CAP-PLUGIN-001` — calibrated_explanations exposes an extensible plugin system through the   calibrated_explanations.plugins module: ExplainerPlugin defines the protocol for   custom explanation backends, and IntervalCalibratorPlugin defines the protocol for   custom interval calibrators, enabling replacement of default internal implementations.
+- `CE-CAP-EXPL-001` — calibrated_explanations produces calibrated factual explanations for individual   instances via WrapCalibratedExplainer.explain_factual, returning feature   contributions with calibrated probability uncertainty for the predicted class.
+- `CE-CAP-EXPL-002` — calibrated_explanations produces calibrated alternative (counterfactual-style)   explanations for individual instances via WrapCalibratedExplainer.explore_alternatives,   identifying feature changes that would shift the prediction toward an alternative outcome.
+
 ## Consequences
 
 Positive:

--- a/development/adrs/ADR-027-fast-feature-filtering.md
+++ b/development/adrs/ADR-027-fast-feature-filtering.md
@@ -81,6 +81,11 @@ for configuration, failure behavior, and observability.
 - When telemetry is configured, the resolved feature-filter configuration is
   emitted as a single “effective config” event to support traceability.
 
+
+## Governed claims
+
+- `CE-CAP-EXPL-FAST-FILTER-001` — Internal FAST-based feature filtering is opt-in, fail-open, telemetry-visible, and preserves factual and alternative explanation semantics.
+
 ## Consequences
 
 ### Positive

--- a/development/adrs/ADR-028-logging-and-governance-observability.md
+++ b/development/adrs/ADR-028-logging-and-governance-observability.md
@@ -112,6 +112,17 @@ Standard-005, *Logging and Observability*, captures the contributor-facing rules
 that implement this decision (logger naming, level usage, data minimisation,
 testing expectations).
 
+
+## Governed claims
+
+- `CE-CAP-LOG-DATA-MINIMISATION-001` — Logging and governance events minimize sensitive data and avoid raw payload leakage.
+- `CE-CAP-LOG-NO-GLOBAL-HANDLERS-001` — The library does not install global logging handlers on import.
+- `CE-CAP-LOG-STRUCTURED-COMPATIBILITY-001` — Logging remains compatible with structured logging consumers while preserving standard library logging behavior.
+- `CE-CAP-LOG-CONTEXT-PROPAGATION-001` — Logging context propagation preserves request or governance context without global mutable leakage.
+- `CE-CAP-GOVERNANCE-LOG-SEPARATION-001` — Governance events and operational logs remain separated by domain and purpose.
+- `CE-CAP-LOG-DOMAIN-TAXONOMY-001` — Logging uses the ADR-028 logger domain taxonomy for core, plugins, telemetry, and governance events.
+- `CE-CAP-OBS-001` — Governance and operational observability use visible warnings and structured logging where ADR-governed fallbacks or events occur.
+
 ## Alternatives Considered
 
 1. **Ad-hoc, module-local logging without domains or context helpers.**
@@ -222,5 +233,5 @@ Migration guidelines:
 - `docs/foundations/governance/optional_telemetry.md` — Existing telemetry
   guidance; should be updated to reference the new logging hierarchy and
   context helper where appropriate.
-- `docs/improvement/ignore/Logging_Analysis.md` — Detailed analysis of current
-  logging usage and recommendations that informed this ADR.
+- `development/standards/STD-005-logging-and-observability-standard.md` — Current
+  logging usage policy and checks that implement this ADR.

--- a/development/adrs/ADR-029-reject-integration-strategy.md
+++ b/development/adrs/ADR-029-reject-integration-strategy.md
@@ -84,6 +84,16 @@ Defined `RejectPolicy` members (implemented in `core.reject.policy`):
 ### Visualization
 - If visualization is revisited, should it be a dedicated plugin or an overlay?
 
+
+## Governed claims
+
+- `CE-CAP-REJECT-NO-VIZ-001` — Reject visualization is intentionally not integrated unless a future ADR changes that decision.
+- `CE-CAP-REJECT-STRATEGY-REGISTRY-001` — Reject strategies are managed by a lightweight RejectOrchestrator registry.
+- `CE-CAP-REJECT-RESULT-ENVELOPE-001` — Reject-aware outputs use a structured RejectResult envelope when reject integration is active.
+- `CE-CAP-REJECT-POLICY-ENUM-001` — RejectPolicy NONE, FLAG, ONLY_REJECTED, and ONLY_ACCEPTED have stable semantics.
+- `CE-CAP-REJECT-DEFAULT-OFF-001` — Reject integration is disabled by default and legacy behavior is unchanged unless explicitly enabled.
+- `CE-CAP-REJECT-001` — calibrated_explanations supports reject/defer policies: passing a RejectPolicySpec   to WrapCalibratedExplainer.explain_factual or explore_alternatives tags each   instance's explanation envelope with a rejection status (FLAG, ONLY_REJECTED,   ONLY_ACCEPTED) based on the calibrated uncertainty score.
+
 ## Alternatives Considered
 
 ### 1) Invocation model alternatives
@@ -208,7 +218,7 @@ Defined `RejectPolicy` members (implemented in `core.reject.policy`):
 		- Operational rule: Selecting any non-`NONE` `RejectPolicy` MUST implicitly enable the reject orchestration (equivalent to `reject=True`) for the affected call(s) or explainer-level default. In practice this means that supplying `reject_policy != RejectPolicy.NONE` (per-call or via explainer default) triggers `RejectOrchestrator` initialization and evaluation even if the legacy `reject` flag was `False`.
 6. Implement a default built-in reject strategy (the current behaviour) that preserves existing semantics and is registered under the orchestrator's registry as `builtin.default`.
 7. Add CI tests that exercise each `RejectPolicy` member, ensuring return schemas and interactions with existing explanation consumers remain backward compatible when `NONE` is used.
-8. Update documentation and examples: `docs/improvement/` release plan, add `docs/reject.md`, and user-facing examples demonstrating the common policies.
+8. Update documentation and examples under the current `development/` planning structure and user-facing docs (for example, `docs/practitioner/advanced/reject-policy.md`) demonstrating the common policies.
 9. Defer visualization integration until a separate ADR or plugin is proposed.
 
 ## Verification checklist (recommended additions)

--- a/development/adrs/ADR-030-test-quality-priorities-and-enforcement.md
+++ b/development/adrs/ADR-030-test-quality-priorities-and-enforcement.md
@@ -128,6 +128,14 @@ static audits. Specifically:
   - See the formal marker hygiene section below for the binding taxonomy and
     enforcement posture.
 
+- **Requirements-as-code evidence gate**:
+  - ADR-governed behavioral requirements must name executable pytest evidence.
+  - Metadata/linkage checks may verify the ADR → claim → requirement graph, but they
+    are not acceptable proof of runtime, serialization, static-policy, visualization,
+    plugin, quality-gate, or API-contract behavior.
+  - Manual or human verification is allowed only when the requirement is not yet
+    implemented and is registered as an ADR gap.
+
 ### Marker hygiene
 
 ADR-030 adopts a hybrid pytest marker taxonomy that balances explicit review
@@ -189,6 +197,7 @@ evidence is informational only and must not introduce a duration threshold.
 ## Governed claims
 
 - `CE-CAP-TEST-001` — Tests follow the repository quality policy for naming, coverage gates, and justified coverage exemptions.
+- `CE-CAP-REQ-AS-CODE-001` — ADR-governed behavioral requirements terminate in executable pytest evidence, and human verification is allowed only when the unimplemented requirement is registered as an ADR gap.
 
 ## Alternatives Considered
 
@@ -218,32 +227,3 @@ Negative/Risks:
   violations” in CI.
 - Phase 1A (immediate hard blocker): enforce zero tolerance for production
   test-helper wrapper exports via `check_no_test_helper_exports.py`.
-- Phase 2: extend the detector to cover assertion presence, determinism, and
-  mocking heuristics; add allowlists only with justification.
-- Phase 3: enforce marker hygiene and slow-test budgets once tagging is complete.
-- Phase 4: introduce the over-testing density gate in advisory mode, then ratchet
-  the threshold once baselines are stable.
-
-## Implementation status
-
-- 2026-01-11 – Drafted ADR with priorities and enforcement plan; resolved open questions on marker taxonomy and mutation testing modules; no code changes yet.
-- 2026-02-09 – Added over-testing density analysis scripts and proposed a ratcheting
-  gate based on per-test coverage contexts (pending CI rollout).
-- 2026-02-09 – Completed coverage improvement iteration: added integration tests for plotting style overrides/legacy fallbacks, cache fallback testing, and YAML template loading to increase coverage in low-coverage modules (plotting.py, cache.py, narrative_generator.py).
-- 2026-02-15 – Phase 3 (marker hygiene): added `scripts/quality/check_marker_hygiene.py`
-  with `--check` / `--rebaseline` modes and committed baseline
-  (`.github/marker-hygiene-baseline.json`, 72 existing-debt entries). Wired into
-  `ci-pr.yml` and `ci-main.yml` anti-pattern-audit jobs.
-- 2026-02-15 – Phase 4 (over-testing density): wired `over_testing_report.py` and
-  `detect_redundant_tests.py` into `ci-main.yml` as an advisory
-  (`continue-on-error: true`) job with `--cov-context=test` coverage collection.
-  Reports published as CI artifacts.
-- 2026-02-15 – Anti-pattern audit added to `ci-pr.yml` so PR checks survive
-  `test.yml` compat-wrapper decommission (release task 12).
-- 2026-02-23 – Added `scripts/quality/check_no_test_helper_exports.py` and
-  wired it into PR/main/compat CI plus local checks as a hard blocker to prevent
-  production test-helper wrapper exports.
-- 2026-05-12 - Ratified ADR-030 for v0.11.3: promoted marker hygiene and mutation
-  testing policy into formal sections, confirmed PR/main anti-pattern audit gates
-  are blocking, and added focused local ratification with observational timing
-  evidence via `python scripts/local_checks.py --adr030-ratification`.

--- a/development/adrs/ADR-030-test-quality-priorities-and-enforcement.md
+++ b/development/adrs/ADR-030-test-quality-priorities-and-enforcement.md
@@ -185,6 +185,11 @@ guard, then writes observational timing evidence to
 `reports/anti-pattern-analysis/adr030_ratification_timing.json`. Timing
 evidence is informational only and must not introduce a duration threshold.
 
+
+## Governed claims
+
+- `CE-CAP-TEST-001` — Tests follow the repository quality policy for naming, coverage gates, and justified coverage exemptions.
+
 ## Alternatives Considered
 
 1. **Keep coverage as the only required gate.**

--- a/development/adrs/ADR-031-calibrator-serialization-and-state-persistence.md
+++ b/development/adrs/ADR-031-calibrator-serialization-and-state-persistence.md
@@ -55,6 +55,15 @@ semantics while allowing future migrations.
      (probability bounds, interval ordering, and monotonicity expectations).
    - Mapping primitives must remain JSON-safe and deterministic per ADR-009.
 
+
+## Governed claims
+
+- `CE-CAP-SERIAL-ROUNDTRIP-INVARIANTS-001` — Serialization round trips preserve ADR-021 interval semantics and ADR-009 preprocessing semantics.
+- `CE-CAP-SERIAL-FAIL-FAST-VERSIONING-001` — Serialization rejects unsupported or incompatible schema versions with explicit errors.
+- `CE-CAP-EXPLAINER-STATE-PERSISTENCE-001` — Explainer state persistence captures calibration state, preprocessing mappings, plugin identifiers, RNG/determinism state, manifest metadata, timestamps, and checksums.
+- `CE-CAP-CALIBRATOR-PRIMITIVE-SCHEMA-001` — Built-in calibrators implement JSON-safe to_primitive() and from_primitive() schema contracts.
+- `CE-CAP-SERIAL-001` — Calibrator and explainer persistence use versioned primitive state and fail fast on incompatible schema versions.
+
 ## Consequences
 
 Positive:

--- a/development/adrs/ADR-032-guarded-explanation-semantics.md
+++ b/development/adrs/ADR-032-guarded-explanation-semantics.md
@@ -117,6 +117,18 @@ This ADR therefore defines guarded mode as a CE-compatible extension with a sing
    - Calling any guarded entrypoint (`explain_factual(..., guarded_options=GuardedOptions())`, `explore_alternatives(..., guarded_options=GuardedOptions())`) on a fast explainer must hard-fail with `ConfigurationError` before any calibration-alignment check proceeds.
    - This prohibition is enforced in `_require_guarded_calibration_alignment` and is not subject to configuration or opt-out.
 
+
+## Governed claims
+
+- `CE-CAP-ALT-TARGET-CONFIDENCE-001` — filter_by_target_confidence() applies conformal singleton-set filtering, returns a new collection, and validates confidence/probabilistic preconditions.
+- `CE-CAP-GUARD-NO-FAST-001` — Guarded explanations are unsupported for fast explainers and fail with ConfigurationError.
+- `CE-CAP-GUARD-PLUGIN-SUPPORT-001` — Plugin guarded support is expressed only through supports_guarded; missing metadata defaults to false and unguarded plugins must not be silently selected.
+- `CE-CAP-GUARD-CONJUNCTION-001` — Guarded conjunctions use joint representative perturbations and append conjunction audit records.
+- `CE-CAP-GUARD-CALIBRATION-ALIGNMENT-001` — Guarded execution requires calibration-feature alignment and fails hard on unavailable or mismatched calibration features.
+- `CE-CAP-GUARD-AUDIT-001` — Guarded outputs expose get_guarded_audit() with interval-level and summary records.
+- `CE-CAP-GUARD-MEDIAN-PROBE-001` — Guardedness is defined by the single median-probe rule; emitted intervals do not certify every point inside the interval.
+- `CE-CAP-GUARD-001` — calibrated_explanations supports guarded explanations: passing a GuardedOptions   instance to WrapCalibratedExplainer.explain_factual or explore_alternatives restricts   explanation output to instances that lie within the support of the calibration data,   returning a CalibratedExplanations collection.
+
 ## Consequences
 
 Positive:

--- a/development/adrs/ADR-033-modality-extension-plugin-contract-and-packaging.md
+++ b/development/adrs/ADR-033-modality-extension-plugin-contract-and-packaging.md
@@ -94,6 +94,16 @@ Release split:
 6. Aligns release content with a breaking-first / additive-follow-up cadence to reduce release risk.
 7. **Timeseries is excluded from this ADR's scope.** Time-ordered data requires ordered-input semantics, temporal feature indexing, and perturbation strategies that are fundamentally incompatible with the tabular/non-tabular extension contract modelled here. A separate ADR will govern timeseries modality support if and when it is needed.
 
+
+## Governed claims
+
+- `CE-CAP-MODALITY-TABULAR-INVARIANT-001` — Existing tabular CalibratedExplainer workflows remain unaffected by modality extension metadata and package boundaries.
+- `CE-CAP-MODALITY-SHIMS-001` — Modality shim modules preserve import compatibility without moving non-tabular implementations into core.
+- `CE-CAP-MODALITY-RESOLUTION-001` — Modality-aware plugin selection respects data modalities, aliases, compatibility, and deterministic selection order.
+- `CE-CAP-MODALITY-METADATA-001` — Modality plugins declare plugin_api_version and normalized data_modalities metadata with major-hard and minor-soft compatibility checks.
+- `CE-CAP-PLUGIN-001` — calibrated_explanations exposes an extensible plugin system through the   calibrated_explanations.plugins module: ExplainerPlugin defines the protocol for   custom explanation backends, and IntervalCalibratorPlugin defines the protocol for   custom interval calibrators, enabling replacement of default internal implementations.
+- `CE-CAP-MODALITY-001` — Non-tabular modality extensions use plugin metadata and external packages rather than entering the core tabular implementation.
+
 ## Alternatives Considered
 
 1. No metadata extension; use existing `capabilities` only.

--- a/development/adrs/ADR-034-centralized-configuration-management.md
+++ b/development/adrs/ADR-034-centralized-configuration-management.md
@@ -121,6 +121,16 @@ CI enforcement must fail new direct runtime reads outside sanctioned boundaries.
 Temporary exceptions must be explicitly allowlisted with justification and
 target-release ownership.
 
+
+## Governed claims
+
+- `CE-CAP-CONFIG-CI-ENFORCEMENT-001` — Direct runtime config reads outside sanctioned boundary modules are enforced by the quality script.
+- `CE-CAP-CONFIG-DIAGNOSTIC-EXPORT-001` — Effective config export includes schema markers, source attribution, profile ID, and diagnostic boundaries.
+- `CE-CAP-CONFIG-STRICT-VALIDATION-001` — Strict mode raises ConfigurationError; non-strict mode records validation reports without suppressing observability.
+- `CE-CAP-CONFIG-PRECEDENCE-SNAPSHOT-001` — Configuration resolution follows call-site override, environment, pyproject, then profile defaults and is snapshot-based.
+- `CE-CAP-CONFIG-AUTHORITY-001` — ConfigManager is the canonical runtime configuration read surface.
+- `CE-CAP-CONFIG-001` — Runtime and call-time configuration use governed tiers, centralized reads, and suffix conventions for Config, Spec, and Options objects.
+
 ## Alternatives Considered
 
 1. **Keep distributed readers.** Rejected: preserves precedence drift and scattered

--- a/development/adrs/ADR-035-ci-workflow-governance.md
+++ b/development/adrs/ADR-035-ci-workflow-governance.md
@@ -45,6 +45,7 @@ A PR that modifies CI-governed files MUST NOT merge unless all are satisfied:
 - **Heavy workload gating:** heavy jobs (`parity`, `perf`, `notebook-audit`, `docs`) MUST be path-gated and/or manual/scheduled (`workflow_dispatch` / `schedule`).
 - **Local reproducibility parity:** CI changes that affect contributor-runnable checks MUST update `scripts/local_checks.py` and `Makefile` targets.
 - **Cleanup process:** legacy workflow deletions should be grouped in a `ci:cleanup` PR and reference `development/finished-work/CI-upgrade.md`.
+- **Requirements-as-code evidence:** CI-governed requirement metadata MUST preserve the executable-evidence contract from ADR-030. Behavioral requirements must cite executable pytest evidence; human verification is allowed only for unimplemented requirements recorded as ADR gaps.
 
 ### 4. Exceptions and emergency path
 
@@ -72,6 +73,7 @@ Changes to `.github/actions/ci-policy/**` are high-integrity and require two cor
 ## Governed claims
 
 - `CE-CAP-CI-001` — CI workflow changes comply with reusable workflow, least-privilege, pinning, constraints, and local reproducibility policy.
+- `CE-CAP-REQ-AS-CODE-001` — ADR-governed behavioral requirements terminate in executable pytest evidence, and human verification is allowed only when the unimplemented requirement is registered as an ADR gap.
 
 ## Consequences
 

--- a/development/adrs/ADR-035-ci-workflow-governance.md
+++ b/development/adrs/ADR-035-ci-workflow-governance.md
@@ -68,6 +68,11 @@ Changes to `.github/actions/ci-policy/**` are high-integrity and require two cor
 2. Tune false positives and document accepted equivalent patterns.
 3. Flip `ci-policy/validate-workflows` to required status check in branch protection.
 
+
+## Governed claims
+
+- `CE-CAP-CI-001` — CI workflow changes comply with reusable workflow, least-privilege, pinning, constraints, and local reproducibility policy.
+
 ## Consequences
 
 **Positive**

--- a/development/adrs/ADR-036-plot-spec-canonical-contract-and-validation-boundary.md
+++ b/development/adrs/ADR-036-plot-spec-canonical-contract-and-validation-boundary.md
@@ -105,6 +105,16 @@ Additional optional fields **MAY** be defined, but required semantics **MUST** r
 - This ADR does not define release sequencing or implementation journaling.
 - This ADR does not authorize runtime plot-kind extension.
 
+
+## Governed claims
+
+- `CE-CAP-PLOTSPEC-BACKEND-NEUTRALITY-001` — Canonical PlotSpec semantics remain backend-neutral and exclude renderer-owned formatting fields.
+- `CE-CAP-PLOTSPEC-BUILDER-VALIDATION-001` — Plot builders emit canonical PlotSpec objects and validation occurs before renderer invocation.
+- `CE-CAP-PLOTSPEC-BOUNDARY-SERIALIZATION-001` — PlotSpec dict/JSON forms are non-canonical boundary serialization artifacts translated before canonical validation or rendering.
+- `CE-CAP-PLOTSPEC-CANONICAL-DATACLASS-001` — PlotSpec canonical in-memory representation uses typed dataclass objects.
+- `CE-CAP-PLOTSPEC-001` — PlotSpec-enabled visualization paths preserve backend-independent semantic plot intent through canonical PlotSpec objects and validated renderer boundaries.
+- `CE-CAP-VIZ-001` — calibrated_explanations provides visualization output for explanations via   WrapCalibratedExplainer.plot and CalibratedExplanations.plot, supporting   multiple output styles ('regular', 'triangular') and optional file saving,   without raising exceptions for standard single-instance and batch inputs   when a non-interactive rendering backend is available.
+
 ## Consequences
 
 ### Positive

--- a/development/adrs/ADR-037-visualization-extension-and-rendering-governance.md
+++ b/development/adrs/ADR-037-visualization-extension-and-rendering-governance.md
@@ -94,6 +94,15 @@ at v1.0.0. New plugins must use the semantic names.
 - This ADR does not prescribe pixel-level parity requirements.
 - This ADR does not serve as a release plan.
 
+
+## Governed claims
+
+- `CE-CAP-VIZ-DEFAULT-PLOTSPEC-PATH-001` — PlotSpec is the default user-facing plotting path after accepted promotion, with legacy rendering only as explicit opt-out or visible fallback.
+- `CE-CAP-VIZ-PLOT-KIND-GOVERNANCE-001` — Visualization plot kinds use a governed semantic vocabulary and runtime plot-kind extension remains disallowed.
+- `CE-CAP-VIZ-EXTENSION-METADATA-001` — Visualization extensions provide deterministic builder/renderer governance metadata.
+- `CE-CAP-VIZ-001` — calibrated_explanations provides visualization output for explanations via   WrapCalibratedExplainer.plot and CalibratedExplanations.plot, supporting   multiple output styles ('regular', 'triangular') and optional file saving,   without raising exceptions for standard single-instance and batch inputs   when a non-interactive rendering backend is available.
+- `CE-CAP-PLOTSPEC-001` — PlotSpec-enabled visualization paths preserve backend-independent semantic plot intent through canonical PlotSpec objects and validated renderer boundaries.
+
 ## Consequences
 
 ### Positive

--- a/development/adrs/ADR-038-call-time-configuration-taxonomy.md
+++ b/development/adrs/ADR-038-call-time-configuration-taxonomy.md
@@ -184,6 +184,13 @@ coverage sense, consistent with the established `reject_confidence` convention.
 Both express the same conformity threshold; the coverage convention makes the
 relationship with `reject_confidence` immediately readable.
 
+
+## Governed claims
+
+- `CE-CAP-CONFIG-001` — Runtime and call-time configuration use governed tiers, centralized reads, and suffix conventions for Config, Spec, and Options objects.
+- `CE-CAP-REJECT-001` — calibrated_explanations supports reject/defer policies: passing a RejectPolicySpec   to WrapCalibratedExplainer.explain_factual or explore_alternatives tags each   instance's explanation envelope with a rejection status (FLAG, ONLY_REJECTED,   ONLY_ACCEPTED) based on the calibrated uncertainty score.
+- `CE-CAP-GUARD-001` — calibrated_explanations supports guarded explanations: passing a GuardedOptions   instance to WrapCalibratedExplainer.explain_factual or explore_alternatives restricts   explanation output to instances that lie within the support of the calibration data,   returning a CalibratedExplanations collection.
+
 ## Alternatives Considered
 
 1. **Use `*Config` for all grouped parameter bundles (session and per-call alike).**

--- a/development/capabilities/claims/CE-CAP-ALT-TARGET-CONFIDENCE-001.yaml
+++ b/development/capabilities/claims/CE-CAP-ALT-TARGET-CONFIDENCE-001.yaml
@@ -1,0 +1,35 @@
+claim_id: CE-CAP-ALT-TARGET-CONFIDENCE-001
+claim_type: capability
+owner: calibrated_explanations
+status: current
+adr_links:
+  - ADR-032
+
+claim_text: >
+  filter_by_target_confidence() applies conformal singleton-set filtering, returns a new collection, and validates confidence/probabilistic preconditions.
+
+public_api: []
+
+task_types:
+  - governance
+
+requirements:
+  - CE-REQ-ALT-TARGET-CONFIDENCE-001
+
+verification:
+  proves:
+    - documentation_boundary
+    - adr_semantic_coverage
+  verification_type: concrete_evidence_refs_or_manual_review
+  verification_status: manual_review_required
+
+assumptions:
+  - This semantic governance claim records an ADR obligation at claim granularity.
+  - Runtime verification is provided by the linked requirement's named tests, quality scripts, or manual review scope.
+  - This claim does not broaden public API guarantees beyond the owning ADR and linked requirement.
+
+evidence_required:
+  - commit_sha
+  - package_version
+  - test_id
+  - result

--- a/development/capabilities/claims/CE-CAP-CACHE-001.yaml
+++ b/development/capabilities/claims/CE-CAP-CACHE-001.yaml
@@ -1,0 +1,33 @@
+claim_id: CE-CAP-CACHE-001
+claim_type: capability
+owner: calibrated_explanations
+status: current
+adr_links:
+  - ADR-003
+
+claim_text: >
+  Caching is opt-in, transparent to public APIs, and governed by deterministic key and fallback visibility constraints.
+
+public_api: []
+
+task_types:
+  - governance
+
+requirements:
+  - CE-REQ-CACHE-GOV-001
+
+verification:
+  proves:
+    - documentation_boundary
+    - governance_linkage
+  verification_type: automated_metadata_check
+
+assumptions:
+  - This governance capability is verified by ADR, claim, requirement, and test-link consistency checks.
+  - Behavioral enforcement remains scoped to the implementation and tests named by the linked requirement.
+
+evidence_required:
+  - commit_sha
+  - package_version
+  - test_id
+  - result

--- a/development/capabilities/claims/CE-CAP-CALIBRATOR-PRIMITIVE-SCHEMA-001.yaml
+++ b/development/capabilities/claims/CE-CAP-CALIBRATOR-PRIMITIVE-SCHEMA-001.yaml
@@ -1,0 +1,35 @@
+claim_id: CE-CAP-CALIBRATOR-PRIMITIVE-SCHEMA-001
+claim_type: capability
+owner: calibrated_explanations
+status: current
+adr_links:
+  - ADR-031
+
+claim_text: >
+  Built-in calibrators implement JSON-safe to_primitive() and from_primitive() schema contracts.
+
+public_api: []
+
+task_types:
+  - governance
+
+requirements:
+  - CE-REQ-CALIBRATOR-PRIMITIVE-SCHEMA-001
+
+verification:
+  proves:
+    - documentation_boundary
+    - adr_semantic_coverage
+  verification_type: concrete_evidence_refs_or_manual_review
+  verification_status: manual_review_required
+
+assumptions:
+  - This semantic governance claim records an ADR obligation at claim granularity.
+  - Runtime verification is provided by the linked requirement's named tests, quality scripts, or manual review scope.
+  - This claim does not broaden public API guarantees beyond the owning ADR and linked requirement.
+
+evidence_required:
+  - commit_sha
+  - package_version
+  - test_id
+  - result

--- a/development/capabilities/claims/CE-CAP-CI-001.yaml
+++ b/development/capabilities/claims/CE-CAP-CI-001.yaml
@@ -1,0 +1,33 @@
+claim_id: CE-CAP-CI-001
+claim_type: capability
+owner: calibrated_explanations
+status: current
+adr_links:
+  - ADR-035
+
+claim_text: >
+  CI workflow changes comply with reusable workflow, least-privilege, pinning, constraints, and local reproducibility policy.
+
+public_api: []
+
+task_types:
+  - governance
+
+requirements:
+  - CE-REQ-CI-GOV-001
+
+verification:
+  proves:
+    - documentation_boundary
+    - governance_linkage
+  verification_type: automated_metadata_check
+
+assumptions:
+  - This governance capability is verified by ADR, claim, requirement, and test-link consistency checks.
+  - Behavioral enforcement remains scoped to the implementation and tests named by the linked requirement.
+
+evidence_required:
+  - commit_sha
+  - package_version
+  - test_id
+  - result

--- a/development/capabilities/claims/CE-CAP-CONFIG-001.yaml
+++ b/development/capabilities/claims/CE-CAP-CONFIG-001.yaml
@@ -1,0 +1,34 @@
+claim_id: CE-CAP-CONFIG-001
+claim_type: capability
+owner: calibrated_explanations
+status: current
+adr_links:
+  - ADR-034
+  - ADR-038
+
+claim_text: >
+  Runtime and call-time configuration use governed tiers, centralized reads, and suffix conventions for Config, Spec, and Options objects.
+
+public_api: []
+
+task_types:
+  - governance
+
+requirements:
+  - CE-REQ-CONFIG-GOV-001
+
+verification:
+  proves:
+    - documentation_boundary
+    - governance_linkage
+  verification_type: automated_metadata_check
+
+assumptions:
+  - This governance capability is verified by ADR, claim, requirement, and test-link consistency checks.
+  - Behavioral enforcement remains scoped to the implementation and tests named by the linked requirement.
+
+evidence_required:
+  - commit_sha
+  - package_version
+  - test_id
+  - result

--- a/development/capabilities/claims/CE-CAP-CONFIG-AUTHORITY-001.yaml
+++ b/development/capabilities/claims/CE-CAP-CONFIG-AUTHORITY-001.yaml
@@ -1,0 +1,35 @@
+claim_id: CE-CAP-CONFIG-AUTHORITY-001
+claim_type: capability
+owner: calibrated_explanations
+status: current
+adr_links:
+  - ADR-034
+
+claim_text: >
+  ConfigManager is the canonical runtime configuration read surface.
+
+public_api: []
+
+task_types:
+  - governance
+
+requirements:
+  - CE-REQ-CONFIG-AUTHORITY-001
+
+verification:
+  proves:
+    - documentation_boundary
+    - adr_semantic_coverage
+  verification_type: concrete_evidence_refs_or_manual_review
+  verification_status: manual_review_required
+
+assumptions:
+  - This semantic governance claim records an ADR obligation at claim granularity.
+  - Runtime verification is provided by the linked requirement's named tests, quality scripts, or manual review scope.
+  - This claim does not broaden public API guarantees beyond the owning ADR and linked requirement.
+
+evidence_required:
+  - commit_sha
+  - package_version
+  - test_id
+  - result

--- a/development/capabilities/claims/CE-CAP-CONFIG-CI-ENFORCEMENT-001.yaml
+++ b/development/capabilities/claims/CE-CAP-CONFIG-CI-ENFORCEMENT-001.yaml
@@ -1,0 +1,35 @@
+claim_id: CE-CAP-CONFIG-CI-ENFORCEMENT-001
+claim_type: capability
+owner: calibrated_explanations
+status: current
+adr_links:
+  - ADR-034
+
+claim_text: >
+  Direct runtime config reads outside sanctioned boundary modules are enforced by the quality script.
+
+public_api: []
+
+task_types:
+  - governance
+
+requirements:
+  - CE-REQ-CONFIG-CI-ENFORCEMENT-001
+
+verification:
+  proves:
+    - documentation_boundary
+    - adr_semantic_coverage
+  verification_type: concrete_evidence_refs_or_manual_review
+  verification_status: manual_review_required
+
+assumptions:
+  - This semantic governance claim records an ADR obligation at claim granularity.
+  - Runtime verification is provided by the linked requirement's named tests, quality scripts, or manual review scope.
+  - This claim does not broaden public API guarantees beyond the owning ADR and linked requirement.
+
+evidence_required:
+  - commit_sha
+  - package_version
+  - test_id
+  - result

--- a/development/capabilities/claims/CE-CAP-CONFIG-DIAGNOSTIC-EXPORT-001.yaml
+++ b/development/capabilities/claims/CE-CAP-CONFIG-DIAGNOSTIC-EXPORT-001.yaml
@@ -1,0 +1,35 @@
+claim_id: CE-CAP-CONFIG-DIAGNOSTIC-EXPORT-001
+claim_type: capability
+owner: calibrated_explanations
+status: current
+adr_links:
+  - ADR-034
+
+claim_text: >
+  Effective config export includes schema markers, source attribution, profile ID, and diagnostic boundaries.
+
+public_api: []
+
+task_types:
+  - governance
+
+requirements:
+  - CE-REQ-CONFIG-DIAGNOSTIC-EXPORT-001
+
+verification:
+  proves:
+    - documentation_boundary
+    - adr_semantic_coverage
+  verification_type: concrete_evidence_refs_or_manual_review
+  verification_status: manual_review_required
+
+assumptions:
+  - This semantic governance claim records an ADR obligation at claim granularity.
+  - Runtime verification is provided by the linked requirement's named tests, quality scripts, or manual review scope.
+  - This claim does not broaden public API guarantees beyond the owning ADR and linked requirement.
+
+evidence_required:
+  - commit_sha
+  - package_version
+  - test_id
+  - result

--- a/development/capabilities/claims/CE-CAP-CONFIG-PRECEDENCE-SNAPSHOT-001.yaml
+++ b/development/capabilities/claims/CE-CAP-CONFIG-PRECEDENCE-SNAPSHOT-001.yaml
@@ -1,0 +1,35 @@
+claim_id: CE-CAP-CONFIG-PRECEDENCE-SNAPSHOT-001
+claim_type: capability
+owner: calibrated_explanations
+status: current
+adr_links:
+  - ADR-034
+
+claim_text: >
+  Configuration resolution follows call-site override, environment, pyproject, then profile defaults and is snapshot-based.
+
+public_api: []
+
+task_types:
+  - governance
+
+requirements:
+  - CE-REQ-CONFIG-PRECEDENCE-SNAPSHOT-001
+
+verification:
+  proves:
+    - documentation_boundary
+    - adr_semantic_coverage
+  verification_type: concrete_evidence_refs_or_manual_review
+  verification_status: manual_review_required
+
+assumptions:
+  - This semantic governance claim records an ADR obligation at claim granularity.
+  - Runtime verification is provided by the linked requirement's named tests, quality scripts, or manual review scope.
+  - This claim does not broaden public API guarantees beyond the owning ADR and linked requirement.
+
+evidence_required:
+  - commit_sha
+  - package_version
+  - test_id
+  - result

--- a/development/capabilities/claims/CE-CAP-CONFIG-STRICT-VALIDATION-001.yaml
+++ b/development/capabilities/claims/CE-CAP-CONFIG-STRICT-VALIDATION-001.yaml
@@ -1,0 +1,35 @@
+claim_id: CE-CAP-CONFIG-STRICT-VALIDATION-001
+claim_type: capability
+owner: calibrated_explanations
+status: current
+adr_links:
+  - ADR-034
+
+claim_text: >
+  Strict mode raises ConfigurationError; non-strict mode records validation reports without suppressing observability.
+
+public_api: []
+
+task_types:
+  - governance
+
+requirements:
+  - CE-REQ-CONFIG-STRICT-VALIDATION-001
+
+verification:
+  proves:
+    - documentation_boundary
+    - adr_semantic_coverage
+  verification_type: concrete_evidence_refs_or_manual_review
+  verification_status: manual_review_required
+
+assumptions:
+  - This semantic governance claim records an ADR obligation at claim granularity.
+  - Runtime verification is provided by the linked requirement's named tests, quality scripts, or manual review scope.
+  - This claim does not broaden public API guarantees beyond the owning ADR and linked requirement.
+
+evidence_required:
+  - commit_sha
+  - package_version
+  - test_id
+  - result

--- a/development/capabilities/claims/CE-CAP-CORE-001.yaml
+++ b/development/capabilities/claims/CE-CAP-CORE-001.yaml
@@ -1,0 +1,33 @@
+claim_id: CE-CAP-CORE-001
+claim_type: capability
+owner: calibrated_explanations
+status: current
+adr_links:
+  - ADR-001
+
+claim_text: >
+  Core package boundaries preserve stable separation between core, calibration, explanations, schema, plugins, cache, and parallel services.
+
+public_api: []
+
+task_types:
+  - governance
+
+requirements:
+  - CE-REQ-CORE-BOUNDARY-001
+
+verification:
+  proves:
+    - documentation_boundary
+    - governance_linkage
+  verification_type: automated_metadata_check
+
+assumptions:
+  - This governance capability is verified by ADR, claim, requirement, and test-link consistency checks.
+  - Behavioral enforcement remains scoped to the implementation and tests named by the linked requirement.
+
+evidence_required:
+  - commit_sha
+  - package_version
+  - test_id
+  - result

--- a/development/capabilities/claims/CE-CAP-DEPREC-001.yaml
+++ b/development/capabilities/claims/CE-CAP-DEPREC-001.yaml
@@ -1,0 +1,33 @@
+claim_id: CE-CAP-DEPREC-001
+claim_type: capability
+owner: calibrated_explanations
+status: current
+adr_links:
+  - ADR-011
+
+claim_text: >
+  Deprecations follow the accepted migration lifecycle, including visible warnings and documented removal windows.
+
+public_api: []
+
+task_types:
+  - governance
+
+requirements:
+  - CE-REQ-DEPREC-GOV-001
+
+verification:
+  proves:
+    - documentation_boundary
+    - governance_linkage
+  verification_type: automated_metadata_check
+
+assumptions:
+  - This governance capability is verified by ADR, claim, requirement, and test-link consistency checks.
+  - Behavioral enforcement remains scoped to the implementation and tests named by the linked requirement.
+
+evidence_required:
+  - commit_sha
+  - package_version
+  - test_id
+  - result

--- a/development/capabilities/claims/CE-CAP-DIST-001.yaml
+++ b/development/capabilities/claims/CE-CAP-DIST-001.yaml
@@ -1,0 +1,33 @@
+claim_id: CE-CAP-DIST-001
+claim_type: capability
+owner: calibrated_explanations
+status: current
+adr_links:
+  - ADR-010
+
+claim_text: >
+  The core package and evaluation tooling remain separately distributed and independently governed.
+
+public_api: []
+
+task_types:
+  - governance
+
+requirements:
+  - CE-REQ-DIST-GOV-001
+
+verification:
+  proves:
+    - documentation_boundary
+    - governance_linkage
+  verification_type: automated_metadata_check
+
+assumptions:
+  - This governance capability is verified by ADR, claim, requirement, and test-link consistency checks.
+  - Behavioral enforcement remains scoped to the implementation and tests named by the linked requirement.
+
+evidence_required:
+  - commit_sha
+  - package_version
+  - test_id
+  - result

--- a/development/capabilities/claims/CE-CAP-DOCS-001.yaml
+++ b/development/capabilities/claims/CE-CAP-DOCS-001.yaml
@@ -1,0 +1,33 @@
+claim_id: CE-CAP-DOCS-001
+claim_type: capability
+owner: calibrated_explanations
+status: current
+adr_links:
+  - ADR-012
+
+claim_text: >
+  Documentation and gallery builds use maintained source pages and documented build policy rather than obsolete improvement paths.
+
+public_api: []
+
+task_types:
+  - governance
+
+requirements:
+  - CE-REQ-DOCS-GOV-001
+
+verification:
+  proves:
+    - documentation_boundary
+    - governance_linkage
+  verification_type: automated_metadata_check
+
+assumptions:
+  - This governance capability is verified by ADR, claim, requirement, and test-link consistency checks.
+  - Behavioral enforcement remains scoped to the implementation and tests named by the linked requirement.
+
+evidence_required:
+  - commit_sha
+  - package_version
+  - test_id
+  - result

--- a/development/capabilities/claims/CE-CAP-DOMAIN-LEGACY-ADAPTER-001.yaml
+++ b/development/capabilities/claims/CE-CAP-DOMAIN-LEGACY-ADAPTER-001.yaml
@@ -1,0 +1,35 @@
+claim_id: CE-CAP-DOMAIN-LEGACY-ADAPTER-001
+claim_type: capability
+owner: calibrated_explanations
+status: current
+adr_links:
+  - ADR-008
+
+claim_text: >
+  Legacy adapters preserve public and serialized shapes while internal explanation models evolve.
+
+public_api: []
+
+task_types:
+  - governance
+
+requirements:
+  - CE-REQ-DOMAIN-LEGACY-ADAPTER-001
+
+verification:
+  proves:
+    - documentation_boundary
+    - adr_semantic_coverage
+  verification_type: concrete_evidence_refs_or_manual_review
+  verification_status: manual_review_required
+
+assumptions:
+  - This semantic governance claim records an ADR obligation at claim granularity.
+  - Runtime verification is provided by the linked requirement's named tests, quality scripts, or manual review scope.
+  - This claim does not broaden public API guarantees beyond the owning ADR and linked requirement.
+
+evidence_required:
+  - commit_sha
+  - package_version
+  - test_id
+  - result

--- a/development/capabilities/claims/CE-CAP-DOMAIN-MODEL-001.yaml
+++ b/development/capabilities/claims/CE-CAP-DOMAIN-MODEL-001.yaml
@@ -1,0 +1,35 @@
+claim_id: CE-CAP-DOMAIN-MODEL-001
+claim_type: capability
+owner: calibrated_explanations
+status: current
+adr_links:
+  - ADR-008
+
+claim_text: >
+  The internal explanation domain model uses Explanation and FeatureRule concepts for rules, metadata, predicates, attribution, support, and uncertainty.
+
+public_api: []
+
+task_types:
+  - governance
+
+requirements:
+  - CE-REQ-DOMAIN-MODEL-001
+
+verification:
+  proves:
+    - documentation_boundary
+    - adr_semantic_coverage
+  verification_type: concrete_evidence_refs_or_manual_review
+  verification_status: manual_review_required
+
+assumptions:
+  - This semantic governance claim records an ADR obligation at claim granularity.
+  - Runtime verification is provided by the linked requirement's named tests, quality scripts, or manual review scope.
+  - This claim does not broaden public API guarantees beyond the owning ADR and linked requirement.
+
+evidence_required:
+  - commit_sha
+  - package_version
+  - test_id
+  - result

--- a/development/capabilities/claims/CE-CAP-EXPL-001.yaml
+++ b/development/capabilities/claims/CE-CAP-EXPL-001.yaml
@@ -3,6 +3,11 @@ claim_type: capability
 owner: calibrated_explanations
 status: current
 
+adr_links:
+  - ADR-008
+  - ADR-015
+  - ADR-026
+
 claim_text: >
   calibrated_explanations produces calibrated factual explanations for individual
   instances via WrapCalibratedExplainer.explain_factual, returning feature

--- a/development/capabilities/claims/CE-CAP-EXPL-002.yaml
+++ b/development/capabilities/claims/CE-CAP-EXPL-002.yaml
@@ -3,6 +3,11 @@ claim_type: capability
 owner: calibrated_explanations
 status: current
 
+adr_links:
+  - ADR-008
+  - ADR-015
+  - ADR-026
+
 claim_text: >
   calibrated_explanations produces calibrated alternative (counterfactual-style)
   explanations for individual instances via WrapCalibratedExplainer.explore_alternatives,

--- a/development/capabilities/claims/CE-CAP-EXPL-CONJ-001.yaml
+++ b/development/capabilities/claims/CE-CAP-EXPL-CONJ-001.yaml
@@ -3,6 +3,9 @@ claim_type: capability
 owner: calibrated_explanations
 status: current
 
+adr_links:
+  - ADR-008
+
 claim_text: >
   calibrated_explanations supports conjunctive multi-feature explanation rules via
   add_conjunctions(), which extends any explanation collection or individual explanation

--- a/development/capabilities/claims/CE-CAP-EXPL-FAST-FILTER-001.yaml
+++ b/development/capabilities/claims/CE-CAP-EXPL-FAST-FILTER-001.yaml
@@ -1,0 +1,35 @@
+claim_id: CE-CAP-EXPL-FAST-FILTER-001
+claim_type: capability
+owner: calibrated_explanations
+status: current
+adr_links:
+  - ADR-027
+
+claim_text: >
+  Internal FAST-based feature filtering is opt-in, fail-open, telemetry-visible, and preserves factual and alternative explanation semantics.
+
+public_api: []
+
+task_types:
+  - governance
+
+requirements:
+  - CE-REQ-EXPL-FAST-FILTER-001
+
+verification:
+  proves:
+    - documentation_boundary
+    - adr_semantic_coverage
+  verification_type: concrete_evidence_refs_or_manual_review
+  verification_status: manual_review_required
+
+assumptions:
+  - This semantic governance claim records an ADR obligation at claim granularity.
+  - Runtime verification is provided by the linked requirement's named tests, quality scripts, or manual review scope.
+  - This claim does not broaden public API guarantees beyond the owning ADR and linked requirement.
+
+evidence_required:
+  - commit_sha
+  - package_version
+  - test_id
+  - result

--- a/development/capabilities/claims/CE-CAP-EXPL-FILTER-001.yaml
+++ b/development/capabilities/claims/CE-CAP-EXPL-FILTER-001.yaml
@@ -3,6 +3,9 @@ claim_type: capability
 owner: calibrated_explanations
 status: current
 
+adr_links:
+  - ADR-008
+
 claim_text: >
   calibrated_explanations supports rule-type filtering on alternative explanations via five
   filter operations: super_explanations (rules with higher probability supporting the

--- a/development/capabilities/claims/CE-CAP-EXPL-PAPER-SEMANTICS-001.yaml
+++ b/development/capabilities/claims/CE-CAP-EXPL-PAPER-SEMANTICS-001.yaml
@@ -1,0 +1,35 @@
+claim_id: CE-CAP-EXPL-PAPER-SEMANTICS-001
+claim_type: capability
+owner: calibrated_explanations
+status: current
+adr_links:
+  - ADR-008
+
+claim_text: >
+  Factual and alternative explanations preserve the paper-aligned factual-condition and alternative-condition semantics.
+
+public_api: []
+
+task_types:
+  - governance
+
+requirements:
+  - CE-REQ-EXPL-PAPER-SEMANTICS-001
+
+verification:
+  proves:
+    - documentation_boundary
+    - adr_semantic_coverage
+  verification_type: concrete_evidence_refs_or_manual_review
+  verification_status: manual_review_required
+
+assumptions:
+  - This semantic governance claim records an ADR obligation at claim granularity.
+  - Runtime verification is provided by the linked requirement's named tests, quality scripts, or manual review scope.
+  - This claim does not broaden public API guarantees beyond the owning ADR and linked requirement.
+
+evidence_required:
+  - commit_sha
+  - package_version
+  - test_id
+  - result

--- a/development/capabilities/claims/CE-CAP-EXPLAINER-STATE-PERSISTENCE-001.yaml
+++ b/development/capabilities/claims/CE-CAP-EXPLAINER-STATE-PERSISTENCE-001.yaml
@@ -1,0 +1,35 @@
+claim_id: CE-CAP-EXPLAINER-STATE-PERSISTENCE-001
+claim_type: capability
+owner: calibrated_explanations
+status: current
+adr_links:
+  - ADR-031
+
+claim_text: >
+  Explainer state persistence captures calibration state, preprocessing mappings, plugin identifiers, RNG/determinism state, manifest metadata, timestamps, and checksums.
+
+public_api: []
+
+task_types:
+  - governance
+
+requirements:
+  - CE-REQ-EXPLAINER-STATE-PERSISTENCE-001
+
+verification:
+  proves:
+    - documentation_boundary
+    - adr_semantic_coverage
+  verification_type: concrete_evidence_refs_or_manual_review
+  verification_status: manual_review_required
+
+assumptions:
+  - This semantic governance claim records an ADR obligation at claim granularity.
+  - Runtime verification is provided by the linked requirement's named tests, quality scripts, or manual review scope.
+  - This claim does not broaden public API guarantees beyond the owning ADR and linked requirement.
+
+evidence_required:
+  - commit_sha
+  - package_version
+  - test_id
+  - result

--- a/development/capabilities/claims/CE-CAP-FAST-INTERVAL-PLUGIN-001.yaml
+++ b/development/capabilities/claims/CE-CAP-FAST-INTERVAL-PLUGIN-001.yaml
@@ -1,0 +1,35 @@
+claim_id: CE-CAP-FAST-INTERVAL-PLUGIN-001
+claim_type: capability
+owner: calibrated_explanations
+status: current
+adr_links:
+  - ADR-013
+
+claim_text: >
+  core.interval.fast is opt-in and never part of the primary interval fallback chain.
+
+public_api: []
+
+task_types:
+  - governance
+
+requirements:
+  - CE-REQ-FAST-INTERVAL-PLUGIN-001
+
+verification:
+  proves:
+    - documentation_boundary
+    - adr_semantic_coverage
+  verification_type: concrete_evidence_refs_or_manual_review
+  verification_status: manual_review_required
+
+assumptions:
+  - This semantic governance claim records an ADR obligation at claim granularity.
+  - Runtime verification is provided by the linked requirement's named tests, quality scripts, or manual review scope.
+  - This claim does not broaden public API guarantees beyond the owning ADR and linked requirement.
+
+evidence_required:
+  - commit_sha
+  - package_version
+  - test_id
+  - result

--- a/development/capabilities/claims/CE-CAP-GOVERNANCE-LOG-SEPARATION-001.yaml
+++ b/development/capabilities/claims/CE-CAP-GOVERNANCE-LOG-SEPARATION-001.yaml
@@ -1,0 +1,35 @@
+claim_id: CE-CAP-GOVERNANCE-LOG-SEPARATION-001
+claim_type: capability
+owner: calibrated_explanations
+status: current
+adr_links:
+  - ADR-028
+
+claim_text: >
+  Governance events and operational logs remain separated by domain and purpose.
+
+public_api: []
+
+task_types:
+  - governance
+
+requirements:
+  - CE-REQ-GOVERNANCE-LOG-SEPARATION-001
+
+verification:
+  proves:
+    - documentation_boundary
+    - adr_semantic_coverage
+  verification_type: concrete_evidence_refs_or_manual_review
+  verification_status: manual_review_required
+
+assumptions:
+  - This semantic governance claim records an ADR obligation at claim granularity.
+  - Runtime verification is provided by the linked requirement's named tests, quality scripts, or manual review scope.
+  - This claim does not broaden public API guarantees beyond the owning ADR and linked requirement.
+
+evidence_required:
+  - commit_sha
+  - package_version
+  - test_id
+  - result

--- a/development/capabilities/claims/CE-CAP-GUARD-001.yaml
+++ b/development/capabilities/claims/CE-CAP-GUARD-001.yaml
@@ -3,6 +3,10 @@ claim_type: capability
 owner: calibrated_explanations
 status: current
 
+adr_links:
+  - ADR-032
+  - ADR-038
+
 claim_text: >
   calibrated_explanations supports guarded explanations: passing a GuardedOptions
   instance to WrapCalibratedExplainer.explain_factual or explore_alternatives restricts

--- a/development/capabilities/claims/CE-CAP-GUARD-AUDIT-001.yaml
+++ b/development/capabilities/claims/CE-CAP-GUARD-AUDIT-001.yaml
@@ -1,0 +1,35 @@
+claim_id: CE-CAP-GUARD-AUDIT-001
+claim_type: capability
+owner: calibrated_explanations
+status: current
+adr_links:
+  - ADR-032
+
+claim_text: >
+  Guarded outputs expose get_guarded_audit() with interval-level and summary records.
+
+public_api: []
+
+task_types:
+  - governance
+
+requirements:
+  - CE-REQ-GUARD-AUDIT-001
+
+verification:
+  proves:
+    - documentation_boundary
+    - adr_semantic_coverage
+  verification_type: concrete_evidence_refs_or_manual_review
+  verification_status: manual_review_required
+
+assumptions:
+  - This semantic governance claim records an ADR obligation at claim granularity.
+  - Runtime verification is provided by the linked requirement's named tests, quality scripts, or manual review scope.
+  - This claim does not broaden public API guarantees beyond the owning ADR and linked requirement.
+
+evidence_required:
+  - commit_sha
+  - package_version
+  - test_id
+  - result

--- a/development/capabilities/claims/CE-CAP-GUARD-CALIBRATION-ALIGNMENT-001.yaml
+++ b/development/capabilities/claims/CE-CAP-GUARD-CALIBRATION-ALIGNMENT-001.yaml
@@ -1,0 +1,35 @@
+claim_id: CE-CAP-GUARD-CALIBRATION-ALIGNMENT-001
+claim_type: capability
+owner: calibrated_explanations
+status: current
+adr_links:
+  - ADR-032
+
+claim_text: >
+  Guarded execution requires calibration-feature alignment and fails hard on unavailable or mismatched calibration features.
+
+public_api: []
+
+task_types:
+  - governance
+
+requirements:
+  - CE-REQ-GUARD-CALIBRATION-ALIGNMENT-001
+
+verification:
+  proves:
+    - documentation_boundary
+    - adr_semantic_coverage
+  verification_type: concrete_evidence_refs_or_manual_review
+  verification_status: manual_review_required
+
+assumptions:
+  - This semantic governance claim records an ADR obligation at claim granularity.
+  - Runtime verification is provided by the linked requirement's named tests, quality scripts, or manual review scope.
+  - This claim does not broaden public API guarantees beyond the owning ADR and linked requirement.
+
+evidence_required:
+  - commit_sha
+  - package_version
+  - test_id
+  - result

--- a/development/capabilities/claims/CE-CAP-GUARD-CONJUNCTION-001.yaml
+++ b/development/capabilities/claims/CE-CAP-GUARD-CONJUNCTION-001.yaml
@@ -1,0 +1,35 @@
+claim_id: CE-CAP-GUARD-CONJUNCTION-001
+claim_type: capability
+owner: calibrated_explanations
+status: current
+adr_links:
+  - ADR-032
+
+claim_text: >
+  Guarded conjunctions use joint representative perturbations and append conjunction audit records.
+
+public_api: []
+
+task_types:
+  - governance
+
+requirements:
+  - CE-REQ-GUARD-CONJUNCTION-001
+
+verification:
+  proves:
+    - documentation_boundary
+    - adr_semantic_coverage
+  verification_type: concrete_evidence_refs_or_manual_review
+  verification_status: manual_review_required
+
+assumptions:
+  - This semantic governance claim records an ADR obligation at claim granularity.
+  - Runtime verification is provided by the linked requirement's named tests, quality scripts, or manual review scope.
+  - This claim does not broaden public API guarantees beyond the owning ADR and linked requirement.
+
+evidence_required:
+  - commit_sha
+  - package_version
+  - test_id
+  - result

--- a/development/capabilities/claims/CE-CAP-GUARD-MEDIAN-PROBE-001.yaml
+++ b/development/capabilities/claims/CE-CAP-GUARD-MEDIAN-PROBE-001.yaml
@@ -1,0 +1,35 @@
+claim_id: CE-CAP-GUARD-MEDIAN-PROBE-001
+claim_type: capability
+owner: calibrated_explanations
+status: current
+adr_links:
+  - ADR-032
+
+claim_text: >
+  Guardedness is defined by the single median-probe rule; emitted intervals do not certify every point inside the interval.
+
+public_api: []
+
+task_types:
+  - governance
+
+requirements:
+  - CE-REQ-GUARD-MEDIAN-PROBE-001
+
+verification:
+  proves:
+    - documentation_boundary
+    - adr_semantic_coverage
+  verification_type: concrete_evidence_refs_or_manual_review
+  verification_status: manual_review_required
+
+assumptions:
+  - This semantic governance claim records an ADR obligation at claim granularity.
+  - Runtime verification is provided by the linked requirement's named tests, quality scripts, or manual review scope.
+  - This claim does not broaden public API guarantees beyond the owning ADR and linked requirement.
+
+evidence_required:
+  - commit_sha
+  - package_version
+  - test_id
+  - result

--- a/development/capabilities/claims/CE-CAP-GUARD-NO-FAST-001.yaml
+++ b/development/capabilities/claims/CE-CAP-GUARD-NO-FAST-001.yaml
@@ -1,0 +1,35 @@
+claim_id: CE-CAP-GUARD-NO-FAST-001
+claim_type: capability
+owner: calibrated_explanations
+status: current
+adr_links:
+  - ADR-032
+
+claim_text: >
+  Guarded explanations are unsupported for fast explainers and fail with ConfigurationError.
+
+public_api: []
+
+task_types:
+  - governance
+
+requirements:
+  - CE-REQ-GUARD-NO-FAST-001
+
+verification:
+  proves:
+    - documentation_boundary
+    - adr_semantic_coverage
+  verification_type: concrete_evidence_refs_or_manual_review
+  verification_status: manual_review_required
+
+assumptions:
+  - This semantic governance claim records an ADR obligation at claim granularity.
+  - Runtime verification is provided by the linked requirement's named tests, quality scripts, or manual review scope.
+  - This claim does not broaden public API guarantees beyond the owning ADR and linked requirement.
+
+evidence_required:
+  - commit_sha
+  - package_version
+  - test_id
+  - result

--- a/development/capabilities/claims/CE-CAP-GUARD-PLUGIN-SUPPORT-001.yaml
+++ b/development/capabilities/claims/CE-CAP-GUARD-PLUGIN-SUPPORT-001.yaml
@@ -1,0 +1,35 @@
+claim_id: CE-CAP-GUARD-PLUGIN-SUPPORT-001
+claim_type: capability
+owner: calibrated_explanations
+status: current
+adr_links:
+  - ADR-032
+
+claim_text: >
+  Plugin guarded support is expressed only through supports_guarded; missing metadata defaults to false and unguarded plugins must not be silently selected.
+
+public_api: []
+
+task_types:
+  - governance
+
+requirements:
+  - CE-REQ-GUARD-PLUGIN-SUPPORT-001
+
+verification:
+  proves:
+    - documentation_boundary
+    - adr_semantic_coverage
+  verification_type: concrete_evidence_refs_or_manual_review
+  verification_status: manual_review_required
+
+assumptions:
+  - This semantic governance claim records an ADR obligation at claim granularity.
+  - Runtime verification is provided by the linked requirement's named tests, quality scripts, or manual review scope.
+  - This claim does not broaden public API guarantees beyond the owning ADR and linked requirement.
+
+evidence_required:
+  - commit_sha
+  - package_version
+  - test_id
+  - result

--- a/development/capabilities/claims/CE-CAP-INTERVAL-CONTEXT-IMMUTABILITY-001.yaml
+++ b/development/capabilities/claims/CE-CAP-INTERVAL-CONTEXT-IMMUTABILITY-001.yaml
@@ -1,0 +1,35 @@
+claim_id: CE-CAP-INTERVAL-CONTEXT-IMMUTABILITY-001
+claim_type: capability
+owner: calibrated_explanations
+status: current
+adr_links:
+  - ADR-013
+
+claim_text: >
+  IntervalCalibratorContext exposes frozen/read-only calibration state and plugin-local scratch state without mutating the explainer.
+
+public_api: []
+
+task_types:
+  - governance
+
+requirements:
+  - CE-REQ-INTERVAL-CONTEXT-IMMUTABILITY-001
+
+verification:
+  proves:
+    - documentation_boundary
+    - adr_semantic_coverage
+  verification_type: concrete_evidence_refs_or_manual_review
+  verification_status: manual_review_required
+
+assumptions:
+  - This semantic governance claim records an ADR obligation at claim granularity.
+  - Runtime verification is provided by the linked requirement's named tests, quality scripts, or manual review scope.
+  - This claim does not broaden public API guarantees beyond the owning ADR and linked requirement.
+
+evidence_required:
+  - commit_sha
+  - package_version
+  - test_id
+  - result

--- a/development/capabilities/claims/CE-CAP-INTERVAL-PLUGIN-FALLBACK-001.yaml
+++ b/development/capabilities/claims/CE-CAP-INTERVAL-PLUGIN-FALLBACK-001.yaml
@@ -1,0 +1,35 @@
+claim_id: CE-CAP-INTERVAL-PLUGIN-FALLBACK-001
+claim_type: capability
+owner: calibrated_explanations
+status: current
+adr_links:
+  - ADR-013
+
+claim_text: >
+  core.interval.legacy remains the trusted mandatory interval calibrator fallback.
+
+public_api: []
+
+task_types:
+  - governance
+
+requirements:
+  - CE-REQ-INTERVAL-PLUGIN-FALLBACK-001
+
+verification:
+  proves:
+    - documentation_boundary
+    - adr_semantic_coverage
+  verification_type: concrete_evidence_refs_or_manual_review
+  verification_status: manual_review_required
+
+assumptions:
+  - This semantic governance claim records an ADR obligation at claim granularity.
+  - Runtime verification is provided by the linked requirement's named tests, quality scripts, or manual review scope.
+  - This claim does not broaden public API guarantees beyond the owning ADR and linked requirement.
+
+evidence_required:
+  - commit_sha
+  - package_version
+  - test_id
+  - result

--- a/development/capabilities/claims/CE-CAP-INTERVAL-PLUGIN-PROTOCOL-001.yaml
+++ b/development/capabilities/claims/CE-CAP-INTERVAL-PLUGIN-PROTOCOL-001.yaml
@@ -1,0 +1,35 @@
+claim_id: CE-CAP-INTERVAL-PLUGIN-PROTOCOL-001
+claim_type: capability
+owner: calibrated_explanations
+status: current
+adr_links:
+  - ADR-013
+
+claim_text: >
+  Interval plugins satisfy classification and regression calibrator protocols and output shapes.
+
+public_api: []
+
+task_types:
+  - governance
+
+requirements:
+  - CE-REQ-INTERVAL-PLUGIN-PROTOCOL-001
+
+verification:
+  proves:
+    - documentation_boundary
+    - adr_semantic_coverage
+  verification_type: concrete_evidence_refs_or_manual_review
+  verification_status: manual_review_required
+
+assumptions:
+  - This semantic governance claim records an ADR obligation at claim granularity.
+  - Runtime verification is provided by the linked requirement's named tests, quality scripts, or manual review scope.
+  - This claim does not broaden public API guarantees beyond the owning ADR and linked requirement.
+
+evidence_required:
+  - commit_sha
+  - package_version
+  - test_id
+  - result

--- a/development/capabilities/claims/CE-CAP-INTERVAL-PLUGIN-VALIDATION-001.yaml
+++ b/development/capabilities/claims/CE-CAP-INTERVAL-PLUGIN-VALIDATION-001.yaml
@@ -1,0 +1,35 @@
+claim_id: CE-CAP-INTERVAL-PLUGIN-VALIDATION-001
+claim_type: capability
+owner: calibrated_explanations
+status: current
+adr_links:
+  - ADR-013
+
+claim_text: >
+  Interval plugin outputs are validated for shape, dtype, monotonicity, and protocol conformity; misconfiguration does not silently degrade calibration quality.
+
+public_api: []
+
+task_types:
+  - governance
+
+requirements:
+  - CE-REQ-INTERVAL-PLUGIN-VALIDATION-001
+
+verification:
+  proves:
+    - documentation_boundary
+    - adr_semantic_coverage
+  verification_type: concrete_evidence_refs_or_manual_review
+  verification_status: manual_review_required
+
+assumptions:
+  - This semantic governance claim records an ADR obligation at claim granularity.
+  - Runtime verification is provided by the linked requirement's named tests, quality scripts, or manual review scope.
+  - This claim does not broaden public API guarantees beyond the owning ADR and linked requirement.
+
+evidence_required:
+  - commit_sha
+  - package_version
+  - test_id
+  - result

--- a/development/capabilities/claims/CE-CAP-LEGACY-001.yaml
+++ b/development/capabilities/claims/CE-CAP-LEGACY-001.yaml
@@ -1,0 +1,33 @@
+claim_id: CE-CAP-LEGACY-001
+claim_type: capability
+owner: calibrated_explanations
+status: current
+adr_links:
+  - ADR-020
+
+claim_text: >
+  Legacy user APIs remain stable within the documented major-version compatibility boundary.
+
+public_api: []
+
+task_types:
+  - governance
+
+requirements:
+  - CE-REQ-LEGACY-GOV-001
+
+verification:
+  proves:
+    - documentation_boundary
+    - governance_linkage
+  verification_type: automated_metadata_check
+
+assumptions:
+  - This governance capability is verified by ADR, claim, requirement, and test-link consistency checks.
+  - Behavioral enforcement remains scoped to the implementation and tests named by the linked requirement.
+
+evidence_required:
+  - commit_sha
+  - package_version
+  - test_id
+  - result

--- a/development/capabilities/claims/CE-CAP-LOG-CONTEXT-PROPAGATION-001.yaml
+++ b/development/capabilities/claims/CE-CAP-LOG-CONTEXT-PROPAGATION-001.yaml
@@ -1,0 +1,35 @@
+claim_id: CE-CAP-LOG-CONTEXT-PROPAGATION-001
+claim_type: capability
+owner: calibrated_explanations
+status: current
+adr_links:
+  - ADR-028
+
+claim_text: >
+  Logging context propagation preserves request or governance context without global mutable leakage.
+
+public_api: []
+
+task_types:
+  - governance
+
+requirements:
+  - CE-REQ-LOG-CONTEXT-PROPAGATION-001
+
+verification:
+  proves:
+    - documentation_boundary
+    - adr_semantic_coverage
+  verification_type: concrete_evidence_refs_or_manual_review
+  verification_status: manual_review_required
+
+assumptions:
+  - This semantic governance claim records an ADR obligation at claim granularity.
+  - Runtime verification is provided by the linked requirement's named tests, quality scripts, or manual review scope.
+  - This claim does not broaden public API guarantees beyond the owning ADR and linked requirement.
+
+evidence_required:
+  - commit_sha
+  - package_version
+  - test_id
+  - result

--- a/development/capabilities/claims/CE-CAP-LOG-DATA-MINIMISATION-001.yaml
+++ b/development/capabilities/claims/CE-CAP-LOG-DATA-MINIMISATION-001.yaml
@@ -1,0 +1,35 @@
+claim_id: CE-CAP-LOG-DATA-MINIMISATION-001
+claim_type: capability
+owner: calibrated_explanations
+status: current
+adr_links:
+  - ADR-028
+
+claim_text: >
+  Logging and governance events minimize sensitive data and avoid raw payload leakage.
+
+public_api: []
+
+task_types:
+  - governance
+
+requirements:
+  - CE-REQ-LOG-DATA-MINIMISATION-001
+
+verification:
+  proves:
+    - documentation_boundary
+    - adr_semantic_coverage
+  verification_type: concrete_evidence_refs_or_manual_review
+  verification_status: manual_review_required
+
+assumptions:
+  - This semantic governance claim records an ADR obligation at claim granularity.
+  - Runtime verification is provided by the linked requirement's named tests, quality scripts, or manual review scope.
+  - This claim does not broaden public API guarantees beyond the owning ADR and linked requirement.
+
+evidence_required:
+  - commit_sha
+  - package_version
+  - test_id
+  - result

--- a/development/capabilities/claims/CE-CAP-LOG-DOMAIN-TAXONOMY-001.yaml
+++ b/development/capabilities/claims/CE-CAP-LOG-DOMAIN-TAXONOMY-001.yaml
@@ -1,0 +1,35 @@
+claim_id: CE-CAP-LOG-DOMAIN-TAXONOMY-001
+claim_type: capability
+owner: calibrated_explanations
+status: current
+adr_links:
+  - ADR-028
+
+claim_text: >
+  Logging uses the ADR-028 logger domain taxonomy for core, plugins, telemetry, and governance events.
+
+public_api: []
+
+task_types:
+  - governance
+
+requirements:
+  - CE-REQ-LOG-DOMAIN-TAXONOMY-001
+
+verification:
+  proves:
+    - documentation_boundary
+    - adr_semantic_coverage
+  verification_type: concrete_evidence_refs_or_manual_review
+  verification_status: manual_review_required
+
+assumptions:
+  - This semantic governance claim records an ADR obligation at claim granularity.
+  - Runtime verification is provided by the linked requirement's named tests, quality scripts, or manual review scope.
+  - This claim does not broaden public API guarantees beyond the owning ADR and linked requirement.
+
+evidence_required:
+  - commit_sha
+  - package_version
+  - test_id
+  - result

--- a/development/capabilities/claims/CE-CAP-LOG-NO-GLOBAL-HANDLERS-001.yaml
+++ b/development/capabilities/claims/CE-CAP-LOG-NO-GLOBAL-HANDLERS-001.yaml
@@ -1,0 +1,35 @@
+claim_id: CE-CAP-LOG-NO-GLOBAL-HANDLERS-001
+claim_type: capability
+owner: calibrated_explanations
+status: current
+adr_links:
+  - ADR-028
+
+claim_text: >
+  The library does not install global logging handlers on import.
+
+public_api: []
+
+task_types:
+  - governance
+
+requirements:
+  - CE-REQ-LOG-NO-GLOBAL-HANDLERS-001
+
+verification:
+  proves:
+    - documentation_boundary
+    - adr_semantic_coverage
+  verification_type: concrete_evidence_refs_or_manual_review
+  verification_status: manual_review_required
+
+assumptions:
+  - This semantic governance claim records an ADR obligation at claim granularity.
+  - Runtime verification is provided by the linked requirement's named tests, quality scripts, or manual review scope.
+  - This claim does not broaden public API guarantees beyond the owning ADR and linked requirement.
+
+evidence_required:
+  - commit_sha
+  - package_version
+  - test_id
+  - result

--- a/development/capabilities/claims/CE-CAP-LOG-STRUCTURED-COMPATIBILITY-001.yaml
+++ b/development/capabilities/claims/CE-CAP-LOG-STRUCTURED-COMPATIBILITY-001.yaml
@@ -1,0 +1,35 @@
+claim_id: CE-CAP-LOG-STRUCTURED-COMPATIBILITY-001
+claim_type: capability
+owner: calibrated_explanations
+status: current
+adr_links:
+  - ADR-028
+
+claim_text: >
+  Logging remains compatible with structured logging consumers while preserving standard library logging behavior.
+
+public_api: []
+
+task_types:
+  - governance
+
+requirements:
+  - CE-REQ-LOG-STRUCTURED-COMPATIBILITY-001
+
+verification:
+  proves:
+    - documentation_boundary
+    - adr_semantic_coverage
+  verification_type: concrete_evidence_refs_or_manual_review
+  verification_status: manual_review_required
+
+assumptions:
+  - This semantic governance claim records an ADR obligation at claim granularity.
+  - Runtime verification is provided by the linked requirement's named tests, quality scripts, or manual review scope.
+  - This claim does not broaden public API guarantees beyond the owning ADR and linked requirement.
+
+evidence_required:
+  - commit_sha
+  - package_version
+  - test_id
+  - result

--- a/development/capabilities/claims/CE-CAP-MODALITY-001.yaml
+++ b/development/capabilities/claims/CE-CAP-MODALITY-001.yaml
@@ -1,0 +1,33 @@
+claim_id: CE-CAP-MODALITY-001
+claim_type: capability
+owner: calibrated_explanations
+status: current
+adr_links:
+  - ADR-033
+
+claim_text: >
+  Non-tabular modality extensions use plugin metadata and external packages rather than entering the core tabular implementation.
+
+public_api: []
+
+task_types:
+  - governance
+
+requirements:
+  - CE-REQ-MODALITY-GOV-001
+
+verification:
+  proves:
+    - documentation_boundary
+    - governance_linkage
+  verification_type: automated_metadata_check
+
+assumptions:
+  - This governance capability is verified by ADR, claim, requirement, and test-link consistency checks.
+  - Behavioral enforcement remains scoped to the implementation and tests named by the linked requirement.
+
+evidence_required:
+  - commit_sha
+  - package_version
+  - test_id
+  - result

--- a/development/capabilities/claims/CE-CAP-MODALITY-METADATA-001.yaml
+++ b/development/capabilities/claims/CE-CAP-MODALITY-METADATA-001.yaml
@@ -1,0 +1,35 @@
+claim_id: CE-CAP-MODALITY-METADATA-001
+claim_type: capability
+owner: calibrated_explanations
+status: current
+adr_links:
+  - ADR-033
+
+claim_text: >
+  Modality plugins declare plugin_api_version and normalized data_modalities metadata with major-hard and minor-soft compatibility checks.
+
+public_api: []
+
+task_types:
+  - governance
+
+requirements:
+  - CE-REQ-MODALITY-METADATA-001
+
+verification:
+  proves:
+    - documentation_boundary
+    - adr_semantic_coverage
+  verification_type: concrete_evidence_refs_or_manual_review
+  verification_status: manual_review_required
+
+assumptions:
+  - This semantic governance claim records an ADR obligation at claim granularity.
+  - Runtime verification is provided by the linked requirement's named tests, quality scripts, or manual review scope.
+  - This claim does not broaden public API guarantees beyond the owning ADR and linked requirement.
+
+evidence_required:
+  - commit_sha
+  - package_version
+  - test_id
+  - result

--- a/development/capabilities/claims/CE-CAP-MODALITY-RESOLUTION-001.yaml
+++ b/development/capabilities/claims/CE-CAP-MODALITY-RESOLUTION-001.yaml
@@ -1,0 +1,35 @@
+claim_id: CE-CAP-MODALITY-RESOLUTION-001
+claim_type: capability
+owner: calibrated_explanations
+status: current
+adr_links:
+  - ADR-033
+
+claim_text: >
+  Modality-aware plugin selection respects data modalities, aliases, compatibility, and deterministic selection order.
+
+public_api: []
+
+task_types:
+  - governance
+
+requirements:
+  - CE-REQ-MODALITY-RESOLUTION-001
+
+verification:
+  proves:
+    - documentation_boundary
+    - adr_semantic_coverage
+  verification_type: concrete_evidence_refs_or_manual_review
+  verification_status: manual_review_required
+
+assumptions:
+  - This semantic governance claim records an ADR obligation at claim granularity.
+  - Runtime verification is provided by the linked requirement's named tests, quality scripts, or manual review scope.
+  - This claim does not broaden public API guarantees beyond the owning ADR and linked requirement.
+
+evidence_required:
+  - commit_sha
+  - package_version
+  - test_id
+  - result

--- a/development/capabilities/claims/CE-CAP-MODALITY-SHIMS-001.yaml
+++ b/development/capabilities/claims/CE-CAP-MODALITY-SHIMS-001.yaml
@@ -1,0 +1,35 @@
+claim_id: CE-CAP-MODALITY-SHIMS-001
+claim_type: capability
+owner: calibrated_explanations
+status: current
+adr_links:
+  - ADR-033
+
+claim_text: >
+  Modality shim modules preserve import compatibility without moving non-tabular implementations into core.
+
+public_api: []
+
+task_types:
+  - governance
+
+requirements:
+  - CE-REQ-MODALITY-SHIMS-001
+
+verification:
+  proves:
+    - documentation_boundary
+    - adr_semantic_coverage
+  verification_type: concrete_evidence_refs_or_manual_review
+  verification_status: manual_review_required
+
+assumptions:
+  - This semantic governance claim records an ADR obligation at claim granularity.
+  - Runtime verification is provided by the linked requirement's named tests, quality scripts, or manual review scope.
+  - This claim does not broaden public API guarantees beyond the owning ADR and linked requirement.
+
+evidence_required:
+  - commit_sha
+  - package_version
+  - test_id
+  - result

--- a/development/capabilities/claims/CE-CAP-MODALITY-TABULAR-INVARIANT-001.yaml
+++ b/development/capabilities/claims/CE-CAP-MODALITY-TABULAR-INVARIANT-001.yaml
@@ -1,0 +1,35 @@
+claim_id: CE-CAP-MODALITY-TABULAR-INVARIANT-001
+claim_type: capability
+owner: calibrated_explanations
+status: current
+adr_links:
+  - ADR-033
+
+claim_text: >
+  Existing tabular CalibratedExplainer workflows remain unaffected by modality extension metadata and package boundaries.
+
+public_api: []
+
+task_types:
+  - governance
+
+requirements:
+  - CE-REQ-MODALITY-TABULAR-INVARIANT-001
+
+verification:
+  proves:
+    - documentation_boundary
+    - adr_semantic_coverage
+  verification_type: concrete_evidence_refs_or_manual_review
+  verification_status: manual_review_required
+
+assumptions:
+  - This semantic governance claim records an ADR obligation at claim granularity.
+  - Runtime verification is provided by the linked requirement's named tests, quality scripts, or manual review scope.
+  - This claim does not broaden public API guarantees beyond the owning ADR and linked requirement.
+
+evidence_required:
+  - commit_sha
+  - package_version
+  - test_id
+  - result

--- a/development/capabilities/claims/CE-CAP-MOND-001.yaml
+++ b/development/capabilities/claims/CE-CAP-MOND-001.yaml
@@ -3,6 +3,9 @@ claim_type: capability
 owner: calibrated_explanations
 status: current
 
+adr_links:
+  - ADR-013
+
 claim_text: >
   calibrated_explanations supports Mondrian (class-conditional) calibration: passing
   a MondrianCategorizer callable to WrapCalibratedExplainer.calibrate produces separate

--- a/development/capabilities/claims/CE-CAP-NARR-001.yaml
+++ b/development/capabilities/claims/CE-CAP-NARR-001.yaml
@@ -3,6 +3,9 @@ claim_type: capability
 owner: calibrated_explanations
 status: current
 
+adr_links:
+  - ADR-008
+
 claim_text: >
   calibrated_explanations generates human-readable natural language narratives for
   factual and alternative explanations via CalibratedExplanations.to_narrative(),

--- a/development/capabilities/claims/CE-CAP-OBS-001.yaml
+++ b/development/capabilities/claims/CE-CAP-OBS-001.yaml
@@ -1,0 +1,33 @@
+claim_id: CE-CAP-OBS-001
+claim_type: capability
+owner: calibrated_explanations
+status: current
+adr_links:
+  - ADR-028
+
+claim_text: >
+  Governance and operational observability use visible warnings and structured logging where ADR-governed fallbacks or events occur.
+
+public_api: []
+
+task_types:
+  - governance
+
+requirements:
+  - CE-REQ-OBS-GOV-001
+
+verification:
+  proves:
+    - documentation_boundary
+    - governance_linkage
+  verification_type: automated_metadata_check
+
+assumptions:
+  - This governance capability is verified by ADR, claim, requirement, and test-link consistency checks.
+  - Behavioral enforcement remains scoped to the implementation and tests named by the linked requirement.
+
+evidence_required:
+  - commit_sha
+  - package_version
+  - test_id
+  - result

--- a/development/capabilities/claims/CE-CAP-PARALLEL-001.yaml
+++ b/development/capabilities/claims/CE-CAP-PARALLEL-001.yaml
@@ -1,0 +1,33 @@
+claim_id: CE-CAP-PARALLEL-001
+claim_type: capability
+owner: calibrated_explanations
+status: current
+adr_links:
+  - ADR-004
+
+claim_text: >
+  Parallel execution remains explicit and opt-in, with deterministic result ordering and serial-by-default behavior.
+
+public_api: []
+
+task_types:
+  - governance
+
+requirements:
+  - CE-REQ-PARALLEL-GOV-001
+
+verification:
+  proves:
+    - documentation_boundary
+    - governance_linkage
+  verification_type: automated_metadata_check
+
+assumptions:
+  - This governance capability is verified by ADR, claim, requirement, and test-link consistency checks.
+  - Behavioral enforcement remains scoped to the implementation and tests named by the linked requirement.
+
+evidence_required:
+  - commit_sha
+  - package_version
+  - test_id
+  - result

--- a/development/capabilities/claims/CE-CAP-PLOTSPEC-001.yaml
+++ b/development/capabilities/claims/CE-CAP-PLOTSPEC-001.yaml
@@ -1,0 +1,34 @@
+claim_id: CE-CAP-PLOTSPEC-001
+claim_type: capability
+owner: calibrated_explanations
+status: current
+adr_links:
+  - ADR-036
+  - ADR-037
+
+claim_text: >
+  PlotSpec-enabled visualization paths preserve backend-independent semantic plot intent through canonical PlotSpec objects and validated renderer boundaries.
+
+public_api: []
+
+task_types:
+  - governance
+
+requirements:
+  - CE-REQ-PLOTSPEC-GOV-001
+
+verification:
+  proves:
+    - documentation_boundary
+    - governance_linkage
+  verification_type: automated_metadata_check
+
+assumptions:
+  - This governance capability is verified by ADR, claim, requirement, and test-link consistency checks.
+  - Behavioral enforcement remains scoped to the implementation and tests named by the linked requirement.
+
+evidence_required:
+  - commit_sha
+  - package_version
+  - test_id
+  - result

--- a/development/capabilities/claims/CE-CAP-PLOTSPEC-BACKEND-NEUTRALITY-001.yaml
+++ b/development/capabilities/claims/CE-CAP-PLOTSPEC-BACKEND-NEUTRALITY-001.yaml
@@ -1,0 +1,35 @@
+claim_id: CE-CAP-PLOTSPEC-BACKEND-NEUTRALITY-001
+claim_type: capability
+owner: calibrated_explanations
+status: current
+adr_links:
+  - ADR-036
+
+claim_text: >
+  Canonical PlotSpec semantics remain backend-neutral and exclude renderer-owned formatting fields.
+
+public_api: []
+
+task_types:
+  - governance
+
+requirements:
+  - CE-REQ-PLOTSPEC-BACKEND-NEUTRALITY-001
+
+verification:
+  proves:
+    - documentation_boundary
+    - adr_semantic_coverage
+  verification_type: concrete_evidence_refs_or_manual_review
+  verification_status: manual_review_required
+
+assumptions:
+  - This semantic governance claim records an ADR obligation at claim granularity.
+  - Runtime verification is provided by the linked requirement's named tests, quality scripts, or manual review scope.
+  - This claim does not broaden public API guarantees beyond the owning ADR and linked requirement.
+
+evidence_required:
+  - commit_sha
+  - package_version
+  - test_id
+  - result

--- a/development/capabilities/claims/CE-CAP-PLOTSPEC-BOUNDARY-SERIALIZATION-001.yaml
+++ b/development/capabilities/claims/CE-CAP-PLOTSPEC-BOUNDARY-SERIALIZATION-001.yaml
@@ -1,0 +1,35 @@
+claim_id: CE-CAP-PLOTSPEC-BOUNDARY-SERIALIZATION-001
+claim_type: capability
+owner: calibrated_explanations
+status: current
+adr_links:
+  - ADR-036
+
+claim_text: >
+  PlotSpec dict/JSON forms are non-canonical boundary serialization artifacts translated before canonical validation or rendering.
+
+public_api: []
+
+task_types:
+  - governance
+
+requirements:
+  - CE-REQ-PLOTSPEC-BOUNDARY-SERIALIZATION-001
+
+verification:
+  proves:
+    - documentation_boundary
+    - adr_semantic_coverage
+  verification_type: concrete_evidence_refs_or_manual_review
+  verification_status: manual_review_required
+
+assumptions:
+  - This semantic governance claim records an ADR obligation at claim granularity.
+  - Runtime verification is provided by the linked requirement's named tests, quality scripts, or manual review scope.
+  - This claim does not broaden public API guarantees beyond the owning ADR and linked requirement.
+
+evidence_required:
+  - commit_sha
+  - package_version
+  - test_id
+  - result

--- a/development/capabilities/claims/CE-CAP-PLOTSPEC-BUILDER-VALIDATION-001.yaml
+++ b/development/capabilities/claims/CE-CAP-PLOTSPEC-BUILDER-VALIDATION-001.yaml
@@ -1,0 +1,35 @@
+claim_id: CE-CAP-PLOTSPEC-BUILDER-VALIDATION-001
+claim_type: capability
+owner: calibrated_explanations
+status: current
+adr_links:
+  - ADR-036
+
+claim_text: >
+  Plot builders emit canonical PlotSpec objects and validation occurs before renderer invocation.
+
+public_api: []
+
+task_types:
+  - governance
+
+requirements:
+  - CE-REQ-PLOTSPEC-BUILDER-VALIDATION-001
+
+verification:
+  proves:
+    - documentation_boundary
+    - adr_semantic_coverage
+  verification_type: concrete_evidence_refs_or_manual_review
+  verification_status: manual_review_required
+
+assumptions:
+  - This semantic governance claim records an ADR obligation at claim granularity.
+  - Runtime verification is provided by the linked requirement's named tests, quality scripts, or manual review scope.
+  - This claim does not broaden public API guarantees beyond the owning ADR and linked requirement.
+
+evidence_required:
+  - commit_sha
+  - package_version
+  - test_id
+  - result

--- a/development/capabilities/claims/CE-CAP-PLOTSPEC-CANONICAL-DATACLASS-001.yaml
+++ b/development/capabilities/claims/CE-CAP-PLOTSPEC-CANONICAL-DATACLASS-001.yaml
@@ -1,0 +1,35 @@
+claim_id: CE-CAP-PLOTSPEC-CANONICAL-DATACLASS-001
+claim_type: capability
+owner: calibrated_explanations
+status: current
+adr_links:
+  - ADR-036
+
+claim_text: >
+  PlotSpec canonical in-memory representation uses typed dataclass objects.
+
+public_api: []
+
+task_types:
+  - governance
+
+requirements:
+  - CE-REQ-PLOTSPEC-CANONICAL-DATACLASS-001
+
+verification:
+  proves:
+    - documentation_boundary
+    - adr_semantic_coverage
+  verification_type: concrete_evidence_refs_or_manual_review
+  verification_status: manual_review_required
+
+assumptions:
+  - This semantic governance claim records an ADR obligation at claim granularity.
+  - Runtime verification is provided by the linked requirement's named tests, quality scripts, or manual review scope.
+  - This claim does not broaden public API guarantees beyond the owning ADR and linked requirement.
+
+evidence_required:
+  - commit_sha
+  - package_version
+  - test_id
+  - result

--- a/development/capabilities/claims/CE-CAP-PLUGIN-001.yaml
+++ b/development/capabilities/claims/CE-CAP-PLUGIN-001.yaml
@@ -3,6 +3,13 @@ claim_type: capability
 owner: calibrated_explanations
 status: current
 
+adr_links:
+  - ADR-006
+  - ADR-013
+  - ADR-015
+  - ADR-026
+  - ADR-033
+
 claim_text: >
   calibrated_explanations exposes an extensible plugin system through the
   calibrated_explanations.plugins module: ExplainerPlugin defines the protocol for

--- a/development/capabilities/claims/CE-CAP-PLUGIN-AUDIT-EVENTS-001.yaml
+++ b/development/capabilities/claims/CE-CAP-PLUGIN-AUDIT-EVENTS-001.yaml
@@ -1,0 +1,35 @@
+claim_id: CE-CAP-PLUGIN-AUDIT-EVENTS-001
+claim_type: capability
+owner: calibrated_explanations
+status: current
+adr_links:
+  - ADR-006
+
+claim_text: >
+  Plugin trust and registration decisions emit warnings or governance audit events where ADR-006 requires visibility.
+
+public_api: []
+
+task_types:
+  - governance
+
+requirements:
+  - CE-REQ-PLUGIN-AUDIT-EVENTS-001
+
+verification:
+  proves:
+    - documentation_boundary
+    - adr_semantic_coverage
+  verification_type: concrete_evidence_refs_or_manual_review
+  verification_status: manual_review_required
+
+assumptions:
+  - This semantic governance claim records an ADR obligation at claim granularity.
+  - Runtime verification is provided by the linked requirement's named tests, quality scripts, or manual review scope.
+  - This claim does not broaden public API guarantees beyond the owning ADR and linked requirement.
+
+evidence_required:
+  - commit_sha
+  - package_version
+  - test_id
+  - result

--- a/development/capabilities/claims/CE-CAP-PLUGIN-DISCOVERY-REPORT-001.yaml
+++ b/development/capabilities/claims/CE-CAP-PLUGIN-DISCOVERY-REPORT-001.yaml
@@ -1,0 +1,35 @@
+claim_id: CE-CAP-PLUGIN-DISCOVERY-REPORT-001
+claim_type: capability
+owner: calibrated_explanations
+status: current
+adr_links:
+  - ADR-006
+
+claim_text: >
+  Plugin discovery reports expose plugin metadata and trust status without executing untrusted plugin behavior.
+
+public_api: []
+
+task_types:
+  - governance
+
+requirements:
+  - CE-REQ-PLUGIN-DISCOVERY-REPORT-001
+
+verification:
+  proves:
+    - documentation_boundary
+    - adr_semantic_coverage
+  verification_type: concrete_evidence_refs_or_manual_review
+  verification_status: manual_review_required
+
+assumptions:
+  - This semantic governance claim records an ADR obligation at claim granularity.
+  - Runtime verification is provided by the linked requirement's named tests, quality scripts, or manual review scope.
+  - This claim does not broaden public API guarantees beyond the owning ADR and linked requirement.
+
+evidence_required:
+  - commit_sha
+  - package_version
+  - test_id
+  - result

--- a/development/capabilities/claims/CE-CAP-PLUGIN-TRUST-POLICY-001.yaml
+++ b/development/capabilities/claims/CE-CAP-PLUGIN-TRUST-POLICY-001.yaml
@@ -1,0 +1,35 @@
+claim_id: CE-CAP-PLUGIN-TRUST-POLICY-001
+claim_type: capability
+owner: calibrated_explanations
+status: current
+adr_links:
+  - ADR-006
+
+claim_text: >
+  Plugin loading follows explicit trust policy controls, allow and deny lists, and documented trust precedence.
+
+public_api: []
+
+task_types:
+  - governance
+
+requirements:
+  - CE-REQ-PLUGIN-TRUST-POLICY-001
+
+verification:
+  proves:
+    - documentation_boundary
+    - adr_semantic_coverage
+  verification_type: concrete_evidence_refs_or_manual_review
+  verification_status: manual_review_required
+
+assumptions:
+  - This semantic governance claim records an ADR obligation at claim granularity.
+  - Runtime verification is provided by the linked requirement's named tests, quality scripts, or manual review scope.
+  - This claim does not broaden public API guarantees beyond the owning ADR and linked requirement.
+
+evidence_required:
+  - commit_sha
+  - package_version
+  - test_id
+  - result

--- a/development/capabilities/claims/CE-CAP-PRED-001.yaml
+++ b/development/capabilities/claims/CE-CAP-PRED-001.yaml
@@ -3,6 +3,10 @@ claim_type: capability
 owner: calibrated_explanations
 status: current
 
+adr_links:
+  - ADR-013
+  - ADR-021
+
 claim_text: >
   calibrated_explanations returns calibrated uncertainty intervals for predictions
   via WrapCalibratedExplainer.predict with uq_interval=True (or predict_proba with

--- a/development/capabilities/claims/CE-CAP-PRED-CLASS-001.yaml
+++ b/development/capabilities/claims/CE-CAP-PRED-CLASS-001.yaml
@@ -3,6 +3,9 @@ claim_type: capability
 owner: calibrated_explanations
 status: current
 
+adr_links:
+  - ADR-021
+
 claim_text: >
   calibrated_explanations produces Venn-Abers calibrated class probabilities for
   binary and multiclass classification tasks via WrapCalibratedExplainer.predict_proba,

--- a/development/capabilities/claims/CE-CAP-PRED-PROB-001.yaml
+++ b/development/capabilities/claims/CE-CAP-PRED-PROB-001.yaml
@@ -3,6 +3,9 @@ claim_type: capability
 owner: calibrated_explanations
 status: current
 
+adr_links:
+  - ADR-021
+
 claim_text: >
   calibrated_explanations supports probabilistic regression queries: given a scalar
   threshold, WrapCalibratedExplainer.predict_proba(X, threshold=y_threshold) returns
@@ -35,6 +38,7 @@ assumptions:
   - This claim does not assert frequency-calibration of P(Y > threshold | X); it
     asserts only that the returned array is in [0, 1] and has the correct shape.
   - The API test verifies shape and bounds only; it does not verify conformal coverage.
+  - ADR-021 threshold-event alignment note: the public `threshold=` helper reports the library convention documented here, while ADR-021 also describes conformal threshold events using `y <= t` / interval events. Maintainers must keep API documentation and ADR terminology synchronized when threshold semantics change.
 
 evidence_required:
   - commit_sha

--- a/development/capabilities/claims/CE-CAP-PREPROC-001.yaml
+++ b/development/capabilities/claims/CE-CAP-PREPROC-001.yaml
@@ -1,0 +1,33 @@
+claim_id: CE-CAP-PREPROC-001
+claim_type: capability
+owner: calibrated_explanations
+status: current
+adr_links:
+  - ADR-009
+
+claim_text: >
+  Wrapper preprocessing learns and reuses deterministic feature mappings while keeping the core numeric and preserving provenance boundaries.
+
+public_api: []
+
+task_types:
+  - governance
+
+requirements:
+  - CE-REQ-PREPROC-GOV-001
+
+verification:
+  proves:
+    - documentation_boundary
+    - governance_linkage
+  verification_type: automated_metadata_check
+
+assumptions:
+  - This governance capability is verified by ADR, claim, requirement, and test-link consistency checks.
+  - Behavioral enforcement remains scoped to the implementation and tests named by the linked requirement.
+
+evidence_required:
+  - commit_sha
+  - package_version
+  - test_id
+  - result

--- a/development/capabilities/claims/CE-CAP-REJECT-001.yaml
+++ b/development/capabilities/claims/CE-CAP-REJECT-001.yaml
@@ -3,6 +3,10 @@ claim_type: capability
 owner: calibrated_explanations
 status: current
 
+adr_links:
+  - ADR-029
+  - ADR-038
+
 claim_text: >
   calibrated_explanations supports reject/defer policies: passing a RejectPolicySpec
   to WrapCalibratedExplainer.explain_factual or explore_alternatives tags each

--- a/development/capabilities/claims/CE-CAP-REJECT-DEFAULT-OFF-001.yaml
+++ b/development/capabilities/claims/CE-CAP-REJECT-DEFAULT-OFF-001.yaml
@@ -1,0 +1,35 @@
+claim_id: CE-CAP-REJECT-DEFAULT-OFF-001
+claim_type: capability
+owner: calibrated_explanations
+status: current
+adr_links:
+  - ADR-029
+
+claim_text: >
+  Reject integration is disabled by default and legacy behavior is unchanged unless explicitly enabled.
+
+public_api: []
+
+task_types:
+  - governance
+
+requirements:
+  - CE-REQ-REJECT-DEFAULT-OFF-001
+
+verification:
+  proves:
+    - documentation_boundary
+    - adr_semantic_coverage
+  verification_type: concrete_evidence_refs_or_manual_review
+  verification_status: manual_review_required
+
+assumptions:
+  - This semantic governance claim records an ADR obligation at claim granularity.
+  - Runtime verification is provided by the linked requirement's named tests, quality scripts, or manual review scope.
+  - This claim does not broaden public API guarantees beyond the owning ADR and linked requirement.
+
+evidence_required:
+  - commit_sha
+  - package_version
+  - test_id
+  - result

--- a/development/capabilities/claims/CE-CAP-REJECT-NO-VIZ-001.yaml
+++ b/development/capabilities/claims/CE-CAP-REJECT-NO-VIZ-001.yaml
@@ -1,0 +1,35 @@
+claim_id: CE-CAP-REJECT-NO-VIZ-001
+claim_type: capability
+owner: calibrated_explanations
+status: current
+adr_links:
+  - ADR-029
+
+claim_text: >
+  Reject visualization is intentionally not integrated unless a future ADR changes that decision.
+
+public_api: []
+
+task_types:
+  - governance
+
+requirements:
+  - CE-REQ-REJECT-NO-VIZ-001
+
+verification:
+  proves:
+    - documentation_boundary
+    - adr_semantic_coverage
+  verification_type: concrete_evidence_refs_or_manual_review
+  verification_status: manual_review_required
+
+assumptions:
+  - This semantic governance claim records an ADR obligation at claim granularity.
+  - Runtime verification is provided by the linked requirement's named tests, quality scripts, or manual review scope.
+  - This claim does not broaden public API guarantees beyond the owning ADR and linked requirement.
+
+evidence_required:
+  - commit_sha
+  - package_version
+  - test_id
+  - result

--- a/development/capabilities/claims/CE-CAP-REJECT-POLICY-ENUM-001.yaml
+++ b/development/capabilities/claims/CE-CAP-REJECT-POLICY-ENUM-001.yaml
@@ -1,0 +1,35 @@
+claim_id: CE-CAP-REJECT-POLICY-ENUM-001
+claim_type: capability
+owner: calibrated_explanations
+status: current
+adr_links:
+  - ADR-029
+
+claim_text: >
+  RejectPolicy NONE, FLAG, ONLY_REJECTED, and ONLY_ACCEPTED have stable semantics.
+
+public_api: []
+
+task_types:
+  - governance
+
+requirements:
+  - CE-REQ-REJECT-POLICY-ENUM-001
+
+verification:
+  proves:
+    - documentation_boundary
+    - adr_semantic_coverage
+  verification_type: concrete_evidence_refs_or_manual_review
+  verification_status: manual_review_required
+
+assumptions:
+  - This semantic governance claim records an ADR obligation at claim granularity.
+  - Runtime verification is provided by the linked requirement's named tests, quality scripts, or manual review scope.
+  - This claim does not broaden public API guarantees beyond the owning ADR and linked requirement.
+
+evidence_required:
+  - commit_sha
+  - package_version
+  - test_id
+  - result

--- a/development/capabilities/claims/CE-CAP-REJECT-RESULT-ENVELOPE-001.yaml
+++ b/development/capabilities/claims/CE-CAP-REJECT-RESULT-ENVELOPE-001.yaml
@@ -1,0 +1,35 @@
+claim_id: CE-CAP-REJECT-RESULT-ENVELOPE-001
+claim_type: capability
+owner: calibrated_explanations
+status: current
+adr_links:
+  - ADR-029
+
+claim_text: >
+  Reject-aware outputs use a structured RejectResult envelope when reject integration is active.
+
+public_api: []
+
+task_types:
+  - governance
+
+requirements:
+  - CE-REQ-REJECT-RESULT-ENVELOPE-001
+
+verification:
+  proves:
+    - documentation_boundary
+    - adr_semantic_coverage
+  verification_type: concrete_evidence_refs_or_manual_review
+  verification_status: manual_review_required
+
+assumptions:
+  - This semantic governance claim records an ADR obligation at claim granularity.
+  - Runtime verification is provided by the linked requirement's named tests, quality scripts, or manual review scope.
+  - This claim does not broaden public API guarantees beyond the owning ADR and linked requirement.
+
+evidence_required:
+  - commit_sha
+  - package_version
+  - test_id
+  - result

--- a/development/capabilities/claims/CE-CAP-REJECT-STRATEGY-REGISTRY-001.yaml
+++ b/development/capabilities/claims/CE-CAP-REJECT-STRATEGY-REGISTRY-001.yaml
@@ -1,0 +1,35 @@
+claim_id: CE-CAP-REJECT-STRATEGY-REGISTRY-001
+claim_type: capability
+owner: calibrated_explanations
+status: current
+adr_links:
+  - ADR-029
+
+claim_text: >
+  Reject strategies are managed by a lightweight RejectOrchestrator registry.
+
+public_api: []
+
+task_types:
+  - governance
+
+requirements:
+  - CE-REQ-REJECT-STRATEGY-REGISTRY-001
+
+verification:
+  proves:
+    - documentation_boundary
+    - adr_semantic_coverage
+  verification_type: concrete_evidence_refs_or_manual_review
+  verification_status: manual_review_required
+
+assumptions:
+  - This semantic governance claim records an ADR obligation at claim granularity.
+  - Runtime verification is provided by the linked requirement's named tests, quality scripts, or manual review scope.
+  - This claim does not broaden public API guarantees beyond the owning ADR and linked requirement.
+
+evidence_required:
+  - commit_sha
+  - package_version
+  - test_id
+  - result

--- a/development/capabilities/claims/CE-CAP-REQ-AS-CODE-001.yaml
+++ b/development/capabilities/claims/CE-CAP-REQ-AS-CODE-001.yaml
@@ -1,0 +1,39 @@
+claim_id: CE-CAP-REQ-AS-CODE-001
+claim_type: capability
+owner: calibrated_explanations
+status: current
+adr_links:
+  - ADR-030
+  - ADR-035
+
+claim_text: >
+  ADR-governed behavioral requirements terminate in executable pytest evidence,
+  and human verification is allowed only when the unimplemented requirement is
+  registered as an ADR gap.
+
+public_api: []
+
+task_types:
+  - governance
+  - quality_gate
+
+requirements:
+  - CE-REQ-REQ-AS-CODE-EVIDENCE-001
+
+verification:
+  proves:
+    - requirements_as_code_evidence
+    - executable_test_target_integrity
+    - manual_verification_gap_boundary
+  verification_type: automated_governance_integration_test
+
+assumptions:
+  - Metadata/linkage tests are drift guards, not proof of runtime behavior.
+  - Behavioral proof requires an executable pytest or quality-gate target that checks the requirement's observable behavior.
+  - Human review is permitted only to classify a missing implementation as an ADR gap; it is not test evidence.
+
+evidence_required:
+  - commit_sha
+  - package_version
+  - test_id
+  - result

--- a/development/capabilities/claims/CE-CAP-SCHEMA-001.yaml
+++ b/development/capabilities/claims/CE-CAP-SCHEMA-001.yaml
@@ -1,0 +1,34 @@
+claim_id: CE-CAP-SCHEMA-001
+claim_type: capability
+owner: calibrated_explanations
+status: current
+adr_links:
+  - ADR-005
+  - ADR-008
+
+claim_text: >
+  Explanation payloads use a versioned CE-first schema contract with explicit metadata and governed extension surfaces.
+
+public_api: []
+
+task_types:
+  - governance
+
+requirements:
+  - CE-REQ-SCHEMA-GOV-001
+
+verification:
+  proves:
+    - documentation_boundary
+    - governance_linkage
+  verification_type: automated_metadata_check
+
+assumptions:
+  - This governance capability is verified by ADR, claim, requirement, and test-link consistency checks.
+  - Behavioral enforcement remains scoped to the implementation and tests named by the linked requirement.
+
+evidence_required:
+  - commit_sha
+  - package_version
+  - test_id
+  - result

--- a/development/capabilities/claims/CE-CAP-SCHEMA-EXTENSION-SURFACE-001.yaml
+++ b/development/capabilities/claims/CE-CAP-SCHEMA-EXTENSION-SURFACE-001.yaml
@@ -1,0 +1,35 @@
+claim_id: CE-CAP-SCHEMA-EXTENSION-SURFACE-001
+claim_type: capability
+owner: calibrated_explanations
+status: current
+adr_links:
+  - ADR-005
+
+claim_text: >
+  Provenance and metadata are the governed optional extension surfaces; top-level envelope validation remains deferred.
+
+public_api: []
+
+task_types:
+  - governance
+
+requirements:
+  - CE-REQ-SCHEMA-EXTENSION-SURFACE-001
+
+verification:
+  proves:
+    - documentation_boundary
+    - adr_semantic_coverage
+  verification_type: concrete_evidence_refs_or_manual_review
+  verification_status: manual_review_required
+
+assumptions:
+  - This semantic governance claim records an ADR obligation at claim granularity.
+  - Runtime verification is provided by the linked requirement's named tests, quality scripts, or manual review scope.
+  - This claim does not broaden public API guarantees beyond the owning ADR and linked requirement.
+
+evidence_required:
+  - commit_sha
+  - package_version
+  - test_id
+  - result

--- a/development/capabilities/claims/CE-CAP-SCHEMA-PAYLOAD-V1-001.yaml
+++ b/development/capabilities/claims/CE-CAP-SCHEMA-PAYLOAD-V1-001.yaml
@@ -1,0 +1,35 @@
+claim_id: CE-CAP-SCHEMA-PAYLOAD-V1-001
+claim_type: capability
+owner: calibrated_explanations
+status: current
+adr_links:
+  - ADR-005
+
+claim_text: >
+  Explanation payload schema v1 defines the required CE-first fields for serialized instance-level explanations.
+
+public_api: []
+
+task_types:
+  - governance
+
+requirements:
+  - CE-REQ-SCHEMA-PAYLOAD-V1-001
+
+verification:
+  proves:
+    - documentation_boundary
+    - adr_semantic_coverage
+  verification_type: concrete_evidence_refs_or_manual_review
+  verification_status: manual_review_required
+
+assumptions:
+  - This semantic governance claim records an ADR obligation at claim granularity.
+  - Runtime verification is provided by the linked requirement's named tests, quality scripts, or manual review scope.
+  - This claim does not broaden public API guarantees beyond the owning ADR and linked requirement.
+
+evidence_required:
+  - commit_sha
+  - package_version
+  - test_id
+  - result

--- a/development/capabilities/claims/CE-CAP-SCHEMA-VALIDATION-001.yaml
+++ b/development/capabilities/claims/CE-CAP-SCHEMA-VALIDATION-001.yaml
@@ -1,0 +1,35 @@
+claim_id: CE-CAP-SCHEMA-VALIDATION-001
+claim_type: capability
+owner: calibrated_explanations
+status: current
+adr_links:
+  - ADR-005
+
+claim_text: >
+  Schema validation enforces semver schema versions and interval invariants where payload validation is invoked.
+
+public_api: []
+
+task_types:
+  - governance
+
+requirements:
+  - CE-REQ-SCHEMA-VALIDATION-001
+
+verification:
+  proves:
+    - documentation_boundary
+    - adr_semantic_coverage
+  verification_type: concrete_evidence_refs_or_manual_review
+  verification_status: manual_review_required
+
+assumptions:
+  - This semantic governance claim records an ADR obligation at claim granularity.
+  - Runtime verification is provided by the linked requirement's named tests, quality scripts, or manual review scope.
+  - This claim does not broaden public API guarantees beyond the owning ADR and linked requirement.
+
+evidence_required:
+  - commit_sha
+  - package_version
+  - test_id
+  - result

--- a/development/capabilities/claims/CE-CAP-SERIAL-001.yaml
+++ b/development/capabilities/claims/CE-CAP-SERIAL-001.yaml
@@ -1,0 +1,33 @@
+claim_id: CE-CAP-SERIAL-001
+claim_type: capability
+owner: calibrated_explanations
+status: current
+adr_links:
+  - ADR-031
+
+claim_text: >
+  Calibrator and explainer persistence use versioned primitive state and fail fast on incompatible schema versions.
+
+public_api: []
+
+task_types:
+  - governance
+
+requirements:
+  - CE-REQ-SERIAL-GOV-001
+
+verification:
+  proves:
+    - documentation_boundary
+    - governance_linkage
+  verification_type: automated_metadata_check
+
+assumptions:
+  - This governance capability is verified by ADR, claim, requirement, and test-link consistency checks.
+  - Behavioral enforcement remains scoped to the implementation and tests named by the linked requirement.
+
+evidence_required:
+  - commit_sha
+  - package_version
+  - test_id
+  - result

--- a/development/capabilities/claims/CE-CAP-SERIAL-FAIL-FAST-VERSIONING-001.yaml
+++ b/development/capabilities/claims/CE-CAP-SERIAL-FAIL-FAST-VERSIONING-001.yaml
@@ -1,0 +1,35 @@
+claim_id: CE-CAP-SERIAL-FAIL-FAST-VERSIONING-001
+claim_type: capability
+owner: calibrated_explanations
+status: current
+adr_links:
+  - ADR-031
+
+claim_text: >
+  Serialization rejects unsupported or incompatible schema versions with explicit errors.
+
+public_api: []
+
+task_types:
+  - governance
+
+requirements:
+  - CE-REQ-SERIAL-FAIL-FAST-VERSIONING-001
+
+verification:
+  proves:
+    - documentation_boundary
+    - adr_semantic_coverage
+  verification_type: concrete_evidence_refs_or_manual_review
+  verification_status: manual_review_required
+
+assumptions:
+  - This semantic governance claim records an ADR obligation at claim granularity.
+  - Runtime verification is provided by the linked requirement's named tests, quality scripts, or manual review scope.
+  - This claim does not broaden public API guarantees beyond the owning ADR and linked requirement.
+
+evidence_required:
+  - commit_sha
+  - package_version
+  - test_id
+  - result

--- a/development/capabilities/claims/CE-CAP-SERIAL-ROUNDTRIP-INVARIANTS-001.yaml
+++ b/development/capabilities/claims/CE-CAP-SERIAL-ROUNDTRIP-INVARIANTS-001.yaml
@@ -1,0 +1,35 @@
+claim_id: CE-CAP-SERIAL-ROUNDTRIP-INVARIANTS-001
+claim_type: capability
+owner: calibrated_explanations
+status: current
+adr_links:
+  - ADR-031
+
+claim_text: >
+  Serialization round trips preserve ADR-021 interval semantics and ADR-009 preprocessing semantics.
+
+public_api: []
+
+task_types:
+  - governance
+
+requirements:
+  - CE-REQ-SERIAL-ROUNDTRIP-INVARIANTS-001
+
+verification:
+  proves:
+    - documentation_boundary
+    - adr_semantic_coverage
+  verification_type: concrete_evidence_refs_or_manual_review
+  verification_status: manual_review_required
+
+assumptions:
+  - This semantic governance claim records an ADR obligation at claim granularity.
+  - Runtime verification is provided by the linked requirement's named tests, quality scripts, or manual review scope.
+  - This claim does not broaden public API guarantees beyond the owning ADR and linked requirement.
+
+evidence_required:
+  - commit_sha
+  - package_version
+  - test_id
+  - result

--- a/development/capabilities/claims/CE-CAP-TEST-001.yaml
+++ b/development/capabilities/claims/CE-CAP-TEST-001.yaml
@@ -1,0 +1,34 @@
+claim_id: CE-CAP-TEST-001
+claim_type: capability
+owner: calibrated_explanations
+status: current
+adr_links:
+  - ADR-023
+  - ADR-030
+
+claim_text: >
+  Tests follow the repository quality policy for naming, coverage gates, and justified coverage exemptions.
+
+public_api: []
+
+task_types:
+  - governance
+
+requirements:
+  - CE-REQ-TEST-GOV-001
+
+verification:
+  proves:
+    - documentation_boundary
+    - governance_linkage
+  verification_type: automated_metadata_check
+
+assumptions:
+  - This governance capability is verified by ADR, claim, requirement, and test-link consistency checks.
+  - Behavioral enforcement remains scoped to the implementation and tests named by the linked requirement.
+
+evidence_required:
+  - commit_sha
+  - package_version
+  - test_id
+  - result

--- a/development/capabilities/claims/CE-CAP-VALID-001.yaml
+++ b/development/capabilities/claims/CE-CAP-VALID-001.yaml
@@ -1,0 +1,33 @@
+claim_id: CE-CAP-VALID-001
+claim_type: capability
+owner: calibrated_explanations
+status: current
+adr_links:
+  - ADR-002
+
+claim_text: >
+  Public validation failures use the CE exception taxonomy rather than ad-hoc generic exceptions where ADR-002 scope applies.
+
+public_api: []
+
+task_types:
+  - governance
+
+requirements:
+  - CE-REQ-VALID-EXCEPTION-001
+
+verification:
+  proves:
+    - documentation_boundary
+    - governance_linkage
+  verification_type: automated_metadata_check
+
+assumptions:
+  - This governance capability is verified by ADR, claim, requirement, and test-link consistency checks.
+  - Behavioral enforcement remains scoped to the implementation and tests named by the linked requirement.
+
+evidence_required:
+  - commit_sha
+  - package_version
+  - test_id
+  - result

--- a/development/capabilities/claims/CE-CAP-VIZ-001.yaml
+++ b/development/capabilities/claims/CE-CAP-VIZ-001.yaml
@@ -3,6 +3,11 @@ claim_type: capability
 owner: calibrated_explanations
 status: current
 
+adr_links:
+  - ADR-023
+  - ADR-036
+  - ADR-037
+
 claim_text: >
   calibrated_explanations provides visualization output for explanations via
   WrapCalibratedExplainer.plot and CalibratedExplanations.plot, supporting

--- a/development/capabilities/claims/CE-CAP-VIZ-DEFAULT-PLOTSPEC-PATH-001.yaml
+++ b/development/capabilities/claims/CE-CAP-VIZ-DEFAULT-PLOTSPEC-PATH-001.yaml
@@ -1,0 +1,35 @@
+claim_id: CE-CAP-VIZ-DEFAULT-PLOTSPEC-PATH-001
+claim_type: capability
+owner: calibrated_explanations
+status: current
+adr_links:
+  - ADR-037
+
+claim_text: >
+  PlotSpec is the default user-facing plotting path after accepted promotion, with legacy rendering only as explicit opt-out or visible fallback.
+
+public_api: []
+
+task_types:
+  - governance
+
+requirements:
+  - CE-REQ-VIZ-DEFAULT-PLOTSPEC-PATH-001
+
+verification:
+  proves:
+    - documentation_boundary
+    - adr_semantic_coverage
+  verification_type: concrete_evidence_refs_or_manual_review
+  verification_status: manual_review_required
+
+assumptions:
+  - This semantic governance claim records an ADR obligation at claim granularity.
+  - Runtime verification is provided by the linked requirement's named tests, quality scripts, or manual review scope.
+  - This claim does not broaden public API guarantees beyond the owning ADR and linked requirement.
+
+evidence_required:
+  - commit_sha
+  - package_version
+  - test_id
+  - result

--- a/development/capabilities/claims/CE-CAP-VIZ-EXTENSION-METADATA-001.yaml
+++ b/development/capabilities/claims/CE-CAP-VIZ-EXTENSION-METADATA-001.yaml
@@ -1,0 +1,35 @@
+claim_id: CE-CAP-VIZ-EXTENSION-METADATA-001
+claim_type: capability
+owner: calibrated_explanations
+status: current
+adr_links:
+  - ADR-037
+
+claim_text: >
+  Visualization extensions provide deterministic builder/renderer governance metadata.
+
+public_api: []
+
+task_types:
+  - governance
+
+requirements:
+  - CE-REQ-VIZ-EXTENSION-METADATA-001
+
+verification:
+  proves:
+    - documentation_boundary
+    - adr_semantic_coverage
+  verification_type: concrete_evidence_refs_or_manual_review
+  verification_status: manual_review_required
+
+assumptions:
+  - This semantic governance claim records an ADR obligation at claim granularity.
+  - Runtime verification is provided by the linked requirement's named tests, quality scripts, or manual review scope.
+  - This claim does not broaden public API guarantees beyond the owning ADR and linked requirement.
+
+evidence_required:
+  - commit_sha
+  - package_version
+  - test_id
+  - result

--- a/development/capabilities/claims/CE-CAP-VIZ-PLOT-KIND-GOVERNANCE-001.yaml
+++ b/development/capabilities/claims/CE-CAP-VIZ-PLOT-KIND-GOVERNANCE-001.yaml
@@ -1,0 +1,35 @@
+claim_id: CE-CAP-VIZ-PLOT-KIND-GOVERNANCE-001
+claim_type: capability
+owner: calibrated_explanations
+status: current
+adr_links:
+  - ADR-037
+
+claim_text: >
+  Visualization plot kinds use a governed semantic vocabulary and runtime plot-kind extension remains disallowed.
+
+public_api: []
+
+task_types:
+  - governance
+
+requirements:
+  - CE-REQ-VIZ-PLOT-KIND-GOVERNANCE-001
+
+verification:
+  proves:
+    - documentation_boundary
+    - adr_semantic_coverage
+  verification_type: concrete_evidence_refs_or_manual_review
+  verification_status: manual_review_required
+
+assumptions:
+  - This semantic governance claim records an ADR obligation at claim granularity.
+  - Runtime verification is provided by the linked requirement's named tests, quality scripts, or manual review scope.
+  - This claim does not broaden public API guarantees beyond the owning ADR and linked requirement.
+
+evidence_required:
+  - commit_sha
+  - package_version
+  - test_id
+  - result

--- a/development/capabilities/requirements/CE-REQ-ALT-TARGET-CONFIDENCE-001.md
+++ b/development/capabilities/requirements/CE-REQ-ALT-TARGET-CONFIDENCE-001.md
@@ -1,0 +1,65 @@
+# CE-REQ-ALT-TARGET-CONFIDENCE-001 — filter_by_target_confidence() applies conformal singleton-set filtering, returns a new collection, and validates confidence/probabilistic preconditions.
+
+## Metadata
+
+| Field | Value |
+|---|---|
+| requirement_id | CE-REQ-ALT-TARGET-CONFIDENCE-001 |
+| obligation_type | api_contract |
+| claim_refs | CE-CAP-ALT-TARGET-CONFIDENCE-001 |
+| adr_refs | ADR-032 |
+| status | active |
+| verification_status | manual_review_required |
+
+## Scope
+
+ADR-governed implementation, documentation, and verification artifacts for `ADR-032`.
+
+## Observable behavior
+
+Alternative target-confidence filtering MUST validate confidence and probabilistic preconditions, MUST apply conformal singleton-set filtering, and MUST return a new collection without mutating the source collection.
+
+## Acceptance criterion
+
+Behavioral acceptance for this requirement is the ADR-specific obligation itself:
+
+- Alternative target-confidence filtering MUST validate confidence and probabilistic preconditions, MUST apply conformal singleton-set filtering, and MUST return a new collection without mutating the source collection.
+- Automated metadata tests MAY prove that the requirement is linked, but MUST NOT be
+  treated as proof that the behavioral obligation is satisfied.
+- Until a named runtime, static-policy, serialization, schema, or quality-gate check below
+  directly verifies the obligation, the verification status remains `manual_review_required`.
+
+## Verification method
+
+Verification method: `manual_review` plus the concrete source, documentation, schema,
+quality-script, or pytest targets listed below. Metadata tests are linkage guards only.
+
+## Verification targets
+
+- source: `development/adrs/ADR-032*.md`
+- docs: `docs/foundations/concepts/guarded_explanations.md`
+- docs: `docs/get-started/quickstart_guarded.md`
+- metadata_test: `tests/capabilities/test_adr_capability_links.py::test_should_validate_adr_claim_requirement_link_metadata`
+- metadata_test: `tests/capabilities/test_adr_capability_links.py::test_should_validate_curated_semantic_claim_presence`
+- manual_review: `development/current-work/RELEASE_PLAN_status_appendix.md` (ADR-032 section)
+
+Test IDs:
+- `test_should_validate_adr_claim_requirement_link_metadata`
+- `test_should_validate_curated_semantic_claim_presence`
+- `test_should_require_behavioral_requirements_to_name_concrete_evidence`
+- `test_should_prevent_runtime_obligations_from_using_documentation_boundary_type`
+
+## Evidence required
+
+| Field | Required |
+|---|---|
+| commit_sha | yes |
+| package_version | yes |
+| test_id | yes |
+| result | yes (pass/fail/partial) |
+
+## Assumption boundary
+
+This requirement captures the normative ADR obligation and its evidence chain. It does not
+claim that metadata checks alone prove runtime correctness; behavior remains verified by the
+specific source, test, documentation, or quality-script evidence maintained for `ADR-032`.

--- a/development/capabilities/requirements/CE-REQ-CACHE-GOV-001.md
+++ b/development/capabilities/requirements/CE-REQ-CACHE-GOV-001.md
@@ -1,0 +1,55 @@
+# CE-REQ-CACHE-GOV-001 — ADR Governance Linkage Contract
+
+## Metadata
+
+| Field | Value |
+|---|---|
+| requirement_id | CE-REQ-CACHE-GOV-001 |
+| obligation_type | documentation_boundary |
+| claim_refs | CE-CAP-CACHE-001 |
+| adr_refs | ADR-003 |
+| status | active |
+
+## Scope
+
+Development governance artifacts under `development/adrs/` and
+`development/capabilities/` for ADR-003.
+
+## Observable behavior
+
+The governed ADR claim chain MUST remain navigable in-place:
+
+1. Each owning ADR MUST list `CE-CAP-CACHE-001` in its `## Governed claims` section.
+2. `CE-CAP-CACHE-001` MUST list its owning ADRs in `adr_links`.
+3. `CE-CAP-CACHE-001` MUST list `CE-REQ-CACHE-GOV-001` in `requirements`.
+4. This requirement MUST list `CE-CAP-CACHE-001` in `claim_refs`.
+5. Linked test references MUST point to existing tests or explicit metadata checks.
+
+## Acceptance criterion
+
+The capability traceability validation test passes for this ADR/claim/requirement
+chain without relying on a standalone traceability table or generated matrix.
+
+## Verification method
+
+Automated pytest test in `tests/capabilities/`.
+
+Test ID:
+- `test_should_validate_adr_claim_requirement_link_metadata`
+
+(in `tests/capabilities/test_adr_capability_links.py`)
+
+## Evidence required
+
+| Field | Required |
+|---|---|
+| commit_sha | yes |
+| package_version | yes |
+| test_id | yes |
+| result | yes (pass/fail) |
+
+## Assumption boundary
+
+This requirement verifies governance linkage and metadata consistency. It does not
+prove every runtime behavior implied by the owning ADR; runtime behavior remains
+covered by the specific implementation tests referenced by feature requirements.

--- a/development/capabilities/requirements/CE-REQ-CALIBRATOR-PRIMITIVE-SCHEMA-001.md
+++ b/development/capabilities/requirements/CE-REQ-CALIBRATOR-PRIMITIVE-SCHEMA-001.md
@@ -1,0 +1,65 @@
+# CE-REQ-CALIBRATOR-PRIMITIVE-SCHEMA-001 — Built-in calibrators implement JSON-safe to_primitive() and from_primitive() schema contracts.
+
+## Metadata
+
+| Field | Value |
+|---|---|
+| requirement_id | CE-REQ-CALIBRATOR-PRIMITIVE-SCHEMA-001 |
+| obligation_type | serialization_contract |
+| claim_refs | CE-CAP-CALIBRATOR-PRIMITIVE-SCHEMA-001 |
+| adr_refs | ADR-031 |
+| status | active |
+| verification_status | manual_review_required |
+
+## Scope
+
+ADR-governed implementation, documentation, and verification artifacts for `ADR-031`.
+
+## Observable behavior
+
+Built-in calibrators MUST serialize to JSON-safe primitives and restore via from_primitive() with explicit schema_version metadata.
+
+## Acceptance criterion
+
+Behavioral acceptance for this requirement is the ADR-specific obligation itself:
+
+- Built-in calibrators MUST serialize to JSON-safe primitives and restore via from_primitive() with explicit schema_version metadata.
+- Automated metadata tests MAY prove that the requirement is linked, but MUST NOT be
+  treated as proof that the behavioral obligation is satisfied.
+- Until a named runtime, static-policy, serialization, schema, or quality-gate check below
+  directly verifies the obligation, the verification status remains `manual_review_required`.
+
+## Verification method
+
+Verification method: `manual_review` plus the concrete source, documentation, schema,
+quality-script, or pytest targets listed below. Metadata tests are linkage guards only.
+
+## Verification targets
+
+- source: `development/adrs/ADR-031*.md`
+- docs: `docs/api/serialization.md`
+- schema: `development/schemas/primitives_schema.json`
+- metadata_test: `tests/capabilities/test_adr_capability_links.py::test_should_validate_adr_claim_requirement_link_metadata`
+- metadata_test: `tests/capabilities/test_adr_capability_links.py::test_should_validate_curated_semantic_claim_presence`
+- manual_review: `development/current-work/RELEASE_PLAN_status_appendix.md` (ADR-031 section)
+
+Test IDs:
+- `test_should_validate_adr_claim_requirement_link_metadata`
+- `test_should_validate_curated_semantic_claim_presence`
+- `test_should_require_behavioral_requirements_to_name_concrete_evidence`
+- `test_should_prevent_runtime_obligations_from_using_documentation_boundary_type`
+
+## Evidence required
+
+| Field | Required |
+|---|---|
+| commit_sha | yes |
+| package_version | yes |
+| test_id | yes |
+| result | yes (pass/fail/partial) |
+
+## Assumption boundary
+
+This requirement captures the normative ADR obligation and its evidence chain. It does not
+claim that metadata checks alone prove runtime correctness; behavior remains verified by the
+specific source, test, documentation, or quality-script evidence maintained for `ADR-031`.

--- a/development/capabilities/requirements/CE-REQ-CI-GOV-001.md
+++ b/development/capabilities/requirements/CE-REQ-CI-GOV-001.md
@@ -1,0 +1,55 @@
+# CE-REQ-CI-GOV-001 — ADR Governance Linkage Contract
+
+## Metadata
+
+| Field | Value |
+|---|---|
+| requirement_id | CE-REQ-CI-GOV-001 |
+| obligation_type | documentation_boundary |
+| claim_refs | CE-CAP-CI-001 |
+| adr_refs | ADR-035 |
+| status | active |
+
+## Scope
+
+Development governance artifacts under `development/adrs/` and
+`development/capabilities/` for ADR-035.
+
+## Observable behavior
+
+The governed ADR claim chain MUST remain navigable in-place:
+
+1. Each owning ADR MUST list `CE-CAP-CI-001` in its `## Governed claims` section.
+2. `CE-CAP-CI-001` MUST list its owning ADRs in `adr_links`.
+3. `CE-CAP-CI-001` MUST list `CE-REQ-CI-GOV-001` in `requirements`.
+4. This requirement MUST list `CE-CAP-CI-001` in `claim_refs`.
+5. Linked test references MUST point to existing tests or explicit metadata checks.
+
+## Acceptance criterion
+
+The capability traceability validation test passes for this ADR/claim/requirement
+chain without relying on a standalone traceability table or generated matrix.
+
+## Verification method
+
+Automated pytest test in `tests/capabilities/`.
+
+Test ID:
+- `test_should_validate_adr_claim_requirement_link_metadata`
+
+(in `tests/capabilities/test_adr_capability_links.py`)
+
+## Evidence required
+
+| Field | Required |
+|---|---|
+| commit_sha | yes |
+| package_version | yes |
+| test_id | yes |
+| result | yes (pass/fail) |
+
+## Assumption boundary
+
+This requirement verifies governance linkage and metadata consistency. It does not
+prove every runtime behavior implied by the owning ADR; runtime behavior remains
+covered by the specific implementation tests referenced by feature requirements.

--- a/development/capabilities/requirements/CE-REQ-CONFIG-AUTHORITY-001.md
+++ b/development/capabilities/requirements/CE-REQ-CONFIG-AUTHORITY-001.md
@@ -1,0 +1,65 @@
+# CE-REQ-CONFIG-AUTHORITY-001 — ConfigManager is the canonical runtime configuration read surface.
+
+## Metadata
+
+| Field | Value |
+|---|---|
+| requirement_id | CE-REQ-CONFIG-AUTHORITY-001 |
+| obligation_type | static_policy |
+| claim_refs | CE-CAP-CONFIG-AUTHORITY-001 |
+| adr_refs | ADR-034 |
+| status | active |
+| verification_status | manual_review_required |
+
+## Scope
+
+ADR-governed implementation, documentation, and verification artifacts for `ADR-034`.
+
+## Observable behavior
+
+Production runtime modules MUST read configuration through ConfigManager or sanctioned boundary helpers rather than direct os.getenv or pyproject parsing.
+
+## Acceptance criterion
+
+Behavioral acceptance for this requirement is the ADR-specific obligation itself:
+
+- Production runtime modules MUST read configuration through ConfigManager or sanctioned boundary helpers rather than direct os.getenv or pyproject parsing.
+- Automated metadata tests MAY prove that the requirement is linked, but MUST NOT be
+  treated as proof that the behavioral obligation is satisfied.
+- Until a named runtime, static-policy, serialization, schema, or quality-gate check below
+  directly verifies the obligation, the verification status remains `manual_review_required`.
+
+## Verification method
+
+Verification method: `manual_review` plus the concrete source, documentation, schema,
+quality-script, or pytest targets listed below. Metadata tests are linkage guards only.
+
+## Verification targets
+
+- source: `development/adrs/ADR-034*.md`
+- quality_script: `scripts/quality/check_config_manager_usage.py`
+- docs: `docs/foundations/how-to/configure_runtime.md`
+- metadata_test: `tests/capabilities/test_adr_capability_links.py::test_should_validate_adr_claim_requirement_link_metadata`
+- metadata_test: `tests/capabilities/test_adr_capability_links.py::test_should_validate_curated_semantic_claim_presence`
+- manual_review: `development/current-work/RELEASE_PLAN_status_appendix.md` (ADR-034 section)
+
+Test IDs:
+- `test_should_validate_adr_claim_requirement_link_metadata`
+- `test_should_validate_curated_semantic_claim_presence`
+- `test_should_require_behavioral_requirements_to_name_concrete_evidence`
+- `test_should_prevent_runtime_obligations_from_using_documentation_boundary_type`
+
+## Evidence required
+
+| Field | Required |
+|---|---|
+| commit_sha | yes |
+| package_version | yes |
+| test_id | yes |
+| result | yes (pass/fail/partial) |
+
+## Assumption boundary
+
+This requirement captures the normative ADR obligation and its evidence chain. It does not
+claim that metadata checks alone prove runtime correctness; behavior remains verified by the
+specific source, test, documentation, or quality-script evidence maintained for `ADR-034`.

--- a/development/capabilities/requirements/CE-REQ-CONFIG-CI-ENFORCEMENT-001.md
+++ b/development/capabilities/requirements/CE-REQ-CONFIG-CI-ENFORCEMENT-001.md
@@ -1,0 +1,65 @@
+# CE-REQ-CONFIG-CI-ENFORCEMENT-001 — Direct runtime config reads outside sanctioned boundary modules are enforced by the quality script.
+
+## Metadata
+
+| Field | Value |
+|---|---|
+| requirement_id | CE-REQ-CONFIG-CI-ENFORCEMENT-001 |
+| obligation_type | quality_gate |
+| claim_refs | CE-CAP-CONFIG-CI-ENFORCEMENT-001 |
+| adr_refs | ADR-034 |
+| status | active |
+| verification_status | manual_review_required |
+
+## Scope
+
+ADR-governed implementation, documentation, and verification artifacts for `ADR-034`.
+
+## Observable behavior
+
+Quality checks MUST enforce that direct runtime configuration reads remain confined to sanctioned ConfigManager boundary modules.
+
+## Acceptance criterion
+
+Behavioral acceptance for this requirement is the ADR-specific obligation itself:
+
+- Quality checks MUST enforce that direct runtime configuration reads remain confined to sanctioned ConfigManager boundary modules.
+- Automated metadata tests MAY prove that the requirement is linked, but MUST NOT be
+  treated as proof that the behavioral obligation is satisfied.
+- Until a named runtime, static-policy, serialization, schema, or quality-gate check below
+  directly verifies the obligation, the verification status remains `manual_review_required`.
+
+## Verification method
+
+Verification method: `manual_review` plus the concrete source, documentation, schema,
+quality-script, or pytest targets listed below. Metadata tests are linkage guards only.
+
+## Verification targets
+
+- source: `development/adrs/ADR-034*.md`
+- quality_script: `scripts/quality/check_config_manager_usage.py`
+- docs: `docs/foundations/how-to/configure_runtime.md`
+- metadata_test: `tests/capabilities/test_adr_capability_links.py::test_should_validate_adr_claim_requirement_link_metadata`
+- metadata_test: `tests/capabilities/test_adr_capability_links.py::test_should_validate_curated_semantic_claim_presence`
+- manual_review: `development/current-work/RELEASE_PLAN_status_appendix.md` (ADR-034 section)
+
+Test IDs:
+- `test_should_validate_adr_claim_requirement_link_metadata`
+- `test_should_validate_curated_semantic_claim_presence`
+- `test_should_require_behavioral_requirements_to_name_concrete_evidence`
+- `test_should_prevent_runtime_obligations_from_using_documentation_boundary_type`
+
+## Evidence required
+
+| Field | Required |
+|---|---|
+| commit_sha | yes |
+| package_version | yes |
+| test_id | yes |
+| result | yes (pass/fail/partial) |
+
+## Assumption boundary
+
+This requirement captures the normative ADR obligation and its evidence chain. It does not
+claim that metadata checks alone prove runtime correctness; behavior remains verified by the
+specific source, test, documentation, or quality-script evidence maintained for `ADR-034`.

--- a/development/capabilities/requirements/CE-REQ-CONFIG-DIAGNOSTIC-EXPORT-001.md
+++ b/development/capabilities/requirements/CE-REQ-CONFIG-DIAGNOSTIC-EXPORT-001.md
@@ -1,0 +1,65 @@
+# CE-REQ-CONFIG-DIAGNOSTIC-EXPORT-001 — Effective config export includes schema markers, source attribution, profile ID, and diagnostic boundaries.
+
+## Metadata
+
+| Field | Value |
+|---|---|
+| requirement_id | CE-REQ-CONFIG-DIAGNOSTIC-EXPORT-001 |
+| obligation_type | manual_review_boundary |
+| claim_refs | CE-CAP-CONFIG-DIAGNOSTIC-EXPORT-001 |
+| adr_refs | ADR-034 |
+| status | active |
+| verification_status | manual_review_required |
+
+## Scope
+
+ADR-governed implementation, documentation, and verification artifacts for `ADR-034`.
+
+## Observable behavior
+
+Effective configuration export MUST include schema/version markers, source attribution, profile identity, and diagnostic-only boundaries with redaction where needed.
+
+## Acceptance criterion
+
+Behavioral acceptance for this requirement is the ADR-specific obligation itself:
+
+- Effective configuration export MUST include schema/version markers, source attribution, profile identity, and diagnostic-only boundaries with redaction where needed.
+- Automated metadata tests MAY prove that the requirement is linked, but MUST NOT be
+  treated as proof that the behavioral obligation is satisfied.
+- Until a named runtime, static-policy, serialization, schema, or quality-gate check below
+  directly verifies the obligation, the verification status remains `manual_review_required`.
+
+## Verification method
+
+Verification method: `manual_review` plus the concrete source, documentation, schema,
+quality-script, or pytest targets listed below. Metadata tests are linkage guards only.
+
+## Verification targets
+
+- source: `development/adrs/ADR-034*.md`
+- quality_script: `scripts/quality/check_config_manager_usage.py`
+- docs: `docs/foundations/how-to/configure_runtime.md`
+- metadata_test: `tests/capabilities/test_adr_capability_links.py::test_should_validate_adr_claim_requirement_link_metadata`
+- metadata_test: `tests/capabilities/test_adr_capability_links.py::test_should_validate_curated_semantic_claim_presence`
+- manual_review: `development/current-work/RELEASE_PLAN_status_appendix.md` (ADR-034 section)
+
+Test IDs:
+- `test_should_validate_adr_claim_requirement_link_metadata`
+- `test_should_validate_curated_semantic_claim_presence`
+- `test_should_require_behavioral_requirements_to_name_concrete_evidence`
+- `test_should_prevent_runtime_obligations_from_using_documentation_boundary_type`
+
+## Evidence required
+
+| Field | Required |
+|---|---|
+| commit_sha | yes |
+| package_version | yes |
+| test_id | yes |
+| result | yes (pass/fail/partial) |
+
+## Assumption boundary
+
+This requirement captures the normative ADR obligation and its evidence chain. It does not
+claim that metadata checks alone prove runtime correctness; behavior remains verified by the
+specific source, test, documentation, or quality-script evidence maintained for `ADR-034`.

--- a/development/capabilities/requirements/CE-REQ-CONFIG-GOV-001.md
+++ b/development/capabilities/requirements/CE-REQ-CONFIG-GOV-001.md
@@ -1,0 +1,55 @@
+# CE-REQ-CONFIG-GOV-001 — ADR Governance Linkage Contract
+
+## Metadata
+
+| Field | Value |
+|---|---|
+| requirement_id | CE-REQ-CONFIG-GOV-001 |
+| obligation_type | documentation_boundary |
+| claim_refs | CE-CAP-CONFIG-001 |
+| adr_refs | ADR-034, ADR-038 |
+| status | active |
+
+## Scope
+
+Development governance artifacts under `development/adrs/` and
+`development/capabilities/` for ADR-034, ADR-038.
+
+## Observable behavior
+
+The governed ADR claim chain MUST remain navigable in-place:
+
+1. Each owning ADR MUST list `CE-CAP-CONFIG-001` in its `## Governed claims` section.
+2. `CE-CAP-CONFIG-001` MUST list its owning ADRs in `adr_links`.
+3. `CE-CAP-CONFIG-001` MUST list `CE-REQ-CONFIG-GOV-001` in `requirements`.
+4. This requirement MUST list `CE-CAP-CONFIG-001` in `claim_refs`.
+5. Linked test references MUST point to existing tests or explicit metadata checks.
+
+## Acceptance criterion
+
+The capability traceability validation test passes for this ADR/claim/requirement
+chain without relying on a standalone traceability table or generated matrix.
+
+## Verification method
+
+Automated pytest test in `tests/capabilities/`.
+
+Test ID:
+- `test_should_validate_adr_claim_requirement_link_metadata`
+
+(in `tests/capabilities/test_adr_capability_links.py`)
+
+## Evidence required
+
+| Field | Required |
+|---|---|
+| commit_sha | yes |
+| package_version | yes |
+| test_id | yes |
+| result | yes (pass/fail) |
+
+## Assumption boundary
+
+This requirement verifies governance linkage and metadata consistency. It does not
+prove every runtime behavior implied by the owning ADR; runtime behavior remains
+covered by the specific implementation tests referenced by feature requirements.

--- a/development/capabilities/requirements/CE-REQ-CONFIG-PRECEDENCE-SNAPSHOT-001.md
+++ b/development/capabilities/requirements/CE-REQ-CONFIG-PRECEDENCE-SNAPSHOT-001.md
@@ -1,0 +1,65 @@
+# CE-REQ-CONFIG-PRECEDENCE-SNAPSHOT-001 — Configuration resolution follows call-site override, environment, pyproject, then profile defaults and is snapshot-based.
+
+## Metadata
+
+| Field | Value |
+|---|---|
+| requirement_id | CE-REQ-CONFIG-PRECEDENCE-SNAPSHOT-001 |
+| obligation_type | manual_review_boundary |
+| claim_refs | CE-CAP-CONFIG-PRECEDENCE-SNAPSHOT-001 |
+| adr_refs | ADR-034 |
+| status | active |
+| verification_status | manual_review_required |
+
+## Scope
+
+ADR-governed implementation, documentation, and verification artifacts for `ADR-034`.
+
+## Observable behavior
+
+Config resolution MUST follow call-site override > environment > pyproject > profile defaults, and ConfigManager instances MUST use captured snapshots rather than live source rereads.
+
+## Acceptance criterion
+
+Behavioral acceptance for this requirement is the ADR-specific obligation itself:
+
+- Config resolution MUST follow call-site override > environment > pyproject > profile defaults, and ConfigManager instances MUST use captured snapshots rather than live source rereads.
+- Automated metadata tests MAY prove that the requirement is linked, but MUST NOT be
+  treated as proof that the behavioral obligation is satisfied.
+- Until a named runtime, static-policy, serialization, schema, or quality-gate check below
+  directly verifies the obligation, the verification status remains `manual_review_required`.
+
+## Verification method
+
+Verification method: `manual_review` plus the concrete source, documentation, schema,
+quality-script, or pytest targets listed below. Metadata tests are linkage guards only.
+
+## Verification targets
+
+- source: `development/adrs/ADR-034*.md`
+- quality_script: `scripts/quality/check_config_manager_usage.py`
+- docs: `docs/foundations/how-to/configure_runtime.md`
+- metadata_test: `tests/capabilities/test_adr_capability_links.py::test_should_validate_adr_claim_requirement_link_metadata`
+- metadata_test: `tests/capabilities/test_adr_capability_links.py::test_should_validate_curated_semantic_claim_presence`
+- manual_review: `development/current-work/RELEASE_PLAN_status_appendix.md` (ADR-034 section)
+
+Test IDs:
+- `test_should_validate_adr_claim_requirement_link_metadata`
+- `test_should_validate_curated_semantic_claim_presence`
+- `test_should_require_behavioral_requirements_to_name_concrete_evidence`
+- `test_should_prevent_runtime_obligations_from_using_documentation_boundary_type`
+
+## Evidence required
+
+| Field | Required |
+|---|---|
+| commit_sha | yes |
+| package_version | yes |
+| test_id | yes |
+| result | yes (pass/fail/partial) |
+
+## Assumption boundary
+
+This requirement captures the normative ADR obligation and its evidence chain. It does not
+claim that metadata checks alone prove runtime correctness; behavior remains verified by the
+specific source, test, documentation, or quality-script evidence maintained for `ADR-034`.

--- a/development/capabilities/requirements/CE-REQ-CONFIG-STRICT-VALIDATION-001.md
+++ b/development/capabilities/requirements/CE-REQ-CONFIG-STRICT-VALIDATION-001.md
@@ -1,0 +1,65 @@
+# CE-REQ-CONFIG-STRICT-VALIDATION-001 — Strict mode raises ConfigurationError; non-strict mode records validation reports without suppressing observability.
+
+## Metadata
+
+| Field | Value |
+|---|---|
+| requirement_id | CE-REQ-CONFIG-STRICT-VALIDATION-001 |
+| obligation_type | manual_review_boundary |
+| claim_refs | CE-CAP-CONFIG-STRICT-VALIDATION-001 |
+| adr_refs | ADR-034 |
+| status | active |
+| verification_status | manual_review_required |
+
+## Scope
+
+ADR-governed implementation, documentation, and verification artifacts for `ADR-034`.
+
+## Observable behavior
+
+Strict configuration validation MUST raise ConfigurationError on unknown or invalid supported keys, while non-strict mode MUST record validation diagnostics.
+
+## Acceptance criterion
+
+Behavioral acceptance for this requirement is the ADR-specific obligation itself:
+
+- Strict configuration validation MUST raise ConfigurationError on unknown or invalid supported keys, while non-strict mode MUST record validation diagnostics.
+- Automated metadata tests MAY prove that the requirement is linked, but MUST NOT be
+  treated as proof that the behavioral obligation is satisfied.
+- Until a named runtime, static-policy, serialization, schema, or quality-gate check below
+  directly verifies the obligation, the verification status remains `manual_review_required`.
+
+## Verification method
+
+Verification method: `manual_review` plus the concrete source, documentation, schema,
+quality-script, or pytest targets listed below. Metadata tests are linkage guards only.
+
+## Verification targets
+
+- source: `development/adrs/ADR-034*.md`
+- quality_script: `scripts/quality/check_config_manager_usage.py`
+- docs: `docs/foundations/how-to/configure_runtime.md`
+- metadata_test: `tests/capabilities/test_adr_capability_links.py::test_should_validate_adr_claim_requirement_link_metadata`
+- metadata_test: `tests/capabilities/test_adr_capability_links.py::test_should_validate_curated_semantic_claim_presence`
+- manual_review: `development/current-work/RELEASE_PLAN_status_appendix.md` (ADR-034 section)
+
+Test IDs:
+- `test_should_validate_adr_claim_requirement_link_metadata`
+- `test_should_validate_curated_semantic_claim_presence`
+- `test_should_require_behavioral_requirements_to_name_concrete_evidence`
+- `test_should_prevent_runtime_obligations_from_using_documentation_boundary_type`
+
+## Evidence required
+
+| Field | Required |
+|---|---|
+| commit_sha | yes |
+| package_version | yes |
+| test_id | yes |
+| result | yes (pass/fail/partial) |
+
+## Assumption boundary
+
+This requirement captures the normative ADR obligation and its evidence chain. It does not
+claim that metadata checks alone prove runtime correctness; behavior remains verified by the
+specific source, test, documentation, or quality-script evidence maintained for `ADR-034`.

--- a/development/capabilities/requirements/CE-REQ-CORE-BOUNDARY-001.md
+++ b/development/capabilities/requirements/CE-REQ-CORE-BOUNDARY-001.md
@@ -1,0 +1,55 @@
+# CE-REQ-CORE-BOUNDARY-001 — ADR Governance Linkage Contract
+
+## Metadata
+
+| Field | Value |
+|---|---|
+| requirement_id | CE-REQ-CORE-BOUNDARY-001 |
+| obligation_type | documentation_boundary |
+| claim_refs | CE-CAP-CORE-001 |
+| adr_refs | ADR-001 |
+| status | active |
+
+## Scope
+
+Development governance artifacts under `development/adrs/` and
+`development/capabilities/` for ADR-001.
+
+## Observable behavior
+
+The governed ADR claim chain MUST remain navigable in-place:
+
+1. Each owning ADR MUST list `CE-CAP-CORE-001` in its `## Governed claims` section.
+2. `CE-CAP-CORE-001` MUST list its owning ADRs in `adr_links`.
+3. `CE-CAP-CORE-001` MUST list `CE-REQ-CORE-BOUNDARY-001` in `requirements`.
+4. This requirement MUST list `CE-CAP-CORE-001` in `claim_refs`.
+5. Linked test references MUST point to existing tests or explicit metadata checks.
+
+## Acceptance criterion
+
+The capability traceability validation test passes for this ADR/claim/requirement
+chain without relying on a standalone traceability table or generated matrix.
+
+## Verification method
+
+Automated pytest test in `tests/capabilities/`.
+
+Test ID:
+- `test_should_validate_adr_claim_requirement_link_metadata`
+
+(in `tests/capabilities/test_adr_capability_links.py`)
+
+## Evidence required
+
+| Field | Required |
+|---|---|
+| commit_sha | yes |
+| package_version | yes |
+| test_id | yes |
+| result | yes (pass/fail) |
+
+## Assumption boundary
+
+This requirement verifies governance linkage and metadata consistency. It does not
+prove every runtime behavior implied by the owning ADR; runtime behavior remains
+covered by the specific implementation tests referenced by feature requirements.

--- a/development/capabilities/requirements/CE-REQ-DEPREC-GOV-001.md
+++ b/development/capabilities/requirements/CE-REQ-DEPREC-GOV-001.md
@@ -1,0 +1,55 @@
+# CE-REQ-DEPREC-GOV-001 — ADR Governance Linkage Contract
+
+## Metadata
+
+| Field | Value |
+|---|---|
+| requirement_id | CE-REQ-DEPREC-GOV-001 |
+| obligation_type | documentation_boundary |
+| claim_refs | CE-CAP-DEPREC-001 |
+| adr_refs | ADR-011 |
+| status | active |
+
+## Scope
+
+Development governance artifacts under `development/adrs/` and
+`development/capabilities/` for ADR-011.
+
+## Observable behavior
+
+The governed ADR claim chain MUST remain navigable in-place:
+
+1. Each owning ADR MUST list `CE-CAP-DEPREC-001` in its `## Governed claims` section.
+2. `CE-CAP-DEPREC-001` MUST list its owning ADRs in `adr_links`.
+3. `CE-CAP-DEPREC-001` MUST list `CE-REQ-DEPREC-GOV-001` in `requirements`.
+4. This requirement MUST list `CE-CAP-DEPREC-001` in `claim_refs`.
+5. Linked test references MUST point to existing tests or explicit metadata checks.
+
+## Acceptance criterion
+
+The capability traceability validation test passes for this ADR/claim/requirement
+chain without relying on a standalone traceability table or generated matrix.
+
+## Verification method
+
+Automated pytest test in `tests/capabilities/`.
+
+Test ID:
+- `test_should_validate_adr_claim_requirement_link_metadata`
+
+(in `tests/capabilities/test_adr_capability_links.py`)
+
+## Evidence required
+
+| Field | Required |
+|---|---|
+| commit_sha | yes |
+| package_version | yes |
+| test_id | yes |
+| result | yes (pass/fail) |
+
+## Assumption boundary
+
+This requirement verifies governance linkage and metadata consistency. It does not
+prove every runtime behavior implied by the owning ADR; runtime behavior remains
+covered by the specific implementation tests referenced by feature requirements.

--- a/development/capabilities/requirements/CE-REQ-DIST-GOV-001.md
+++ b/development/capabilities/requirements/CE-REQ-DIST-GOV-001.md
@@ -1,0 +1,55 @@
+# CE-REQ-DIST-GOV-001 — ADR Governance Linkage Contract
+
+## Metadata
+
+| Field | Value |
+|---|---|
+| requirement_id | CE-REQ-DIST-GOV-001 |
+| obligation_type | documentation_boundary |
+| claim_refs | CE-CAP-DIST-001 |
+| adr_refs | ADR-010 |
+| status | active |
+
+## Scope
+
+Development governance artifacts under `development/adrs/` and
+`development/capabilities/` for ADR-010.
+
+## Observable behavior
+
+The governed ADR claim chain MUST remain navigable in-place:
+
+1. Each owning ADR MUST list `CE-CAP-DIST-001` in its `## Governed claims` section.
+2. `CE-CAP-DIST-001` MUST list its owning ADRs in `adr_links`.
+3. `CE-CAP-DIST-001` MUST list `CE-REQ-DIST-GOV-001` in `requirements`.
+4. This requirement MUST list `CE-CAP-DIST-001` in `claim_refs`.
+5. Linked test references MUST point to existing tests or explicit metadata checks.
+
+## Acceptance criterion
+
+The capability traceability validation test passes for this ADR/claim/requirement
+chain without relying on a standalone traceability table or generated matrix.
+
+## Verification method
+
+Automated pytest test in `tests/capabilities/`.
+
+Test ID:
+- `test_should_validate_adr_claim_requirement_link_metadata`
+
+(in `tests/capabilities/test_adr_capability_links.py`)
+
+## Evidence required
+
+| Field | Required |
+|---|---|
+| commit_sha | yes |
+| package_version | yes |
+| test_id | yes |
+| result | yes (pass/fail) |
+
+## Assumption boundary
+
+This requirement verifies governance linkage and metadata consistency. It does not
+prove every runtime behavior implied by the owning ADR; runtime behavior remains
+covered by the specific implementation tests referenced by feature requirements.

--- a/development/capabilities/requirements/CE-REQ-DOCS-GOV-001.md
+++ b/development/capabilities/requirements/CE-REQ-DOCS-GOV-001.md
@@ -1,0 +1,55 @@
+# CE-REQ-DOCS-GOV-001 — ADR Governance Linkage Contract
+
+## Metadata
+
+| Field | Value |
+|---|---|
+| requirement_id | CE-REQ-DOCS-GOV-001 |
+| obligation_type | documentation_boundary |
+| claim_refs | CE-CAP-DOCS-001 |
+| adr_refs | ADR-012 |
+| status | active |
+
+## Scope
+
+Development governance artifacts under `development/adrs/` and
+`development/capabilities/` for ADR-012.
+
+## Observable behavior
+
+The governed ADR claim chain MUST remain navigable in-place:
+
+1. Each owning ADR MUST list `CE-CAP-DOCS-001` in its `## Governed claims` section.
+2. `CE-CAP-DOCS-001` MUST list its owning ADRs in `adr_links`.
+3. `CE-CAP-DOCS-001` MUST list `CE-REQ-DOCS-GOV-001` in `requirements`.
+4. This requirement MUST list `CE-CAP-DOCS-001` in `claim_refs`.
+5. Linked test references MUST point to existing tests or explicit metadata checks.
+
+## Acceptance criterion
+
+The capability traceability validation test passes for this ADR/claim/requirement
+chain without relying on a standalone traceability table or generated matrix.
+
+## Verification method
+
+Automated pytest test in `tests/capabilities/`.
+
+Test ID:
+- `test_should_validate_adr_claim_requirement_link_metadata`
+
+(in `tests/capabilities/test_adr_capability_links.py`)
+
+## Evidence required
+
+| Field | Required |
+|---|---|
+| commit_sha | yes |
+| package_version | yes |
+| test_id | yes |
+| result | yes (pass/fail) |
+
+## Assumption boundary
+
+This requirement verifies governance linkage and metadata consistency. It does not
+prove every runtime behavior implied by the owning ADR; runtime behavior remains
+covered by the specific implementation tests referenced by feature requirements.

--- a/development/capabilities/requirements/CE-REQ-DOMAIN-LEGACY-ADAPTER-001.md
+++ b/development/capabilities/requirements/CE-REQ-DOMAIN-LEGACY-ADAPTER-001.md
@@ -1,0 +1,66 @@
+# CE-REQ-DOMAIN-LEGACY-ADAPTER-001 — Legacy adapters preserve public and serialized shapes while internal explanation models evolve.
+
+## Metadata
+
+| Field | Value |
+|---|---|
+| requirement_id | CE-REQ-DOMAIN-LEGACY-ADAPTER-001 |
+| obligation_type | api_contract |
+| claim_refs | CE-CAP-DOMAIN-LEGACY-ADAPTER-001 |
+| adr_refs | ADR-008 |
+| status | active |
+| verification_status | manual_review_required |
+
+## Scope
+
+ADR-governed implementation, documentation, and verification artifacts for `ADR-008`.
+
+## Observable behavior
+
+Domain-model adoption MUST preserve legacy public and serialized shapes through adapters until a governed schema migration changes the public contract.
+
+## Acceptance criterion
+
+Behavioral acceptance for this requirement is the ADR-specific obligation itself:
+
+- Domain-model adoption MUST preserve legacy public and serialized shapes through adapters until a governed schema migration changes the public contract.
+- Automated metadata tests MAY prove that the requirement is linked, but MUST NOT be
+  treated as proof that the behavioral obligation is satisfied.
+- Until a named runtime, static-policy, serialization, schema, or quality-gate check below
+  directly verifies the obligation, the verification status remains `manual_review_required`.
+
+## Verification method
+
+Verification method: `manual_review` plus the concrete source, documentation, schema,
+quality-script, or pytest targets listed below. Metadata tests are linkage guards only.
+
+## Verification targets
+
+- source: `development/adrs/ADR-008*.md`
+- schema: `development/schemas/primitives_schema.json`
+- docs: `docs/schema_v1.md`
+- docs: `docs/foundations/concepts/explanation_structures.md`
+- metadata_test: `tests/capabilities/test_adr_capability_links.py::test_should_validate_adr_claim_requirement_link_metadata`
+- metadata_test: `tests/capabilities/test_adr_capability_links.py::test_should_validate_curated_semantic_claim_presence`
+- manual_review: `development/current-work/RELEASE_PLAN_status_appendix.md` (ADR-008 section)
+
+Test IDs:
+- `test_should_validate_adr_claim_requirement_link_metadata`
+- `test_should_validate_curated_semantic_claim_presence`
+- `test_should_require_behavioral_requirements_to_name_concrete_evidence`
+- `test_should_prevent_runtime_obligations_from_using_documentation_boundary_type`
+
+## Evidence required
+
+| Field | Required |
+|---|---|
+| commit_sha | yes |
+| package_version | yes |
+| test_id | yes |
+| result | yes (pass/fail/partial) |
+
+## Assumption boundary
+
+This requirement captures the normative ADR obligation and its evidence chain. It does not
+claim that metadata checks alone prove runtime correctness; behavior remains verified by the
+specific source, test, documentation, or quality-script evidence maintained for `ADR-008`.

--- a/development/capabilities/requirements/CE-REQ-DOMAIN-MODEL-001.md
+++ b/development/capabilities/requirements/CE-REQ-DOMAIN-MODEL-001.md
@@ -1,0 +1,66 @@
+# CE-REQ-DOMAIN-MODEL-001 — The internal explanation domain model uses Explanation and FeatureRule concepts for rules, metadata, predicates, attribution, support, and uncertainty.
+
+## Metadata
+
+| Field | Value |
+|---|---|
+| requirement_id | CE-REQ-DOMAIN-MODEL-001 |
+| obligation_type | api_contract |
+| claim_refs | CE-CAP-DOMAIN-MODEL-001 |
+| adr_refs | ADR-008 |
+| status | active |
+| verification_status | manual_review_required |
+
+## Scope
+
+ADR-governed implementation, documentation, and verification artifacts for `ADR-008`.
+
+## Observable behavior
+
+Internal explanation assembly MUST be representable through Explanation and FeatureRule domain concepts with metadata, predicates, attribution, support, and uncertainty fields.
+
+## Acceptance criterion
+
+Behavioral acceptance for this requirement is the ADR-specific obligation itself:
+
+- Internal explanation assembly MUST be representable through Explanation and FeatureRule domain concepts with metadata, predicates, attribution, support, and uncertainty fields.
+- Automated metadata tests MAY prove that the requirement is linked, but MUST NOT be
+  treated as proof that the behavioral obligation is satisfied.
+- Until a named runtime, static-policy, serialization, schema, or quality-gate check below
+  directly verifies the obligation, the verification status remains `manual_review_required`.
+
+## Verification method
+
+Verification method: `manual_review` plus the concrete source, documentation, schema,
+quality-script, or pytest targets listed below. Metadata tests are linkage guards only.
+
+## Verification targets
+
+- source: `development/adrs/ADR-008*.md`
+- schema: `development/schemas/primitives_schema.json`
+- docs: `docs/schema_v1.md`
+- docs: `docs/foundations/concepts/explanation_structures.md`
+- metadata_test: `tests/capabilities/test_adr_capability_links.py::test_should_validate_adr_claim_requirement_link_metadata`
+- metadata_test: `tests/capabilities/test_adr_capability_links.py::test_should_validate_curated_semantic_claim_presence`
+- manual_review: `development/current-work/RELEASE_PLAN_status_appendix.md` (ADR-008 section)
+
+Test IDs:
+- `test_should_validate_adr_claim_requirement_link_metadata`
+- `test_should_validate_curated_semantic_claim_presence`
+- `test_should_require_behavioral_requirements_to_name_concrete_evidence`
+- `test_should_prevent_runtime_obligations_from_using_documentation_boundary_type`
+
+## Evidence required
+
+| Field | Required |
+|---|---|
+| commit_sha | yes |
+| package_version | yes |
+| test_id | yes |
+| result | yes (pass/fail/partial) |
+
+## Assumption boundary
+
+This requirement captures the normative ADR obligation and its evidence chain. It does not
+claim that metadata checks alone prove runtime correctness; behavior remains verified by the
+specific source, test, documentation, or quality-script evidence maintained for `ADR-008`.

--- a/development/capabilities/requirements/CE-REQ-EXPL-API-001.md
+++ b/development/capabilities/requirements/CE-REQ-EXPL-API-001.md
@@ -7,6 +7,7 @@
 | requirement_id | CE-REQ-EXPL-API-001 |
 | obligation_type | api_contract |
 | claim_refs | CE-CAP-EXPL-001 |
+| adr_refs | ADR-008, ADR-015, ADR-026 |
 | status | active |
 
 ## Scope

--- a/development/capabilities/requirements/CE-REQ-EXPL-API-002.md
+++ b/development/capabilities/requirements/CE-REQ-EXPL-API-002.md
@@ -7,6 +7,7 @@
 | requirement_id | CE-REQ-EXPL-API-002 |
 | obligation_type | api_contract |
 | claim_refs | CE-CAP-EXPL-002 |
+| adr_refs | ADR-008, ADR-015, ADR-026 |
 | status | active |
 
 ## Scope

--- a/development/capabilities/requirements/CE-REQ-EXPL-CONJ-001.md
+++ b/development/capabilities/requirements/CE-REQ-EXPL-CONJ-001.md
@@ -7,6 +7,7 @@
 | requirement_id | CE-REQ-EXPL-CONJ-001 |
 | obligation_type | api_contract |
 | claim_refs | CE-CAP-EXPL-CONJ-001 |
+| adr_refs | ADR-008 |
 | status | active |
 | applicable_on | collection (CalibratedExplanations, AlternativeExplanations) and individual (FactualExplanation, AlternativeExplanation) |
 | supersedes | CE-REQ-EXPL-CONJ-COL-001, CE-REQ-EXPL-CONJ-IND-001, CE-REQ-EXPL-CONJ-API-001 |

--- a/development/capabilities/requirements/CE-REQ-EXPL-FAST-FILTER-001.md
+++ b/development/capabilities/requirements/CE-REQ-EXPL-FAST-FILTER-001.md
@@ -1,0 +1,65 @@
+# CE-REQ-EXPL-FAST-FILTER-001 — Internal FAST-based feature filtering is opt-in, fail-open, telemetry-visible, and preserves factual and alternative explanation semantics.
+
+## Metadata
+
+| Field | Value |
+|---|---|
+| requirement_id | CE-REQ-EXPL-FAST-FILTER-001 |
+| obligation_type | static_policy |
+| claim_refs | CE-CAP-EXPL-FAST-FILTER-001 |
+| adr_refs | ADR-027 |
+| status | active |
+| verification_status | manual_review_required |
+
+## Scope
+
+ADR-governed implementation, documentation, and verification artifacts for `ADR-027`.
+
+## Observable behavior
+
+FAST filtering MUST remain internal, MUST NOT alter the public CalibratedExplainer API, MUST apply only to factual and alternative modes, MUST proceed without filtering on failure, MUST preserve baseline ignore sets, MUST treat per-instance masks as best-effort metadata, and MUST expose effective config and filter events where telemetry is configured.
+
+## Acceptance criterion
+
+Behavioral acceptance for this requirement is the ADR-specific obligation itself:
+
+- FAST filtering MUST remain internal, MUST NOT alter the public CalibratedExplainer API, MUST apply only to factual and alternative modes, MUST proceed without filtering on failure, MUST preserve baseline ignore sets, MUST treat per-instance masks as best-effort metadata, and MUST expose effective config and filter events where telemetry is configured.
+- Automated metadata tests MAY prove that the requirement is linked, but MUST NOT be
+  treated as proof that the behavioral obligation is satisfied.
+- Until a named runtime, static-policy, serialization, schema, or quality-gate check below
+  directly verifies the obligation, the verification status remains `manual_review_required`.
+
+## Verification method
+
+Verification method: `manual_review` plus the concrete source, documentation, schema,
+quality-script, or pytest targets listed below. Metadata tests are linkage guards only.
+
+## Verification targets
+
+- source: `development/adrs/ADR-027*.md`
+- docs: `docs/practitioner/performance-tuning.md`
+- docs: `notebooks/advanced/fast_feature_filtering_demo.ipynb`
+- metadata_test: `tests/capabilities/test_adr_capability_links.py::test_should_validate_adr_claim_requirement_link_metadata`
+- metadata_test: `tests/capabilities/test_adr_capability_links.py::test_should_validate_curated_semantic_claim_presence`
+- manual_review: `development/current-work/RELEASE_PLAN_status_appendix.md` (ADR-027 section)
+
+Test IDs:
+- `test_should_validate_adr_claim_requirement_link_metadata`
+- `test_should_validate_curated_semantic_claim_presence`
+- `test_should_require_behavioral_requirements_to_name_concrete_evidence`
+- `test_should_prevent_runtime_obligations_from_using_documentation_boundary_type`
+
+## Evidence required
+
+| Field | Required |
+|---|---|
+| commit_sha | yes |
+| package_version | yes |
+| test_id | yes |
+| result | yes (pass/fail/partial) |
+
+## Assumption boundary
+
+This requirement captures the normative ADR obligation and its evidence chain. It does not
+claim that metadata checks alone prove runtime correctness; behavior remains verified by the
+specific source, test, documentation, or quality-script evidence maintained for `ADR-027`.

--- a/development/capabilities/requirements/CE-REQ-EXPL-FILTER-COUNTER-001.md
+++ b/development/capabilities/requirements/CE-REQ-EXPL-FILTER-COUNTER-001.md
@@ -7,6 +7,7 @@
 | requirement_id | CE-REQ-EXPL-FILTER-COUNTER-001 |
 | obligation_type | api_contract |
 | claim_refs | CE-CAP-EXPL-FILTER-001 |
+| adr_refs | ADR-008 |
 | status | active |
 | applicable_on | collection (AlternativeExplanations) and individual (AlternativeExplanation) |
 

--- a/development/capabilities/requirements/CE-REQ-EXPL-FILTER-ENSURED-001.md
+++ b/development/capabilities/requirements/CE-REQ-EXPL-FILTER-ENSURED-001.md
@@ -7,6 +7,7 @@
 | requirement_id | CE-REQ-EXPL-FILTER-ENSURED-001 |
 | obligation_type | api_contract |
 | claim_refs | CE-CAP-EXPL-FILTER-001 |
+| adr_refs | ADR-008 |
 | status | active |
 | applicable_on | collection (AlternativeExplanations) and individual (AlternativeExplanation) |
 

--- a/development/capabilities/requirements/CE-REQ-EXPL-FILTER-PARETO-001.md
+++ b/development/capabilities/requirements/CE-REQ-EXPL-FILTER-PARETO-001.md
@@ -7,6 +7,7 @@
 | requirement_id | CE-REQ-EXPL-FILTER-PARETO-001 |
 | obligation_type | api_contract |
 | claim_refs | CE-CAP-EXPL-FILTER-001 |
+| adr_refs | ADR-008 |
 | status | active |
 | applicable_on | collection (AlternativeExplanations) and individual (AlternativeExplanation) |
 

--- a/development/capabilities/requirements/CE-REQ-EXPL-FILTER-SEMI-001.md
+++ b/development/capabilities/requirements/CE-REQ-EXPL-FILTER-SEMI-001.md
@@ -7,6 +7,7 @@
 | requirement_id | CE-REQ-EXPL-FILTER-SEMI-001 |
 | obligation_type | api_contract |
 | claim_refs | CE-CAP-EXPL-FILTER-001 |
+| adr_refs | ADR-008 |
 | status | active |
 | applicable_on | collection (AlternativeExplanations) and individual (AlternativeExplanation) |
 

--- a/development/capabilities/requirements/CE-REQ-EXPL-FILTER-SUPER-001.md
+++ b/development/capabilities/requirements/CE-REQ-EXPL-FILTER-SUPER-001.md
@@ -7,6 +7,7 @@
 | requirement_id | CE-REQ-EXPL-FILTER-SUPER-001 |
 | obligation_type | api_contract |
 | claim_refs | CE-CAP-EXPL-FILTER-001 |
+| adr_refs | ADR-008 |
 | status | active |
 | applicable_on | collection (AlternativeExplanations) and individual (AlternativeExplanation) |
 | supersedes | CE-REQ-EXPL-ENSURED-API-001 (partial) |

--- a/development/capabilities/requirements/CE-REQ-EXPL-PAPER-SEMANTICS-001.md
+++ b/development/capabilities/requirements/CE-REQ-EXPL-PAPER-SEMANTICS-001.md
@@ -1,0 +1,66 @@
+# CE-REQ-EXPL-PAPER-SEMANTICS-001 — Factual and alternative explanations preserve the paper-aligned factual-condition and alternative-condition semantics.
+
+## Metadata
+
+| Field | Value |
+|---|---|
+| requirement_id | CE-REQ-EXPL-PAPER-SEMANTICS-001 |
+| obligation_type | api_contract |
+| claim_refs | CE-CAP-EXPL-PAPER-SEMANTICS-001 |
+| adr_refs | ADR-008 |
+| status | active |
+| verification_status | manual_review_required |
+
+## Scope
+
+ADR-governed implementation, documentation, and verification artifacts for `ADR-008`.
+
+## Observable behavior
+
+Factual and alternative explanation generation MUST preserve ADR-008 paper-aligned semantics for factual conditions and alternative conditions.
+
+## Acceptance criterion
+
+Behavioral acceptance for this requirement is the ADR-specific obligation itself:
+
+- Factual and alternative explanation generation MUST preserve ADR-008 paper-aligned semantics for factual conditions and alternative conditions.
+- Automated metadata tests MAY prove that the requirement is linked, but MUST NOT be
+  treated as proof that the behavioral obligation is satisfied.
+- Until a named runtime, static-policy, serialization, schema, or quality-gate check below
+  directly verifies the obligation, the verification status remains `manual_review_required`.
+
+## Verification method
+
+Verification method: `manual_review` plus the concrete source, documentation, schema,
+quality-script, or pytest targets listed below. Metadata tests are linkage guards only.
+
+## Verification targets
+
+- source: `development/adrs/ADR-008*.md`
+- schema: `development/schemas/primitives_schema.json`
+- docs: `docs/schema_v1.md`
+- docs: `docs/foundations/concepts/explanation_structures.md`
+- metadata_test: `tests/capabilities/test_adr_capability_links.py::test_should_validate_adr_claim_requirement_link_metadata`
+- metadata_test: `tests/capabilities/test_adr_capability_links.py::test_should_validate_curated_semantic_claim_presence`
+- manual_review: `development/current-work/RELEASE_PLAN_status_appendix.md` (ADR-008 section)
+
+Test IDs:
+- `test_should_validate_adr_claim_requirement_link_metadata`
+- `test_should_validate_curated_semantic_claim_presence`
+- `test_should_require_behavioral_requirements_to_name_concrete_evidence`
+- `test_should_prevent_runtime_obligations_from_using_documentation_boundary_type`
+
+## Evidence required
+
+| Field | Required |
+|---|---|
+| commit_sha | yes |
+| package_version | yes |
+| test_id | yes |
+| result | yes (pass/fail/partial) |
+
+## Assumption boundary
+
+This requirement captures the normative ADR obligation and its evidence chain. It does not
+claim that metadata checks alone prove runtime correctness; behavior remains verified by the
+specific source, test, documentation, or quality-script evidence maintained for `ADR-008`.

--- a/development/capabilities/requirements/CE-REQ-EXPLAINER-STATE-PERSISTENCE-001.md
+++ b/development/capabilities/requirements/CE-REQ-EXPLAINER-STATE-PERSISTENCE-001.md
@@ -1,0 +1,65 @@
+# CE-REQ-EXPLAINER-STATE-PERSISTENCE-001 — Explainer state persistence captures calibration state, preprocessing mappings, plugin identifiers, RNG/determinism state, manifest metadata, timestamps, and checksums.
+
+## Metadata
+
+| Field | Value |
+|---|---|
+| requirement_id | CE-REQ-EXPLAINER-STATE-PERSISTENCE-001 |
+| obligation_type | serialization_contract |
+| claim_refs | CE-CAP-EXPLAINER-STATE-PERSISTENCE-001 |
+| adr_refs | ADR-031 |
+| status | active |
+| verification_status | manual_review_required |
+
+## Scope
+
+ADR-governed implementation, documentation, and verification artifacts for `ADR-031`.
+
+## Observable behavior
+
+Explainer save/load state MUST capture the ADR-031 manifest fields needed to reconstruct calibrated behavior, including preprocessing mappings, plugin identifiers, deterministic state, timestamps, and checksums.
+
+## Acceptance criterion
+
+Behavioral acceptance for this requirement is the ADR-specific obligation itself:
+
+- Explainer save/load state MUST capture the ADR-031 manifest fields needed to reconstruct calibrated behavior, including preprocessing mappings, plugin identifiers, deterministic state, timestamps, and checksums.
+- Automated metadata tests MAY prove that the requirement is linked, but MUST NOT be
+  treated as proof that the behavioral obligation is satisfied.
+- Until a named runtime, static-policy, serialization, schema, or quality-gate check below
+  directly verifies the obligation, the verification status remains `manual_review_required`.
+
+## Verification method
+
+Verification method: `manual_review` plus the concrete source, documentation, schema,
+quality-script, or pytest targets listed below. Metadata tests are linkage guards only.
+
+## Verification targets
+
+- source: `development/adrs/ADR-031*.md`
+- docs: `docs/api/serialization.md`
+- schema: `development/schemas/primitives_schema.json`
+- metadata_test: `tests/capabilities/test_adr_capability_links.py::test_should_validate_adr_claim_requirement_link_metadata`
+- metadata_test: `tests/capabilities/test_adr_capability_links.py::test_should_validate_curated_semantic_claim_presence`
+- manual_review: `development/current-work/RELEASE_PLAN_status_appendix.md` (ADR-031 section)
+
+Test IDs:
+- `test_should_validate_adr_claim_requirement_link_metadata`
+- `test_should_validate_curated_semantic_claim_presence`
+- `test_should_require_behavioral_requirements_to_name_concrete_evidence`
+- `test_should_prevent_runtime_obligations_from_using_documentation_boundary_type`
+
+## Evidence required
+
+| Field | Required |
+|---|---|
+| commit_sha | yes |
+| package_version | yes |
+| test_id | yes |
+| result | yes (pass/fail/partial) |
+
+## Assumption boundary
+
+This requirement captures the normative ADR obligation and its evidence chain. It does not
+claim that metadata checks alone prove runtime correctness; behavior remains verified by the
+specific source, test, documentation, or quality-script evidence maintained for `ADR-031`.

--- a/development/capabilities/requirements/CE-REQ-FAST-INTERVAL-PLUGIN-001.md
+++ b/development/capabilities/requirements/CE-REQ-FAST-INTERVAL-PLUGIN-001.md
@@ -1,0 +1,66 @@
+# CE-REQ-FAST-INTERVAL-PLUGIN-001 — core.interval.fast is opt-in and never part of the primary interval fallback chain.
+
+## Metadata
+
+| Field | Value |
+|---|---|
+| requirement_id | CE-REQ-FAST-INTERVAL-PLUGIN-001 |
+| obligation_type | api_contract |
+| claim_refs | CE-CAP-FAST-INTERVAL-PLUGIN-001 |
+| adr_refs | ADR-013 |
+| status | active |
+| verification_status | manual_review_required |
+
+## Scope
+
+ADR-governed implementation, documentation, and verification artifacts for `ADR-013`.
+
+## Observable behavior
+
+The core.interval.fast plugin MUST be opt-in and MUST NOT participate in the primary fallback chain.
+
+## Acceptance criterion
+
+Behavioral acceptance for this requirement is the ADR-specific obligation itself:
+
+- The core.interval.fast plugin MUST be opt-in and MUST NOT participate in the primary fallback chain.
+- Automated metadata tests MAY prove that the requirement is linked, but MUST NOT be
+  treated as proof that the behavioral obligation is satisfied.
+- Until a named runtime, static-policy, serialization, schema, or quality-gate check below
+  directly verifies the obligation, the verification status remains `manual_review_required`.
+
+## Verification method
+
+Verification method: `manual_review` plus the concrete source, documentation, schema,
+quality-script, or pytest targets listed below. Metadata tests are linkage guards only.
+
+## Verification targets
+
+- source: `development/adrs/ADR-013*.md`
+- quality_script: `scripts/quality/check_trust_mutation_primitive.py`
+- docs: `docs/api/plugins.md`
+- docs: `docs/practitioner/advanced/modality-plugins.md`
+- metadata_test: `tests/capabilities/test_adr_capability_links.py::test_should_validate_adr_claim_requirement_link_metadata`
+- metadata_test: `tests/capabilities/test_adr_capability_links.py::test_should_validate_curated_semantic_claim_presence`
+- manual_review: `development/current-work/RELEASE_PLAN_status_appendix.md` (ADR-013 section)
+
+Test IDs:
+- `test_should_validate_adr_claim_requirement_link_metadata`
+- `test_should_validate_curated_semantic_claim_presence`
+- `test_should_require_behavioral_requirements_to_name_concrete_evidence`
+- `test_should_prevent_runtime_obligations_from_using_documentation_boundary_type`
+
+## Evidence required
+
+| Field | Required |
+|---|---|
+| commit_sha | yes |
+| package_version | yes |
+| test_id | yes |
+| result | yes (pass/fail/partial) |
+
+## Assumption boundary
+
+This requirement captures the normative ADR obligation and its evidence chain. It does not
+claim that metadata checks alone prove runtime correctness; behavior remains verified by the
+specific source, test, documentation, or quality-script evidence maintained for `ADR-013`.

--- a/development/capabilities/requirements/CE-REQ-GOVERNANCE-LOG-SEPARATION-001.md
+++ b/development/capabilities/requirements/CE-REQ-GOVERNANCE-LOG-SEPARATION-001.md
@@ -1,0 +1,65 @@
+# CE-REQ-GOVERNANCE-LOG-SEPARATION-001 — Governance events and operational logs remain separated by domain and purpose.
+
+## Metadata
+
+| Field | Value |
+|---|---|
+| requirement_id | CE-REQ-GOVERNANCE-LOG-SEPARATION-001 |
+| obligation_type | static_policy |
+| claim_refs | CE-CAP-GOVERNANCE-LOG-SEPARATION-001 |
+| adr_refs | ADR-028 |
+| status | active |
+| verification_status | manual_review_required |
+
+## Scope
+
+ADR-governed implementation, documentation, and verification artifacts for `ADR-028`.
+
+## Observable behavior
+
+Governance events MUST remain separated from operational logs so audit records are not conflated with routine diagnostics.
+
+## Acceptance criterion
+
+Behavioral acceptance for this requirement is the ADR-specific obligation itself:
+
+- Governance events MUST remain separated from operational logs so audit records are not conflated with routine diagnostics.
+- Automated metadata tests MAY prove that the requirement is linked, but MUST NOT be
+  treated as proof that the behavioral obligation is satisfied.
+- Until a named runtime, static-policy, serialization, schema, or quality-gate check below
+  directly verifies the obligation, the verification status remains `manual_review_required`.
+
+## Verification method
+
+Verification method: `manual_review` plus the concrete source, documentation, schema,
+quality-script, or pytest targets listed below. Metadata tests are linkage guards only.
+
+## Verification targets
+
+- source: `development/adrs/ADR-028*.md`
+- quality_script: `scripts/quality/check_logging_domains.py`
+- standard: `development/standards/STD-005-logging-and-observability-standard.md`
+- metadata_test: `tests/capabilities/test_adr_capability_links.py::test_should_validate_adr_claim_requirement_link_metadata`
+- metadata_test: `tests/capabilities/test_adr_capability_links.py::test_should_validate_curated_semantic_claim_presence`
+- manual_review: `development/current-work/RELEASE_PLAN_status_appendix.md` (ADR-028 section)
+
+Test IDs:
+- `test_should_validate_adr_claim_requirement_link_metadata`
+- `test_should_validate_curated_semantic_claim_presence`
+- `test_should_require_behavioral_requirements_to_name_concrete_evidence`
+- `test_should_prevent_runtime_obligations_from_using_documentation_boundary_type`
+
+## Evidence required
+
+| Field | Required |
+|---|---|
+| commit_sha | yes |
+| package_version | yes |
+| test_id | yes |
+| result | yes (pass/fail/partial) |
+
+## Assumption boundary
+
+This requirement captures the normative ADR obligation and its evidence chain. It does not
+claim that metadata checks alone prove runtime correctness; behavior remains verified by the
+specific source, test, documentation, or quality-script evidence maintained for `ADR-028`.

--- a/development/capabilities/requirements/CE-REQ-GUARD-API-001.md
+++ b/development/capabilities/requirements/CE-REQ-GUARD-API-001.md
@@ -7,6 +7,7 @@
 | requirement_id | CE-REQ-GUARD-API-001 |
 | obligation_type | api_contract |
 | claim_refs | CE-CAP-GUARD-001 |
+| adr_refs | ADR-032, ADR-038 |
 | status | active |
 
 ## Scope

--- a/development/capabilities/requirements/CE-REQ-GUARD-AUDIT-001.md
+++ b/development/capabilities/requirements/CE-REQ-GUARD-AUDIT-001.md
@@ -1,0 +1,65 @@
+# CE-REQ-GUARD-AUDIT-001 — Guarded outputs expose get_guarded_audit() with interval-level and summary records.
+
+## Metadata
+
+| Field | Value |
+|---|---|
+| requirement_id | CE-REQ-GUARD-AUDIT-001 |
+| obligation_type | api_contract |
+| claim_refs | CE-CAP-GUARD-AUDIT-001 |
+| adr_refs | ADR-032 |
+| status | active |
+| verification_status | manual_review_required |
+
+## Scope
+
+ADR-governed implementation, documentation, and verification artifacts for `ADR-032`.
+
+## Observable behavior
+
+Guarded explanation collections MUST expose get_guarded_audit() records containing interval-level details and summary information for reviewed guarded outputs.
+
+## Acceptance criterion
+
+Behavioral acceptance for this requirement is the ADR-specific obligation itself:
+
+- Guarded explanation collections MUST expose get_guarded_audit() records containing interval-level details and summary information for reviewed guarded outputs.
+- Automated metadata tests MAY prove that the requirement is linked, but MUST NOT be
+  treated as proof that the behavioral obligation is satisfied.
+- Until a named runtime, static-policy, serialization, schema, or quality-gate check below
+  directly verifies the obligation, the verification status remains `manual_review_required`.
+
+## Verification method
+
+Verification method: `manual_review` plus the concrete source, documentation, schema,
+quality-script, or pytest targets listed below. Metadata tests are linkage guards only.
+
+## Verification targets
+
+- source: `development/adrs/ADR-032*.md`
+- docs: `docs/foundations/concepts/guarded_explanations.md`
+- docs: `docs/get-started/quickstart_guarded.md`
+- metadata_test: `tests/capabilities/test_adr_capability_links.py::test_should_validate_adr_claim_requirement_link_metadata`
+- metadata_test: `tests/capabilities/test_adr_capability_links.py::test_should_validate_curated_semantic_claim_presence`
+- manual_review: `development/current-work/RELEASE_PLAN_status_appendix.md` (ADR-032 section)
+
+Test IDs:
+- `test_should_validate_adr_claim_requirement_link_metadata`
+- `test_should_validate_curated_semantic_claim_presence`
+- `test_should_require_behavioral_requirements_to_name_concrete_evidence`
+- `test_should_prevent_runtime_obligations_from_using_documentation_boundary_type`
+
+## Evidence required
+
+| Field | Required |
+|---|---|
+| commit_sha | yes |
+| package_version | yes |
+| test_id | yes |
+| result | yes (pass/fail/partial) |
+
+## Assumption boundary
+
+This requirement captures the normative ADR obligation and its evidence chain. It does not
+claim that metadata checks alone prove runtime correctness; behavior remains verified by the
+specific source, test, documentation, or quality-script evidence maintained for `ADR-032`.

--- a/development/capabilities/requirements/CE-REQ-GUARD-CALIBRATION-ALIGNMENT-001.md
+++ b/development/capabilities/requirements/CE-REQ-GUARD-CALIBRATION-ALIGNMENT-001.md
@@ -1,0 +1,65 @@
+# CE-REQ-GUARD-CALIBRATION-ALIGNMENT-001 — Guarded execution requires calibration-feature alignment and fails hard on unavailable or mismatched calibration features.
+
+## Metadata
+
+| Field | Value |
+|---|---|
+| requirement_id | CE-REQ-GUARD-CALIBRATION-ALIGNMENT-001 |
+| obligation_type | api_contract |
+| claim_refs | CE-CAP-GUARD-CALIBRATION-ALIGNMENT-001 |
+| adr_refs | ADR-032 |
+| status | active |
+| verification_status | manual_review_required |
+
+## Scope
+
+ADR-governed implementation, documentation, and verification artifacts for `ADR-032`.
+
+## Observable behavior
+
+Guarded execution MUST validate calibration feature availability and alignment and MUST fail with an explicit error when required calibration features are unavailable or mismatched.
+
+## Acceptance criterion
+
+Behavioral acceptance for this requirement is the ADR-specific obligation itself:
+
+- Guarded execution MUST validate calibration feature availability and alignment and MUST fail with an explicit error when required calibration features are unavailable or mismatched.
+- Automated metadata tests MAY prove that the requirement is linked, but MUST NOT be
+  treated as proof that the behavioral obligation is satisfied.
+- Until a named runtime, static-policy, serialization, schema, or quality-gate check below
+  directly verifies the obligation, the verification status remains `manual_review_required`.
+
+## Verification method
+
+Verification method: `manual_review` plus the concrete source, documentation, schema,
+quality-script, or pytest targets listed below. Metadata tests are linkage guards only.
+
+## Verification targets
+
+- source: `development/adrs/ADR-032*.md`
+- docs: `docs/foundations/concepts/guarded_explanations.md`
+- docs: `docs/get-started/quickstart_guarded.md`
+- metadata_test: `tests/capabilities/test_adr_capability_links.py::test_should_validate_adr_claim_requirement_link_metadata`
+- metadata_test: `tests/capabilities/test_adr_capability_links.py::test_should_validate_curated_semantic_claim_presence`
+- manual_review: `development/current-work/RELEASE_PLAN_status_appendix.md` (ADR-032 section)
+
+Test IDs:
+- `test_should_validate_adr_claim_requirement_link_metadata`
+- `test_should_validate_curated_semantic_claim_presence`
+- `test_should_require_behavioral_requirements_to_name_concrete_evidence`
+- `test_should_prevent_runtime_obligations_from_using_documentation_boundary_type`
+
+## Evidence required
+
+| Field | Required |
+|---|---|
+| commit_sha | yes |
+| package_version | yes |
+| test_id | yes |
+| result | yes (pass/fail/partial) |
+
+## Assumption boundary
+
+This requirement captures the normative ADR obligation and its evidence chain. It does not
+claim that metadata checks alone prove runtime correctness; behavior remains verified by the
+specific source, test, documentation, or quality-script evidence maintained for `ADR-032`.

--- a/development/capabilities/requirements/CE-REQ-GUARD-CONJUNCTION-001.md
+++ b/development/capabilities/requirements/CE-REQ-GUARD-CONJUNCTION-001.md
@@ -1,0 +1,65 @@
+# CE-REQ-GUARD-CONJUNCTION-001 — Guarded conjunctions use joint representative perturbations and append conjunction audit records.
+
+## Metadata
+
+| Field | Value |
+|---|---|
+| requirement_id | CE-REQ-GUARD-CONJUNCTION-001 |
+| obligation_type | api_contract |
+| claim_refs | CE-CAP-GUARD-CONJUNCTION-001 |
+| adr_refs | ADR-032 |
+| status | active |
+| verification_status | manual_review_required |
+
+## Scope
+
+ADR-governed implementation, documentation, and verification artifacts for `ADR-032`.
+
+## Observable behavior
+
+Guarded conjunction generation MUST evaluate joint representative perturbations and MUST append audit records for conjunction decisions.
+
+## Acceptance criterion
+
+Behavioral acceptance for this requirement is the ADR-specific obligation itself:
+
+- Guarded conjunction generation MUST evaluate joint representative perturbations and MUST append audit records for conjunction decisions.
+- Automated metadata tests MAY prove that the requirement is linked, but MUST NOT be
+  treated as proof that the behavioral obligation is satisfied.
+- Until a named runtime, static-policy, serialization, schema, or quality-gate check below
+  directly verifies the obligation, the verification status remains `manual_review_required`.
+
+## Verification method
+
+Verification method: `manual_review` plus the concrete source, documentation, schema,
+quality-script, or pytest targets listed below. Metadata tests are linkage guards only.
+
+## Verification targets
+
+- source: `development/adrs/ADR-032*.md`
+- docs: `docs/foundations/concepts/guarded_explanations.md`
+- docs: `docs/get-started/quickstart_guarded.md`
+- metadata_test: `tests/capabilities/test_adr_capability_links.py::test_should_validate_adr_claim_requirement_link_metadata`
+- metadata_test: `tests/capabilities/test_adr_capability_links.py::test_should_validate_curated_semantic_claim_presence`
+- manual_review: `development/current-work/RELEASE_PLAN_status_appendix.md` (ADR-032 section)
+
+Test IDs:
+- `test_should_validate_adr_claim_requirement_link_metadata`
+- `test_should_validate_curated_semantic_claim_presence`
+- `test_should_require_behavioral_requirements_to_name_concrete_evidence`
+- `test_should_prevent_runtime_obligations_from_using_documentation_boundary_type`
+
+## Evidence required
+
+| Field | Required |
+|---|---|
+| commit_sha | yes |
+| package_version | yes |
+| test_id | yes |
+| result | yes (pass/fail/partial) |
+
+## Assumption boundary
+
+This requirement captures the normative ADR obligation and its evidence chain. It does not
+claim that metadata checks alone prove runtime correctness; behavior remains verified by the
+specific source, test, documentation, or quality-script evidence maintained for `ADR-032`.

--- a/development/capabilities/requirements/CE-REQ-GUARD-MEDIAN-PROBE-001.md
+++ b/development/capabilities/requirements/CE-REQ-GUARD-MEDIAN-PROBE-001.md
@@ -1,0 +1,65 @@
+# CE-REQ-GUARD-MEDIAN-PROBE-001 — Guardedness is defined by the single median-probe rule; emitted intervals do not certify every point inside the interval.
+
+## Metadata
+
+| Field | Value |
+|---|---|
+| requirement_id | CE-REQ-GUARD-MEDIAN-PROBE-001 |
+| obligation_type | api_contract |
+| claim_refs | CE-CAP-GUARD-MEDIAN-PROBE-001 |
+| adr_refs | ADR-032 |
+| status | active |
+| verification_status | manual_review_required |
+
+## Scope
+
+ADR-governed implementation, documentation, and verification artifacts for `ADR-032`.
+
+## Observable behavior
+
+Guarded explanation logic MUST use the ADR-032 single median-probe semantics and documentation MUST NOT imply that every point inside an emitted interval is certified.
+
+## Acceptance criterion
+
+Behavioral acceptance for this requirement is the ADR-specific obligation itself:
+
+- Guarded explanation logic MUST use the ADR-032 single median-probe semantics and documentation MUST NOT imply that every point inside an emitted interval is certified.
+- Automated metadata tests MAY prove that the requirement is linked, but MUST NOT be
+  treated as proof that the behavioral obligation is satisfied.
+- Until a named runtime, static-policy, serialization, schema, or quality-gate check below
+  directly verifies the obligation, the verification status remains `manual_review_required`.
+
+## Verification method
+
+Verification method: `manual_review` plus the concrete source, documentation, schema,
+quality-script, or pytest targets listed below. Metadata tests are linkage guards only.
+
+## Verification targets
+
+- source: `development/adrs/ADR-032*.md`
+- docs: `docs/foundations/concepts/guarded_explanations.md`
+- docs: `docs/get-started/quickstart_guarded.md`
+- metadata_test: `tests/capabilities/test_adr_capability_links.py::test_should_validate_adr_claim_requirement_link_metadata`
+- metadata_test: `tests/capabilities/test_adr_capability_links.py::test_should_validate_curated_semantic_claim_presence`
+- manual_review: `development/current-work/RELEASE_PLAN_status_appendix.md` (ADR-032 section)
+
+Test IDs:
+- `test_should_validate_adr_claim_requirement_link_metadata`
+- `test_should_validate_curated_semantic_claim_presence`
+- `test_should_require_behavioral_requirements_to_name_concrete_evidence`
+- `test_should_prevent_runtime_obligations_from_using_documentation_boundary_type`
+
+## Evidence required
+
+| Field | Required |
+|---|---|
+| commit_sha | yes |
+| package_version | yes |
+| test_id | yes |
+| result | yes (pass/fail/partial) |
+
+## Assumption boundary
+
+This requirement captures the normative ADR obligation and its evidence chain. It does not
+claim that metadata checks alone prove runtime correctness; behavior remains verified by the
+specific source, test, documentation, or quality-script evidence maintained for `ADR-032`.

--- a/development/capabilities/requirements/CE-REQ-GUARD-NO-FAST-001.md
+++ b/development/capabilities/requirements/CE-REQ-GUARD-NO-FAST-001.md
@@ -1,0 +1,65 @@
+# CE-REQ-GUARD-NO-FAST-001 — Guarded explanations are unsupported for fast explainers and fail with ConfigurationError.
+
+## Metadata
+
+| Field | Value |
+|---|---|
+| requirement_id | CE-REQ-GUARD-NO-FAST-001 |
+| obligation_type | api_contract |
+| claim_refs | CE-CAP-GUARD-NO-FAST-001 |
+| adr_refs | ADR-032 |
+| status | active |
+| verification_status | manual_review_required |
+
+## Scope
+
+ADR-governed implementation, documentation, and verification artifacts for `ADR-032`.
+
+## Observable behavior
+
+Guarded explanation calls MUST reject fast explainers with ConfigurationError rather than silently degrading to an unsupported guarded path.
+
+## Acceptance criterion
+
+Behavioral acceptance for this requirement is the ADR-specific obligation itself:
+
+- Guarded explanation calls MUST reject fast explainers with ConfigurationError rather than silently degrading to an unsupported guarded path.
+- Automated metadata tests MAY prove that the requirement is linked, but MUST NOT be
+  treated as proof that the behavioral obligation is satisfied.
+- Until a named runtime, static-policy, serialization, schema, or quality-gate check below
+  directly verifies the obligation, the verification status remains `manual_review_required`.
+
+## Verification method
+
+Verification method: `manual_review` plus the concrete source, documentation, schema,
+quality-script, or pytest targets listed below. Metadata tests are linkage guards only.
+
+## Verification targets
+
+- source: `development/adrs/ADR-032*.md`
+- docs: `docs/foundations/concepts/guarded_explanations.md`
+- docs: `docs/get-started/quickstart_guarded.md`
+- metadata_test: `tests/capabilities/test_adr_capability_links.py::test_should_validate_adr_claim_requirement_link_metadata`
+- metadata_test: `tests/capabilities/test_adr_capability_links.py::test_should_validate_curated_semantic_claim_presence`
+- manual_review: `development/current-work/RELEASE_PLAN_status_appendix.md` (ADR-032 section)
+
+Test IDs:
+- `test_should_validate_adr_claim_requirement_link_metadata`
+- `test_should_validate_curated_semantic_claim_presence`
+- `test_should_require_behavioral_requirements_to_name_concrete_evidence`
+- `test_should_prevent_runtime_obligations_from_using_documentation_boundary_type`
+
+## Evidence required
+
+| Field | Required |
+|---|---|
+| commit_sha | yes |
+| package_version | yes |
+| test_id | yes |
+| result | yes (pass/fail/partial) |
+
+## Assumption boundary
+
+This requirement captures the normative ADR obligation and its evidence chain. It does not
+claim that metadata checks alone prove runtime correctness; behavior remains verified by the
+specific source, test, documentation, or quality-script evidence maintained for `ADR-032`.

--- a/development/capabilities/requirements/CE-REQ-GUARD-PLUGIN-SUPPORT-001.md
+++ b/development/capabilities/requirements/CE-REQ-GUARD-PLUGIN-SUPPORT-001.md
@@ -1,0 +1,66 @@
+# CE-REQ-GUARD-PLUGIN-SUPPORT-001 — Plugin guarded support is expressed only through supports_guarded; missing metadata defaults to false and unguarded plugins must not be silently selected.
+
+## Metadata
+
+| Field | Value |
+|---|---|
+| requirement_id | CE-REQ-GUARD-PLUGIN-SUPPORT-001 |
+| obligation_type | api_contract |
+| claim_refs | CE-CAP-GUARD-PLUGIN-SUPPORT-001 |
+| adr_refs | ADR-032 |
+| status | active |
+| verification_status | manual_review_required |
+
+## Scope
+
+ADR-governed implementation, documentation, and verification artifacts for `ADR-032`.
+
+## Observable behavior
+
+Plugin guarded eligibility MUST be driven by supports_guarded metadata, missing metadata MUST default to false, and unguarded plugins MUST NOT be silently selected for guarded execution.
+
+## Acceptance criterion
+
+Behavioral acceptance for this requirement is the ADR-specific obligation itself:
+
+- Plugin guarded eligibility MUST be driven by supports_guarded metadata, missing metadata MUST default to false, and unguarded plugins MUST NOT be silently selected for guarded execution.
+- Automated metadata tests MAY prove that the requirement is linked, but MUST NOT be
+  treated as proof that the behavioral obligation is satisfied.
+- Until a named runtime, static-policy, serialization, schema, or quality-gate check below
+  directly verifies the obligation, the verification status remains `manual_review_required`.
+
+## Verification method
+
+Verification method: `manual_review` plus the concrete source, documentation, schema,
+quality-script, or pytest targets listed below. Metadata tests are linkage guards only.
+
+## Verification targets
+
+- source: `development/adrs/ADR-032*.md`
+- quality_script: `scripts/quality/check_trust_mutation_primitive.py`
+- docs: `docs/api/plugins.md`
+- docs: `docs/practitioner/advanced/modality-plugins.md`
+- metadata_test: `tests/capabilities/test_adr_capability_links.py::test_should_validate_adr_claim_requirement_link_metadata`
+- metadata_test: `tests/capabilities/test_adr_capability_links.py::test_should_validate_curated_semantic_claim_presence`
+- manual_review: `development/current-work/RELEASE_PLAN_status_appendix.md` (ADR-032 section)
+
+Test IDs:
+- `test_should_validate_adr_claim_requirement_link_metadata`
+- `test_should_validate_curated_semantic_claim_presence`
+- `test_should_require_behavioral_requirements_to_name_concrete_evidence`
+- `test_should_prevent_runtime_obligations_from_using_documentation_boundary_type`
+
+## Evidence required
+
+| Field | Required |
+|---|---|
+| commit_sha | yes |
+| package_version | yes |
+| test_id | yes |
+| result | yes (pass/fail/partial) |
+
+## Assumption boundary
+
+This requirement captures the normative ADR obligation and its evidence chain. It does not
+claim that metadata checks alone prove runtime correctness; behavior remains verified by the
+specific source, test, documentation, or quality-script evidence maintained for `ADR-032`.

--- a/development/capabilities/requirements/CE-REQ-INTERVAL-CONTEXT-IMMUTABILITY-001.md
+++ b/development/capabilities/requirements/CE-REQ-INTERVAL-CONTEXT-IMMUTABILITY-001.md
@@ -1,0 +1,66 @@
+# CE-REQ-INTERVAL-CONTEXT-IMMUTABILITY-001 — IntervalCalibratorContext exposes frozen/read-only calibration state and plugin-local scratch state without mutating the explainer.
+
+## Metadata
+
+| Field | Value |
+|---|---|
+| requirement_id | CE-REQ-INTERVAL-CONTEXT-IMMUTABILITY-001 |
+| obligation_type | api_contract |
+| claim_refs | CE-CAP-INTERVAL-CONTEXT-IMMUTABILITY-001 |
+| adr_refs | ADR-013 |
+| status | active |
+| verification_status | manual_review_required |
+
+## Scope
+
+ADR-governed implementation, documentation, and verification artifacts for `ADR-013`.
+
+## Observable behavior
+
+IntervalCalibratorContext MUST expose calibration state as read-only context and plugin scratch state MUST NOT mutate explainer-owned calibration state.
+
+## Acceptance criterion
+
+Behavioral acceptance for this requirement is the ADR-specific obligation itself:
+
+- IntervalCalibratorContext MUST expose calibration state as read-only context and plugin scratch state MUST NOT mutate explainer-owned calibration state.
+- Automated metadata tests MAY prove that the requirement is linked, but MUST NOT be
+  treated as proof that the behavioral obligation is satisfied.
+- Until a named runtime, static-policy, serialization, schema, or quality-gate check below
+  directly verifies the obligation, the verification status remains `manual_review_required`.
+
+## Verification method
+
+Verification method: `manual_review` plus the concrete source, documentation, schema,
+quality-script, or pytest targets listed below. Metadata tests are linkage guards only.
+
+## Verification targets
+
+- source: `development/adrs/ADR-013*.md`
+- quality_script: `scripts/quality/check_trust_mutation_primitive.py`
+- docs: `docs/api/plugins.md`
+- docs: `docs/practitioner/advanced/modality-plugins.md`
+- metadata_test: `tests/capabilities/test_adr_capability_links.py::test_should_validate_adr_claim_requirement_link_metadata`
+- metadata_test: `tests/capabilities/test_adr_capability_links.py::test_should_validate_curated_semantic_claim_presence`
+- manual_review: `development/current-work/RELEASE_PLAN_status_appendix.md` (ADR-013 section)
+
+Test IDs:
+- `test_should_validate_adr_claim_requirement_link_metadata`
+- `test_should_validate_curated_semantic_claim_presence`
+- `test_should_require_behavioral_requirements_to_name_concrete_evidence`
+- `test_should_prevent_runtime_obligations_from_using_documentation_boundary_type`
+
+## Evidence required
+
+| Field | Required |
+|---|---|
+| commit_sha | yes |
+| package_version | yes |
+| test_id | yes |
+| result | yes (pass/fail/partial) |
+
+## Assumption boundary
+
+This requirement captures the normative ADR obligation and its evidence chain. It does not
+claim that metadata checks alone prove runtime correctness; behavior remains verified by the
+specific source, test, documentation, or quality-script evidence maintained for `ADR-013`.

--- a/development/capabilities/requirements/CE-REQ-INTERVAL-PLUGIN-FALLBACK-001.md
+++ b/development/capabilities/requirements/CE-REQ-INTERVAL-PLUGIN-FALLBACK-001.md
@@ -1,0 +1,66 @@
+# CE-REQ-INTERVAL-PLUGIN-FALLBACK-001 — core.interval.legacy remains the trusted mandatory interval calibrator fallback.
+
+## Metadata
+
+| Field | Value |
+|---|---|
+| requirement_id | CE-REQ-INTERVAL-PLUGIN-FALLBACK-001 |
+| obligation_type | api_contract |
+| claim_refs | CE-CAP-INTERVAL-PLUGIN-FALLBACK-001 |
+| adr_refs | ADR-013 |
+| status | active |
+| verification_status | manual_review_required |
+
+## Scope
+
+ADR-governed implementation, documentation, and verification artifacts for `ADR-013`.
+
+## Observable behavior
+
+The trusted core.interval.legacy calibrator MUST remain available as the mandatory fallback for interval plugin resolution.
+
+## Acceptance criterion
+
+Behavioral acceptance for this requirement is the ADR-specific obligation itself:
+
+- The trusted core.interval.legacy calibrator MUST remain available as the mandatory fallback for interval plugin resolution.
+- Automated metadata tests MAY prove that the requirement is linked, but MUST NOT be
+  treated as proof that the behavioral obligation is satisfied.
+- Until a named runtime, static-policy, serialization, schema, or quality-gate check below
+  directly verifies the obligation, the verification status remains `manual_review_required`.
+
+## Verification method
+
+Verification method: `manual_review` plus the concrete source, documentation, schema,
+quality-script, or pytest targets listed below. Metadata tests are linkage guards only.
+
+## Verification targets
+
+- source: `development/adrs/ADR-013*.md`
+- quality_script: `scripts/quality/check_trust_mutation_primitive.py`
+- docs: `docs/api/plugins.md`
+- docs: `docs/practitioner/advanced/modality-plugins.md`
+- metadata_test: `tests/capabilities/test_adr_capability_links.py::test_should_validate_adr_claim_requirement_link_metadata`
+- metadata_test: `tests/capabilities/test_adr_capability_links.py::test_should_validate_curated_semantic_claim_presence`
+- manual_review: `development/current-work/RELEASE_PLAN_status_appendix.md` (ADR-013 section)
+
+Test IDs:
+- `test_should_validate_adr_claim_requirement_link_metadata`
+- `test_should_validate_curated_semantic_claim_presence`
+- `test_should_require_behavioral_requirements_to_name_concrete_evidence`
+- `test_should_prevent_runtime_obligations_from_using_documentation_boundary_type`
+
+## Evidence required
+
+| Field | Required |
+|---|---|
+| commit_sha | yes |
+| package_version | yes |
+| test_id | yes |
+| result | yes (pass/fail/partial) |
+
+## Assumption boundary
+
+This requirement captures the normative ADR obligation and its evidence chain. It does not
+claim that metadata checks alone prove runtime correctness; behavior remains verified by the
+specific source, test, documentation, or quality-script evidence maintained for `ADR-013`.

--- a/development/capabilities/requirements/CE-REQ-INTERVAL-PLUGIN-PROTOCOL-001.md
+++ b/development/capabilities/requirements/CE-REQ-INTERVAL-PLUGIN-PROTOCOL-001.md
@@ -1,0 +1,66 @@
+# CE-REQ-INTERVAL-PLUGIN-PROTOCOL-001 — Interval plugins satisfy classification and regression calibrator protocols and output shapes.
+
+## Metadata
+
+| Field | Value |
+|---|---|
+| requirement_id | CE-REQ-INTERVAL-PLUGIN-PROTOCOL-001 |
+| obligation_type | api_contract |
+| claim_refs | CE-CAP-INTERVAL-PLUGIN-PROTOCOL-001 |
+| adr_refs | ADR-013 |
+| status | active |
+| verification_status | manual_review_required |
+
+## Scope
+
+ADR-governed implementation, documentation, and verification artifacts for `ADR-013`.
+
+## Observable behavior
+
+Interval plugins MUST satisfy the classification and regression interval calibrator protocol methods and MUST return outputs with the ADR-013 shapes for their task mode.
+
+## Acceptance criterion
+
+Behavioral acceptance for this requirement is the ADR-specific obligation itself:
+
+- Interval plugins MUST satisfy the classification and regression interval calibrator protocol methods and MUST return outputs with the ADR-013 shapes for their task mode.
+- Automated metadata tests MAY prove that the requirement is linked, but MUST NOT be
+  treated as proof that the behavioral obligation is satisfied.
+- Until a named runtime, static-policy, serialization, schema, or quality-gate check below
+  directly verifies the obligation, the verification status remains `manual_review_required`.
+
+## Verification method
+
+Verification method: `manual_review` plus the concrete source, documentation, schema,
+quality-script, or pytest targets listed below. Metadata tests are linkage guards only.
+
+## Verification targets
+
+- source: `development/adrs/ADR-013*.md`
+- quality_script: `scripts/quality/check_trust_mutation_primitive.py`
+- docs: `docs/api/plugins.md`
+- docs: `docs/practitioner/advanced/modality-plugins.md`
+- metadata_test: `tests/capabilities/test_adr_capability_links.py::test_should_validate_adr_claim_requirement_link_metadata`
+- metadata_test: `tests/capabilities/test_adr_capability_links.py::test_should_validate_curated_semantic_claim_presence`
+- manual_review: `development/current-work/RELEASE_PLAN_status_appendix.md` (ADR-013 section)
+
+Test IDs:
+- `test_should_validate_adr_claim_requirement_link_metadata`
+- `test_should_validate_curated_semantic_claim_presence`
+- `test_should_require_behavioral_requirements_to_name_concrete_evidence`
+- `test_should_prevent_runtime_obligations_from_using_documentation_boundary_type`
+
+## Evidence required
+
+| Field | Required |
+|---|---|
+| commit_sha | yes |
+| package_version | yes |
+| test_id | yes |
+| result | yes (pass/fail/partial) |
+
+## Assumption boundary
+
+This requirement captures the normative ADR obligation and its evidence chain. It does not
+claim that metadata checks alone prove runtime correctness; behavior remains verified by the
+specific source, test, documentation, or quality-script evidence maintained for `ADR-013`.

--- a/development/capabilities/requirements/CE-REQ-INTERVAL-PLUGIN-VALIDATION-001.md
+++ b/development/capabilities/requirements/CE-REQ-INTERVAL-PLUGIN-VALIDATION-001.md
@@ -1,0 +1,66 @@
+# CE-REQ-INTERVAL-PLUGIN-VALIDATION-001 — Interval plugin outputs are validated for shape, dtype, monotonicity, and protocol conformity; misconfiguration does not silently degrade calibration quality.
+
+## Metadata
+
+| Field | Value |
+|---|---|
+| requirement_id | CE-REQ-INTERVAL-PLUGIN-VALIDATION-001 |
+| obligation_type | api_contract |
+| claim_refs | CE-CAP-INTERVAL-PLUGIN-VALIDATION-001 |
+| adr_refs | ADR-013 |
+| status | active |
+| verification_status | manual_review_required |
+
+## Scope
+
+ADR-governed implementation, documentation, and verification artifacts for `ADR-013`.
+
+## Observable behavior
+
+Interval plugin invocation MUST validate output shape, dtype, monotonicity, and protocol conformity, and plugin misconfiguration MUST fail visibly rather than silently degrading calibration quality.
+
+## Acceptance criterion
+
+Behavioral acceptance for this requirement is the ADR-specific obligation itself:
+
+- Interval plugin invocation MUST validate output shape, dtype, monotonicity, and protocol conformity, and plugin misconfiguration MUST fail visibly rather than silently degrading calibration quality.
+- Automated metadata tests MAY prove that the requirement is linked, but MUST NOT be
+  treated as proof that the behavioral obligation is satisfied.
+- Until a named runtime, static-policy, serialization, schema, or quality-gate check below
+  directly verifies the obligation, the verification status remains `manual_review_required`.
+
+## Verification method
+
+Verification method: `manual_review` plus the concrete source, documentation, schema,
+quality-script, or pytest targets listed below. Metadata tests are linkage guards only.
+
+## Verification targets
+
+- source: `development/adrs/ADR-013*.md`
+- quality_script: `scripts/quality/check_trust_mutation_primitive.py`
+- docs: `docs/api/plugins.md`
+- docs: `docs/practitioner/advanced/modality-plugins.md`
+- metadata_test: `tests/capabilities/test_adr_capability_links.py::test_should_validate_adr_claim_requirement_link_metadata`
+- metadata_test: `tests/capabilities/test_adr_capability_links.py::test_should_validate_curated_semantic_claim_presence`
+- manual_review: `development/current-work/RELEASE_PLAN_status_appendix.md` (ADR-013 section)
+
+Test IDs:
+- `test_should_validate_adr_claim_requirement_link_metadata`
+- `test_should_validate_curated_semantic_claim_presence`
+- `test_should_require_behavioral_requirements_to_name_concrete_evidence`
+- `test_should_prevent_runtime_obligations_from_using_documentation_boundary_type`
+
+## Evidence required
+
+| Field | Required |
+|---|---|
+| commit_sha | yes |
+| package_version | yes |
+| test_id | yes |
+| result | yes (pass/fail/partial) |
+
+## Assumption boundary
+
+This requirement captures the normative ADR obligation and its evidence chain. It does not
+claim that metadata checks alone prove runtime correctness; behavior remains verified by the
+specific source, test, documentation, or quality-script evidence maintained for `ADR-013`.

--- a/development/capabilities/requirements/CE-REQ-LEGACY-GOV-001.md
+++ b/development/capabilities/requirements/CE-REQ-LEGACY-GOV-001.md
@@ -1,0 +1,55 @@
+# CE-REQ-LEGACY-GOV-001 — ADR Governance Linkage Contract
+
+## Metadata
+
+| Field | Value |
+|---|---|
+| requirement_id | CE-REQ-LEGACY-GOV-001 |
+| obligation_type | documentation_boundary |
+| claim_refs | CE-CAP-LEGACY-001 |
+| adr_refs | ADR-020 |
+| status | active |
+
+## Scope
+
+Development governance artifacts under `development/adrs/` and
+`development/capabilities/` for ADR-020.
+
+## Observable behavior
+
+The governed ADR claim chain MUST remain navigable in-place:
+
+1. Each owning ADR MUST list `CE-CAP-LEGACY-001` in its `## Governed claims` section.
+2. `CE-CAP-LEGACY-001` MUST list its owning ADRs in `adr_links`.
+3. `CE-CAP-LEGACY-001` MUST list `CE-REQ-LEGACY-GOV-001` in `requirements`.
+4. This requirement MUST list `CE-CAP-LEGACY-001` in `claim_refs`.
+5. Linked test references MUST point to existing tests or explicit metadata checks.
+
+## Acceptance criterion
+
+The capability traceability validation test passes for this ADR/claim/requirement
+chain without relying on a standalone traceability table or generated matrix.
+
+## Verification method
+
+Automated pytest test in `tests/capabilities/`.
+
+Test ID:
+- `test_should_validate_adr_claim_requirement_link_metadata`
+
+(in `tests/capabilities/test_adr_capability_links.py`)
+
+## Evidence required
+
+| Field | Required |
+|---|---|
+| commit_sha | yes |
+| package_version | yes |
+| test_id | yes |
+| result | yes (pass/fail) |
+
+## Assumption boundary
+
+This requirement verifies governance linkage and metadata consistency. It does not
+prove every runtime behavior implied by the owning ADR; runtime behavior remains
+covered by the specific implementation tests referenced by feature requirements.

--- a/development/capabilities/requirements/CE-REQ-LOG-CONTEXT-PROPAGATION-001.md
+++ b/development/capabilities/requirements/CE-REQ-LOG-CONTEXT-PROPAGATION-001.md
@@ -1,0 +1,65 @@
+# CE-REQ-LOG-CONTEXT-PROPAGATION-001 — Logging context propagation preserves request or governance context without global mutable leakage.
+
+## Metadata
+
+| Field | Value |
+|---|---|
+| requirement_id | CE-REQ-LOG-CONTEXT-PROPAGATION-001 |
+| obligation_type | static_policy |
+| claim_refs | CE-CAP-LOG-CONTEXT-PROPAGATION-001 |
+| adr_refs | ADR-028 |
+| status | active |
+| verification_status | manual_review_required |
+
+## Scope
+
+ADR-governed implementation, documentation, and verification artifacts for `ADR-028`.
+
+## Observable behavior
+
+Logging context helpers MUST propagate relevant context without requiring global mutable handler state.
+
+## Acceptance criterion
+
+Behavioral acceptance for this requirement is the ADR-specific obligation itself:
+
+- Logging context helpers MUST propagate relevant context without requiring global mutable handler state.
+- Automated metadata tests MAY prove that the requirement is linked, but MUST NOT be
+  treated as proof that the behavioral obligation is satisfied.
+- Until a named runtime, static-policy, serialization, schema, or quality-gate check below
+  directly verifies the obligation, the verification status remains `manual_review_required`.
+
+## Verification method
+
+Verification method: `manual_review` plus the concrete source, documentation, schema,
+quality-script, or pytest targets listed below. Metadata tests are linkage guards only.
+
+## Verification targets
+
+- source: `development/adrs/ADR-028*.md`
+- quality_script: `scripts/quality/check_logging_domains.py`
+- standard: `development/standards/STD-005-logging-and-observability-standard.md`
+- metadata_test: `tests/capabilities/test_adr_capability_links.py::test_should_validate_adr_claim_requirement_link_metadata`
+- metadata_test: `tests/capabilities/test_adr_capability_links.py::test_should_validate_curated_semantic_claim_presence`
+- manual_review: `development/current-work/RELEASE_PLAN_status_appendix.md` (ADR-028 section)
+
+Test IDs:
+- `test_should_validate_adr_claim_requirement_link_metadata`
+- `test_should_validate_curated_semantic_claim_presence`
+- `test_should_require_behavioral_requirements_to_name_concrete_evidence`
+- `test_should_prevent_runtime_obligations_from_using_documentation_boundary_type`
+
+## Evidence required
+
+| Field | Required |
+|---|---|
+| commit_sha | yes |
+| package_version | yes |
+| test_id | yes |
+| result | yes (pass/fail/partial) |
+
+## Assumption boundary
+
+This requirement captures the normative ADR obligation and its evidence chain. It does not
+claim that metadata checks alone prove runtime correctness; behavior remains verified by the
+specific source, test, documentation, or quality-script evidence maintained for `ADR-028`.

--- a/development/capabilities/requirements/CE-REQ-LOG-DATA-MINIMISATION-001.md
+++ b/development/capabilities/requirements/CE-REQ-LOG-DATA-MINIMISATION-001.md
@@ -1,0 +1,65 @@
+# CE-REQ-LOG-DATA-MINIMISATION-001 — Logging and governance events minimize sensitive data and avoid raw payload leakage.
+
+## Metadata
+
+| Field | Value |
+|---|---|
+| requirement_id | CE-REQ-LOG-DATA-MINIMISATION-001 |
+| obligation_type | static_policy |
+| claim_refs | CE-CAP-LOG-DATA-MINIMISATION-001 |
+| adr_refs | ADR-028 |
+| status | active |
+| verification_status | manual_review_required |
+
+## Scope
+
+ADR-governed implementation, documentation, and verification artifacts for `ADR-028`.
+
+## Observable behavior
+
+Logging and governance event payloads MUST avoid raw user data leakage and retain only the minimal context needed for diagnosis or audit.
+
+## Acceptance criterion
+
+Behavioral acceptance for this requirement is the ADR-specific obligation itself:
+
+- Logging and governance event payloads MUST avoid raw user data leakage and retain only the minimal context needed for diagnosis or audit.
+- Automated metadata tests MAY prove that the requirement is linked, but MUST NOT be
+  treated as proof that the behavioral obligation is satisfied.
+- Until a named runtime, static-policy, serialization, schema, or quality-gate check below
+  directly verifies the obligation, the verification status remains `manual_review_required`.
+
+## Verification method
+
+Verification method: `manual_review` plus the concrete source, documentation, schema,
+quality-script, or pytest targets listed below. Metadata tests are linkage guards only.
+
+## Verification targets
+
+- source: `development/adrs/ADR-028*.md`
+- quality_script: `scripts/quality/check_logging_domains.py`
+- standard: `development/standards/STD-005-logging-and-observability-standard.md`
+- metadata_test: `tests/capabilities/test_adr_capability_links.py::test_should_validate_adr_claim_requirement_link_metadata`
+- metadata_test: `tests/capabilities/test_adr_capability_links.py::test_should_validate_curated_semantic_claim_presence`
+- manual_review: `development/current-work/RELEASE_PLAN_status_appendix.md` (ADR-028 section)
+
+Test IDs:
+- `test_should_validate_adr_claim_requirement_link_metadata`
+- `test_should_validate_curated_semantic_claim_presence`
+- `test_should_require_behavioral_requirements_to_name_concrete_evidence`
+- `test_should_prevent_runtime_obligations_from_using_documentation_boundary_type`
+
+## Evidence required
+
+| Field | Required |
+|---|---|
+| commit_sha | yes |
+| package_version | yes |
+| test_id | yes |
+| result | yes (pass/fail/partial) |
+
+## Assumption boundary
+
+This requirement captures the normative ADR obligation and its evidence chain. It does not
+claim that metadata checks alone prove runtime correctness; behavior remains verified by the
+specific source, test, documentation, or quality-script evidence maintained for `ADR-028`.

--- a/development/capabilities/requirements/CE-REQ-LOG-DOMAIN-TAXONOMY-001.md
+++ b/development/capabilities/requirements/CE-REQ-LOG-DOMAIN-TAXONOMY-001.md
@@ -1,0 +1,65 @@
+# CE-REQ-LOG-DOMAIN-TAXONOMY-001 — Logging uses the ADR-028 logger domain taxonomy for core, plugins, telemetry, and governance events.
+
+## Metadata
+
+| Field | Value |
+|---|---|
+| requirement_id | CE-REQ-LOG-DOMAIN-TAXONOMY-001 |
+| obligation_type | quality_gate |
+| claim_refs | CE-CAP-LOG-DOMAIN-TAXONOMY-001 |
+| adr_refs | ADR-028 |
+| status | active |
+| verification_status | manual_review_required |
+
+## Scope
+
+ADR-governed implementation, documentation, and verification artifacts for `ADR-028`.
+
+## Observable behavior
+
+Logger names MUST map to the ADR-028 domain taxonomy and quality checks MUST reject out-of-domain production loggers.
+
+## Acceptance criterion
+
+Behavioral acceptance for this requirement is the ADR-specific obligation itself:
+
+- Logger names MUST map to the ADR-028 domain taxonomy and quality checks MUST reject out-of-domain production loggers.
+- Automated metadata tests MAY prove that the requirement is linked, but MUST NOT be
+  treated as proof that the behavioral obligation is satisfied.
+- Until a named runtime, static-policy, serialization, schema, or quality-gate check below
+  directly verifies the obligation, the verification status remains `manual_review_required`.
+
+## Verification method
+
+Verification method: `manual_review` plus the concrete source, documentation, schema,
+quality-script, or pytest targets listed below. Metadata tests are linkage guards only.
+
+## Verification targets
+
+- source: `development/adrs/ADR-028*.md`
+- quality_script: `scripts/quality/check_logging_domains.py`
+- standard: `development/standards/STD-005-logging-and-observability-standard.md`
+- metadata_test: `tests/capabilities/test_adr_capability_links.py::test_should_validate_adr_claim_requirement_link_metadata`
+- metadata_test: `tests/capabilities/test_adr_capability_links.py::test_should_validate_curated_semantic_claim_presence`
+- manual_review: `development/current-work/RELEASE_PLAN_status_appendix.md` (ADR-028 section)
+
+Test IDs:
+- `test_should_validate_adr_claim_requirement_link_metadata`
+- `test_should_validate_curated_semantic_claim_presence`
+- `test_should_require_behavioral_requirements_to_name_concrete_evidence`
+- `test_should_prevent_runtime_obligations_from_using_documentation_boundary_type`
+
+## Evidence required
+
+| Field | Required |
+|---|---|
+| commit_sha | yes |
+| package_version | yes |
+| test_id | yes |
+| result | yes (pass/fail/partial) |
+
+## Assumption boundary
+
+This requirement captures the normative ADR obligation and its evidence chain. It does not
+claim that metadata checks alone prove runtime correctness; behavior remains verified by the
+specific source, test, documentation, or quality-script evidence maintained for `ADR-028`.

--- a/development/capabilities/requirements/CE-REQ-LOG-NO-GLOBAL-HANDLERS-001.md
+++ b/development/capabilities/requirements/CE-REQ-LOG-NO-GLOBAL-HANDLERS-001.md
@@ -1,0 +1,65 @@
+# CE-REQ-LOG-NO-GLOBAL-HANDLERS-001 — The library does not install global logging handlers on import.
+
+## Metadata
+
+| Field | Value |
+|---|---|
+| requirement_id | CE-REQ-LOG-NO-GLOBAL-HANDLERS-001 |
+| obligation_type | static_policy |
+| claim_refs | CE-CAP-LOG-NO-GLOBAL-HANDLERS-001 |
+| adr_refs | ADR-028 |
+| status | active |
+| verification_status | manual_review_required |
+
+## Scope
+
+ADR-governed implementation, documentation, and verification artifacts for `ADR-028`.
+
+## Observable behavior
+
+The package MUST NOT install or mutate global logging handlers during import; applications own handler configuration.
+
+## Acceptance criterion
+
+Behavioral acceptance for this requirement is the ADR-specific obligation itself:
+
+- The package MUST NOT install or mutate global logging handlers during import; applications own handler configuration.
+- Automated metadata tests MAY prove that the requirement is linked, but MUST NOT be
+  treated as proof that the behavioral obligation is satisfied.
+- Until a named runtime, static-policy, serialization, schema, or quality-gate check below
+  directly verifies the obligation, the verification status remains `manual_review_required`.
+
+## Verification method
+
+Verification method: `manual_review` plus the concrete source, documentation, schema,
+quality-script, or pytest targets listed below. Metadata tests are linkage guards only.
+
+## Verification targets
+
+- source: `development/adrs/ADR-028*.md`
+- quality_script: `scripts/quality/check_logging_domains.py`
+- standard: `development/standards/STD-005-logging-and-observability-standard.md`
+- metadata_test: `tests/capabilities/test_adr_capability_links.py::test_should_validate_adr_claim_requirement_link_metadata`
+- metadata_test: `tests/capabilities/test_adr_capability_links.py::test_should_validate_curated_semantic_claim_presence`
+- manual_review: `development/current-work/RELEASE_PLAN_status_appendix.md` (ADR-028 section)
+
+Test IDs:
+- `test_should_validate_adr_claim_requirement_link_metadata`
+- `test_should_validate_curated_semantic_claim_presence`
+- `test_should_require_behavioral_requirements_to_name_concrete_evidence`
+- `test_should_prevent_runtime_obligations_from_using_documentation_boundary_type`
+
+## Evidence required
+
+| Field | Required |
+|---|---|
+| commit_sha | yes |
+| package_version | yes |
+| test_id | yes |
+| result | yes (pass/fail/partial) |
+
+## Assumption boundary
+
+This requirement captures the normative ADR obligation and its evidence chain. It does not
+claim that metadata checks alone prove runtime correctness; behavior remains verified by the
+specific source, test, documentation, or quality-script evidence maintained for `ADR-028`.

--- a/development/capabilities/requirements/CE-REQ-LOG-STRUCTURED-COMPATIBILITY-001.md
+++ b/development/capabilities/requirements/CE-REQ-LOG-STRUCTURED-COMPATIBILITY-001.md
@@ -1,0 +1,65 @@
+# CE-REQ-LOG-STRUCTURED-COMPATIBILITY-001 — Logging remains compatible with structured logging consumers while preserving standard library logging behavior.
+
+## Metadata
+
+| Field | Value |
+|---|---|
+| requirement_id | CE-REQ-LOG-STRUCTURED-COMPATIBILITY-001 |
+| obligation_type | static_policy |
+| claim_refs | CE-CAP-LOG-STRUCTURED-COMPATIBILITY-001 |
+| adr_refs | ADR-028 |
+| status | active |
+| verification_status | manual_review_required |
+
+## Scope
+
+ADR-governed implementation, documentation, and verification artifacts for `ADR-028`.
+
+## Observable behavior
+
+Logging helpers MUST preserve standard library logging compatibility and support structured-context consumers without imposing a non-standard logging dependency.
+
+## Acceptance criterion
+
+Behavioral acceptance for this requirement is the ADR-specific obligation itself:
+
+- Logging helpers MUST preserve standard library logging compatibility and support structured-context consumers without imposing a non-standard logging dependency.
+- Automated metadata tests MAY prove that the requirement is linked, but MUST NOT be
+  treated as proof that the behavioral obligation is satisfied.
+- Until a named runtime, static-policy, serialization, schema, or quality-gate check below
+  directly verifies the obligation, the verification status remains `manual_review_required`.
+
+## Verification method
+
+Verification method: `manual_review` plus the concrete source, documentation, schema,
+quality-script, or pytest targets listed below. Metadata tests are linkage guards only.
+
+## Verification targets
+
+- source: `development/adrs/ADR-028*.md`
+- quality_script: `scripts/quality/check_logging_domains.py`
+- standard: `development/standards/STD-005-logging-and-observability-standard.md`
+- metadata_test: `tests/capabilities/test_adr_capability_links.py::test_should_validate_adr_claim_requirement_link_metadata`
+- metadata_test: `tests/capabilities/test_adr_capability_links.py::test_should_validate_curated_semantic_claim_presence`
+- manual_review: `development/current-work/RELEASE_PLAN_status_appendix.md` (ADR-028 section)
+
+Test IDs:
+- `test_should_validate_adr_claim_requirement_link_metadata`
+- `test_should_validate_curated_semantic_claim_presence`
+- `test_should_require_behavioral_requirements_to_name_concrete_evidence`
+- `test_should_prevent_runtime_obligations_from_using_documentation_boundary_type`
+
+## Evidence required
+
+| Field | Required |
+|---|---|
+| commit_sha | yes |
+| package_version | yes |
+| test_id | yes |
+| result | yes (pass/fail/partial) |
+
+## Assumption boundary
+
+This requirement captures the normative ADR obligation and its evidence chain. It does not
+claim that metadata checks alone prove runtime correctness; behavior remains verified by the
+specific source, test, documentation, or quality-script evidence maintained for `ADR-028`.

--- a/development/capabilities/requirements/CE-REQ-MODALITY-GOV-001.md
+++ b/development/capabilities/requirements/CE-REQ-MODALITY-GOV-001.md
@@ -1,0 +1,55 @@
+# CE-REQ-MODALITY-GOV-001 — ADR Governance Linkage Contract
+
+## Metadata
+
+| Field | Value |
+|---|---|
+| requirement_id | CE-REQ-MODALITY-GOV-001 |
+| obligation_type | documentation_boundary |
+| claim_refs | CE-CAP-MODALITY-001 |
+| adr_refs | ADR-033 |
+| status | active |
+
+## Scope
+
+Development governance artifacts under `development/adrs/` and
+`development/capabilities/` for ADR-033.
+
+## Observable behavior
+
+The governed ADR claim chain MUST remain navigable in-place:
+
+1. Each owning ADR MUST list `CE-CAP-MODALITY-001` in its `## Governed claims` section.
+2. `CE-CAP-MODALITY-001` MUST list its owning ADRs in `adr_links`.
+3. `CE-CAP-MODALITY-001` MUST list `CE-REQ-MODALITY-GOV-001` in `requirements`.
+4. This requirement MUST list `CE-CAP-MODALITY-001` in `claim_refs`.
+5. Linked test references MUST point to existing tests or explicit metadata checks.
+
+## Acceptance criterion
+
+The capability traceability validation test passes for this ADR/claim/requirement
+chain without relying on a standalone traceability table or generated matrix.
+
+## Verification method
+
+Automated pytest test in `tests/capabilities/`.
+
+Test ID:
+- `test_should_validate_adr_claim_requirement_link_metadata`
+
+(in `tests/capabilities/test_adr_capability_links.py`)
+
+## Evidence required
+
+| Field | Required |
+|---|---|
+| commit_sha | yes |
+| package_version | yes |
+| test_id | yes |
+| result | yes (pass/fail) |
+
+## Assumption boundary
+
+This requirement verifies governance linkage and metadata consistency. It does not
+prove every runtime behavior implied by the owning ADR; runtime behavior remains
+covered by the specific implementation tests referenced by feature requirements.

--- a/development/capabilities/requirements/CE-REQ-MODALITY-METADATA-001.md
+++ b/development/capabilities/requirements/CE-REQ-MODALITY-METADATA-001.md
@@ -1,0 +1,66 @@
+# CE-REQ-MODALITY-METADATA-001 — Modality plugins declare plugin_api_version and normalized data_modalities metadata with major-hard and minor-soft compatibility checks.
+
+## Metadata
+
+| Field | Value |
+|---|---|
+| requirement_id | CE-REQ-MODALITY-METADATA-001 |
+| obligation_type | static_policy |
+| claim_refs | CE-CAP-MODALITY-METADATA-001 |
+| adr_refs | ADR-033 |
+| status | active |
+| verification_status | manual_review_required |
+
+## Scope
+
+ADR-governed implementation, documentation, and verification artifacts for `ADR-033`.
+
+## Observable behavior
+
+Modality plugin metadata MUST include plugin_api_version and normalized data_modalities, reject major API mismatches, and warn on forward minor/patch compatibility risk.
+
+## Acceptance criterion
+
+Behavioral acceptance for this requirement is the ADR-specific obligation itself:
+
+- Modality plugin metadata MUST include plugin_api_version and normalized data_modalities, reject major API mismatches, and warn on forward minor/patch compatibility risk.
+- Automated metadata tests MAY prove that the requirement is linked, but MUST NOT be
+  treated as proof that the behavioral obligation is satisfied.
+- Until a named runtime, static-policy, serialization, schema, or quality-gate check below
+  directly verifies the obligation, the verification status remains `manual_review_required`.
+
+## Verification method
+
+Verification method: `manual_review` plus the concrete source, documentation, schema,
+quality-script, or pytest targets listed below. Metadata tests are linkage guards only.
+
+## Verification targets
+
+- source: `development/adrs/ADR-033*.md`
+- quality_script: `scripts/quality/check_trust_mutation_primitive.py`
+- docs: `docs/api/plugins.md`
+- docs: `docs/practitioner/advanced/modality-plugins.md`
+- metadata_test: `tests/capabilities/test_adr_capability_links.py::test_should_validate_adr_claim_requirement_link_metadata`
+- metadata_test: `tests/capabilities/test_adr_capability_links.py::test_should_validate_curated_semantic_claim_presence`
+- manual_review: `development/current-work/RELEASE_PLAN_status_appendix.md` (ADR-033 section)
+
+Test IDs:
+- `test_should_validate_adr_claim_requirement_link_metadata`
+- `test_should_validate_curated_semantic_claim_presence`
+- `test_should_require_behavioral_requirements_to_name_concrete_evidence`
+- `test_should_prevent_runtime_obligations_from_using_documentation_boundary_type`
+
+## Evidence required
+
+| Field | Required |
+|---|---|
+| commit_sha | yes |
+| package_version | yes |
+| test_id | yes |
+| result | yes (pass/fail/partial) |
+
+## Assumption boundary
+
+This requirement captures the normative ADR obligation and its evidence chain. It does not
+claim that metadata checks alone prove runtime correctness; behavior remains verified by the
+specific source, test, documentation, or quality-script evidence maintained for `ADR-033`.

--- a/development/capabilities/requirements/CE-REQ-MODALITY-RESOLUTION-001.md
+++ b/development/capabilities/requirements/CE-REQ-MODALITY-RESOLUTION-001.md
@@ -1,0 +1,66 @@
+# CE-REQ-MODALITY-RESOLUTION-001 — Modality-aware plugin selection respects data modalities, aliases, compatibility, and deterministic selection order.
+
+## Metadata
+
+| Field | Value |
+|---|---|
+| requirement_id | CE-REQ-MODALITY-RESOLUTION-001 |
+| obligation_type | static_policy |
+| claim_refs | CE-CAP-MODALITY-RESOLUTION-001 |
+| adr_refs | ADR-033 |
+| status | active |
+| verification_status | manual_review_required |
+
+## Scope
+
+ADR-governed implementation, documentation, and verification artifacts for `ADR-033`.
+
+## Observable behavior
+
+Plugin resolution MUST consider normalized data modalities, aliases, compatibility, trust, and deterministic ordering when selecting modality-capable plugins.
+
+## Acceptance criterion
+
+Behavioral acceptance for this requirement is the ADR-specific obligation itself:
+
+- Plugin resolution MUST consider normalized data modalities, aliases, compatibility, trust, and deterministic ordering when selecting modality-capable plugins.
+- Automated metadata tests MAY prove that the requirement is linked, but MUST NOT be
+  treated as proof that the behavioral obligation is satisfied.
+- Until a named runtime, static-policy, serialization, schema, or quality-gate check below
+  directly verifies the obligation, the verification status remains `manual_review_required`.
+
+## Verification method
+
+Verification method: `manual_review` plus the concrete source, documentation, schema,
+quality-script, or pytest targets listed below. Metadata tests are linkage guards only.
+
+## Verification targets
+
+- source: `development/adrs/ADR-033*.md`
+- quality_script: `scripts/quality/check_trust_mutation_primitive.py`
+- docs: `docs/api/plugins.md`
+- docs: `docs/practitioner/advanced/modality-plugins.md`
+- metadata_test: `tests/capabilities/test_adr_capability_links.py::test_should_validate_adr_claim_requirement_link_metadata`
+- metadata_test: `tests/capabilities/test_adr_capability_links.py::test_should_validate_curated_semantic_claim_presence`
+- manual_review: `development/current-work/RELEASE_PLAN_status_appendix.md` (ADR-033 section)
+
+Test IDs:
+- `test_should_validate_adr_claim_requirement_link_metadata`
+- `test_should_validate_curated_semantic_claim_presence`
+- `test_should_require_behavioral_requirements_to_name_concrete_evidence`
+- `test_should_prevent_runtime_obligations_from_using_documentation_boundary_type`
+
+## Evidence required
+
+| Field | Required |
+|---|---|
+| commit_sha | yes |
+| package_version | yes |
+| test_id | yes |
+| result | yes (pass/fail/partial) |
+
+## Assumption boundary
+
+This requirement captures the normative ADR obligation and its evidence chain. It does not
+claim that metadata checks alone prove runtime correctness; behavior remains verified by the
+specific source, test, documentation, or quality-script evidence maintained for `ADR-033`.

--- a/development/capabilities/requirements/CE-REQ-MODALITY-SHIMS-001.md
+++ b/development/capabilities/requirements/CE-REQ-MODALITY-SHIMS-001.md
@@ -1,0 +1,66 @@
+# CE-REQ-MODALITY-SHIMS-001 — Modality shim modules preserve import compatibility without moving non-tabular implementations into core.
+
+## Metadata
+
+| Field | Value |
+|---|---|
+| requirement_id | CE-REQ-MODALITY-SHIMS-001 |
+| obligation_type | static_policy |
+| claim_refs | CE-CAP-MODALITY-SHIMS-001 |
+| adr_refs | ADR-033 |
+| status | active |
+| verification_status | manual_review_required |
+
+## Scope
+
+ADR-governed implementation, documentation, and verification artifacts for `ADR-033`.
+
+## Observable behavior
+
+Modality shim modules MUST preserve compatibility imports while keeping non-tabular implementation dependencies outside core.
+
+## Acceptance criterion
+
+Behavioral acceptance for this requirement is the ADR-specific obligation itself:
+
+- Modality shim modules MUST preserve compatibility imports while keeping non-tabular implementation dependencies outside core.
+- Automated metadata tests MAY prove that the requirement is linked, but MUST NOT be
+  treated as proof that the behavioral obligation is satisfied.
+- Until a named runtime, static-policy, serialization, schema, or quality-gate check below
+  directly verifies the obligation, the verification status remains `manual_review_required`.
+
+## Verification method
+
+Verification method: `manual_review` plus the concrete source, documentation, schema,
+quality-script, or pytest targets listed below. Metadata tests are linkage guards only.
+
+## Verification targets
+
+- source: `development/adrs/ADR-033*.md`
+- quality_script: `scripts/quality/check_trust_mutation_primitive.py`
+- docs: `docs/api/plugins.md`
+- docs: `docs/practitioner/advanced/modality-plugins.md`
+- metadata_test: `tests/capabilities/test_adr_capability_links.py::test_should_validate_adr_claim_requirement_link_metadata`
+- metadata_test: `tests/capabilities/test_adr_capability_links.py::test_should_validate_curated_semantic_claim_presence`
+- manual_review: `development/current-work/RELEASE_PLAN_status_appendix.md` (ADR-033 section)
+
+Test IDs:
+- `test_should_validate_adr_claim_requirement_link_metadata`
+- `test_should_validate_curated_semantic_claim_presence`
+- `test_should_require_behavioral_requirements_to_name_concrete_evidence`
+- `test_should_prevent_runtime_obligations_from_using_documentation_boundary_type`
+
+## Evidence required
+
+| Field | Required |
+|---|---|
+| commit_sha | yes |
+| package_version | yes |
+| test_id | yes |
+| result | yes (pass/fail/partial) |
+
+## Assumption boundary
+
+This requirement captures the normative ADR obligation and its evidence chain. It does not
+claim that metadata checks alone prove runtime correctness; behavior remains verified by the
+specific source, test, documentation, or quality-script evidence maintained for `ADR-033`.

--- a/development/capabilities/requirements/CE-REQ-MODALITY-TABULAR-INVARIANT-001.md
+++ b/development/capabilities/requirements/CE-REQ-MODALITY-TABULAR-INVARIANT-001.md
@@ -1,0 +1,66 @@
+# CE-REQ-MODALITY-TABULAR-INVARIANT-001 — Existing tabular CalibratedExplainer workflows remain unaffected by modality extension metadata and package boundaries.
+
+## Metadata
+
+| Field | Value |
+|---|---|
+| requirement_id | CE-REQ-MODALITY-TABULAR-INVARIANT-001 |
+| obligation_type | static_policy |
+| claim_refs | CE-CAP-MODALITY-TABULAR-INVARIANT-001 |
+| adr_refs | ADR-033 |
+| status | active |
+| verification_status | manual_review_required |
+
+## Scope
+
+ADR-governed implementation, documentation, and verification artifacts for `ADR-033`.
+
+## Observable behavior
+
+Modality extension support MUST preserve existing tabular CalibratedExplainer workflows and default metadata for legacy tabular plugins.
+
+## Acceptance criterion
+
+Behavioral acceptance for this requirement is the ADR-specific obligation itself:
+
+- Modality extension support MUST preserve existing tabular CalibratedExplainer workflows and default metadata for legacy tabular plugins.
+- Automated metadata tests MAY prove that the requirement is linked, but MUST NOT be
+  treated as proof that the behavioral obligation is satisfied.
+- Until a named runtime, static-policy, serialization, schema, or quality-gate check below
+  directly verifies the obligation, the verification status remains `manual_review_required`.
+
+## Verification method
+
+Verification method: `manual_review` plus the concrete source, documentation, schema,
+quality-script, or pytest targets listed below. Metadata tests are linkage guards only.
+
+## Verification targets
+
+- source: `development/adrs/ADR-033*.md`
+- quality_script: `scripts/quality/check_trust_mutation_primitive.py`
+- docs: `docs/api/plugins.md`
+- docs: `docs/practitioner/advanced/modality-plugins.md`
+- metadata_test: `tests/capabilities/test_adr_capability_links.py::test_should_validate_adr_claim_requirement_link_metadata`
+- metadata_test: `tests/capabilities/test_adr_capability_links.py::test_should_validate_curated_semantic_claim_presence`
+- manual_review: `development/current-work/RELEASE_PLAN_status_appendix.md` (ADR-033 section)
+
+Test IDs:
+- `test_should_validate_adr_claim_requirement_link_metadata`
+- `test_should_validate_curated_semantic_claim_presence`
+- `test_should_require_behavioral_requirements_to_name_concrete_evidence`
+- `test_should_prevent_runtime_obligations_from_using_documentation_boundary_type`
+
+## Evidence required
+
+| Field | Required |
+|---|---|
+| commit_sha | yes |
+| package_version | yes |
+| test_id | yes |
+| result | yes (pass/fail/partial) |
+
+## Assumption boundary
+
+This requirement captures the normative ADR obligation and its evidence chain. It does not
+claim that metadata checks alone prove runtime correctness; behavior remains verified by the
+specific source, test, documentation, or quality-script evidence maintained for `ADR-033`.

--- a/development/capabilities/requirements/CE-REQ-MOND-API-001.md
+++ b/development/capabilities/requirements/CE-REQ-MOND-API-001.md
@@ -7,6 +7,7 @@
 | requirement_id | CE-REQ-MOND-API-001 |
 | obligation_type | api_contract |
 | claim_refs | CE-CAP-MOND-001 |
+| adr_refs | ADR-013 |
 | status | active |
 
 ## Scope

--- a/development/capabilities/requirements/CE-REQ-NARR-API-001.md
+++ b/development/capabilities/requirements/CE-REQ-NARR-API-001.md
@@ -7,6 +7,7 @@
 | requirement_id | CE-REQ-NARR-API-001 |
 | obligation_type | api_contract |
 | claim_refs | CE-CAP-NARR-001 |
+| adr_refs | ADR-008 |
 | status | active |
 
 ## Scope

--- a/development/capabilities/requirements/CE-REQ-OBS-GOV-001.md
+++ b/development/capabilities/requirements/CE-REQ-OBS-GOV-001.md
@@ -1,0 +1,55 @@
+# CE-REQ-OBS-GOV-001 — ADR Governance Linkage Contract
+
+## Metadata
+
+| Field | Value |
+|---|---|
+| requirement_id | CE-REQ-OBS-GOV-001 |
+| obligation_type | documentation_boundary |
+| claim_refs | CE-CAP-OBS-001 |
+| adr_refs | ADR-028 |
+| status | active |
+
+## Scope
+
+Development governance artifacts under `development/adrs/` and
+`development/capabilities/` for ADR-028.
+
+## Observable behavior
+
+The governed ADR claim chain MUST remain navigable in-place:
+
+1. Each owning ADR MUST list `CE-CAP-OBS-001` in its `## Governed claims` section.
+2. `CE-CAP-OBS-001` MUST list its owning ADRs in `adr_links`.
+3. `CE-CAP-OBS-001` MUST list `CE-REQ-OBS-GOV-001` in `requirements`.
+4. This requirement MUST list `CE-CAP-OBS-001` in `claim_refs`.
+5. Linked test references MUST point to existing tests or explicit metadata checks.
+
+## Acceptance criterion
+
+The capability traceability validation test passes for this ADR/claim/requirement
+chain without relying on a standalone traceability table or generated matrix.
+
+## Verification method
+
+Automated pytest test in `tests/capabilities/`.
+
+Test ID:
+- `test_should_validate_adr_claim_requirement_link_metadata`
+
+(in `tests/capabilities/test_adr_capability_links.py`)
+
+## Evidence required
+
+| Field | Required |
+|---|---|
+| commit_sha | yes |
+| package_version | yes |
+| test_id | yes |
+| result | yes (pass/fail) |
+
+## Assumption boundary
+
+This requirement verifies governance linkage and metadata consistency. It does not
+prove every runtime behavior implied by the owning ADR; runtime behavior remains
+covered by the specific implementation tests referenced by feature requirements.

--- a/development/capabilities/requirements/CE-REQ-PARALLEL-GOV-001.md
+++ b/development/capabilities/requirements/CE-REQ-PARALLEL-GOV-001.md
@@ -1,0 +1,55 @@
+# CE-REQ-PARALLEL-GOV-001 — ADR Governance Linkage Contract
+
+## Metadata
+
+| Field | Value |
+|---|---|
+| requirement_id | CE-REQ-PARALLEL-GOV-001 |
+| obligation_type | documentation_boundary |
+| claim_refs | CE-CAP-PARALLEL-001 |
+| adr_refs | ADR-004 |
+| status | active |
+
+## Scope
+
+Development governance artifacts under `development/adrs/` and
+`development/capabilities/` for ADR-004.
+
+## Observable behavior
+
+The governed ADR claim chain MUST remain navigable in-place:
+
+1. Each owning ADR MUST list `CE-CAP-PARALLEL-001` in its `## Governed claims` section.
+2. `CE-CAP-PARALLEL-001` MUST list its owning ADRs in `adr_links`.
+3. `CE-CAP-PARALLEL-001` MUST list `CE-REQ-PARALLEL-GOV-001` in `requirements`.
+4. This requirement MUST list `CE-CAP-PARALLEL-001` in `claim_refs`.
+5. Linked test references MUST point to existing tests or explicit metadata checks.
+
+## Acceptance criterion
+
+The capability traceability validation test passes for this ADR/claim/requirement
+chain without relying on a standalone traceability table or generated matrix.
+
+## Verification method
+
+Automated pytest test in `tests/capabilities/`.
+
+Test ID:
+- `test_should_validate_adr_claim_requirement_link_metadata`
+
+(in `tests/capabilities/test_adr_capability_links.py`)
+
+## Evidence required
+
+| Field | Required |
+|---|---|
+| commit_sha | yes |
+| package_version | yes |
+| test_id | yes |
+| result | yes (pass/fail) |
+
+## Assumption boundary
+
+This requirement verifies governance linkage and metadata consistency. It does not
+prove every runtime behavior implied by the owning ADR; runtime behavior remains
+covered by the specific implementation tests referenced by feature requirements.

--- a/development/capabilities/requirements/CE-REQ-PLOTSPEC-BACKEND-NEUTRALITY-001.md
+++ b/development/capabilities/requirements/CE-REQ-PLOTSPEC-BACKEND-NEUTRALITY-001.md
@@ -1,0 +1,65 @@
+# CE-REQ-PLOTSPEC-BACKEND-NEUTRALITY-001 — Canonical PlotSpec semantics remain backend-neutral and exclude renderer-owned formatting fields.
+
+## Metadata
+
+| Field | Value |
+|---|---|
+| requirement_id | CE-REQ-PLOTSPEC-BACKEND-NEUTRALITY-001 |
+| obligation_type | static_policy |
+| claim_refs | CE-CAP-PLOTSPEC-BACKEND-NEUTRALITY-001 |
+| adr_refs | ADR-036 |
+| status | active |
+| verification_status | manual_review_required |
+
+## Scope
+
+ADR-governed implementation, documentation, and verification artifacts for `ADR-036`.
+
+## Observable behavior
+
+Canonical PlotSpec objects MUST NOT embed backend-specific rendering controls; renderer mappings MUST own backend-specific realization.
+
+## Acceptance criterion
+
+Behavioral acceptance for this requirement is the ADR-specific obligation itself:
+
+- Canonical PlotSpec objects MUST NOT embed backend-specific rendering controls; renderer mappings MUST own backend-specific realization.
+- Automated metadata tests MAY prove that the requirement is linked, but MUST NOT be
+  treated as proof that the behavioral obligation is satisfied.
+- Until a named runtime, static-policy, serialization, schema, or quality-gate check below
+  directly verifies the obligation, the verification status remains `manual_review_required`.
+
+## Verification method
+
+Verification method: `manual_review` plus the concrete source, documentation, schema,
+quality-script, or pytest targets listed below. Metadata tests are linkage guards only.
+
+## Verification targets
+
+- source: `development/adrs/ADR-036*.md`
+- schema: `development/schemas/plotspec_schema.json`
+- docs: `docs/foundations/how-to/plot_with_plotspec.md`
+- metadata_test: `tests/capabilities/test_adr_capability_links.py::test_should_validate_adr_claim_requirement_link_metadata`
+- metadata_test: `tests/capabilities/test_adr_capability_links.py::test_should_validate_curated_semantic_claim_presence`
+- manual_review: `development/current-work/RELEASE_PLAN_status_appendix.md` (ADR-036 section)
+
+Test IDs:
+- `test_should_validate_adr_claim_requirement_link_metadata`
+- `test_should_validate_curated_semantic_claim_presence`
+- `test_should_require_behavioral_requirements_to_name_concrete_evidence`
+- `test_should_prevent_runtime_obligations_from_using_documentation_boundary_type`
+
+## Evidence required
+
+| Field | Required |
+|---|---|
+| commit_sha | yes |
+| package_version | yes |
+| test_id | yes |
+| result | yes (pass/fail/partial) |
+
+## Assumption boundary
+
+This requirement captures the normative ADR obligation and its evidence chain. It does not
+claim that metadata checks alone prove runtime correctness; behavior remains verified by the
+specific source, test, documentation, or quality-script evidence maintained for `ADR-036`.

--- a/development/capabilities/requirements/CE-REQ-PLOTSPEC-BOUNDARY-SERIALIZATION-001.md
+++ b/development/capabilities/requirements/CE-REQ-PLOTSPEC-BOUNDARY-SERIALIZATION-001.md
@@ -1,0 +1,65 @@
+# CE-REQ-PLOTSPEC-BOUNDARY-SERIALIZATION-001 — PlotSpec dict/JSON forms are non-canonical boundary serialization artifacts translated before canonical validation or rendering.
+
+## Metadata
+
+| Field | Value |
+|---|---|
+| requirement_id | CE-REQ-PLOTSPEC-BOUNDARY-SERIALIZATION-001 |
+| obligation_type | static_policy |
+| claim_refs | CE-CAP-PLOTSPEC-BOUNDARY-SERIALIZATION-001 |
+| adr_refs | ADR-036 |
+| status | active |
+| verification_status | manual_review_required |
+
+## Scope
+
+ADR-governed implementation, documentation, and verification artifacts for `ADR-036`.
+
+## Observable behavior
+
+Dict or JSON PlotSpec payloads MUST be treated as boundary artifacts and MUST be translated into canonical PlotSpec objects before canonical validation or renderer consumption.
+
+## Acceptance criterion
+
+Behavioral acceptance for this requirement is the ADR-specific obligation itself:
+
+- Dict or JSON PlotSpec payloads MUST be treated as boundary artifacts and MUST be translated into canonical PlotSpec objects before canonical validation or renderer consumption.
+- Automated metadata tests MAY prove that the requirement is linked, but MUST NOT be
+  treated as proof that the behavioral obligation is satisfied.
+- Until a named runtime, static-policy, serialization, schema, or quality-gate check below
+  directly verifies the obligation, the verification status remains `manual_review_required`.
+
+## Verification method
+
+Verification method: `manual_review` plus the concrete source, documentation, schema,
+quality-script, or pytest targets listed below. Metadata tests are linkage guards only.
+
+## Verification targets
+
+- source: `development/adrs/ADR-036*.md`
+- schema: `development/schemas/plotspec_schema.json`
+- docs: `docs/foundations/how-to/plot_with_plotspec.md`
+- metadata_test: `tests/capabilities/test_adr_capability_links.py::test_should_validate_adr_claim_requirement_link_metadata`
+- metadata_test: `tests/capabilities/test_adr_capability_links.py::test_should_validate_curated_semantic_claim_presence`
+- manual_review: `development/current-work/RELEASE_PLAN_status_appendix.md` (ADR-036 section)
+
+Test IDs:
+- `test_should_validate_adr_claim_requirement_link_metadata`
+- `test_should_validate_curated_semantic_claim_presence`
+- `test_should_require_behavioral_requirements_to_name_concrete_evidence`
+- `test_should_prevent_runtime_obligations_from_using_documentation_boundary_type`
+
+## Evidence required
+
+| Field | Required |
+|---|---|
+| commit_sha | yes |
+| package_version | yes |
+| test_id | yes |
+| result | yes (pass/fail/partial) |
+
+## Assumption boundary
+
+This requirement captures the normative ADR obligation and its evidence chain. It does not
+claim that metadata checks alone prove runtime correctness; behavior remains verified by the
+specific source, test, documentation, or quality-script evidence maintained for `ADR-036`.

--- a/development/capabilities/requirements/CE-REQ-PLOTSPEC-BUILDER-VALIDATION-001.md
+++ b/development/capabilities/requirements/CE-REQ-PLOTSPEC-BUILDER-VALIDATION-001.md
@@ -1,0 +1,65 @@
+# CE-REQ-PLOTSPEC-BUILDER-VALIDATION-001 — Plot builders emit canonical PlotSpec objects and validation occurs before renderer invocation.
+
+## Metadata
+
+| Field | Value |
+|---|---|
+| requirement_id | CE-REQ-PLOTSPEC-BUILDER-VALIDATION-001 |
+| obligation_type | static_policy |
+| claim_refs | CE-CAP-PLOTSPEC-BUILDER-VALIDATION-001 |
+| adr_refs | ADR-036 |
+| status | active |
+| verification_status | manual_review_required |
+
+## Scope
+
+ADR-governed implementation, documentation, and verification artifacts for `ADR-036`.
+
+## Observable behavior
+
+Plot builders MUST emit canonical PlotSpec objects only, and renderers MUST consume validated canonical PlotSpec objects rather than raw backend payloads.
+
+## Acceptance criterion
+
+Behavioral acceptance for this requirement is the ADR-specific obligation itself:
+
+- Plot builders MUST emit canonical PlotSpec objects only, and renderers MUST consume validated canonical PlotSpec objects rather than raw backend payloads.
+- Automated metadata tests MAY prove that the requirement is linked, but MUST NOT be
+  treated as proof that the behavioral obligation is satisfied.
+- Until a named runtime, static-policy, serialization, schema, or quality-gate check below
+  directly verifies the obligation, the verification status remains `manual_review_required`.
+
+## Verification method
+
+Verification method: `manual_review` plus the concrete source, documentation, schema,
+quality-script, or pytest targets listed below. Metadata tests are linkage guards only.
+
+## Verification targets
+
+- source: `development/adrs/ADR-036*.md`
+- schema: `development/schemas/plotspec_schema.json`
+- docs: `docs/foundations/how-to/plot_with_plotspec.md`
+- metadata_test: `tests/capabilities/test_adr_capability_links.py::test_should_validate_adr_claim_requirement_link_metadata`
+- metadata_test: `tests/capabilities/test_adr_capability_links.py::test_should_validate_curated_semantic_claim_presence`
+- manual_review: `development/current-work/RELEASE_PLAN_status_appendix.md` (ADR-036 section)
+
+Test IDs:
+- `test_should_validate_adr_claim_requirement_link_metadata`
+- `test_should_validate_curated_semantic_claim_presence`
+- `test_should_require_behavioral_requirements_to_name_concrete_evidence`
+- `test_should_prevent_runtime_obligations_from_using_documentation_boundary_type`
+
+## Evidence required
+
+| Field | Required |
+|---|---|
+| commit_sha | yes |
+| package_version | yes |
+| test_id | yes |
+| result | yes (pass/fail/partial) |
+
+## Assumption boundary
+
+This requirement captures the normative ADR obligation and its evidence chain. It does not
+claim that metadata checks alone prove runtime correctness; behavior remains verified by the
+specific source, test, documentation, or quality-script evidence maintained for `ADR-036`.

--- a/development/capabilities/requirements/CE-REQ-PLOTSPEC-CANONICAL-DATACLASS-001.md
+++ b/development/capabilities/requirements/CE-REQ-PLOTSPEC-CANONICAL-DATACLASS-001.md
@@ -1,0 +1,65 @@
+# CE-REQ-PLOTSPEC-CANONICAL-DATACLASS-001 — PlotSpec canonical in-memory representation uses typed dataclass objects.
+
+## Metadata
+
+| Field | Value |
+|---|---|
+| requirement_id | CE-REQ-PLOTSPEC-CANONICAL-DATACLASS-001 |
+| obligation_type | static_policy |
+| claim_refs | CE-CAP-PLOTSPEC-CANONICAL-DATACLASS-001 |
+| adr_refs | ADR-036 |
+| status | active |
+| verification_status | manual_review_required |
+
+## Scope
+
+ADR-governed implementation, documentation, and verification artifacts for `ADR-036`.
+
+## Observable behavior
+
+PlotSpec-enabled builders and validators MUST treat typed dataclass PlotSpec objects as the canonical in-memory representation.
+
+## Acceptance criterion
+
+Behavioral acceptance for this requirement is the ADR-specific obligation itself:
+
+- PlotSpec-enabled builders and validators MUST treat typed dataclass PlotSpec objects as the canonical in-memory representation.
+- Automated metadata tests MAY prove that the requirement is linked, but MUST NOT be
+  treated as proof that the behavioral obligation is satisfied.
+- Until a named runtime, static-policy, serialization, schema, or quality-gate check below
+  directly verifies the obligation, the verification status remains `manual_review_required`.
+
+## Verification method
+
+Verification method: `manual_review` plus the concrete source, documentation, schema,
+quality-script, or pytest targets listed below. Metadata tests are linkage guards only.
+
+## Verification targets
+
+- source: `development/adrs/ADR-036*.md`
+- schema: `development/schemas/plotspec_schema.json`
+- docs: `docs/foundations/how-to/plot_with_plotspec.md`
+- metadata_test: `tests/capabilities/test_adr_capability_links.py::test_should_validate_adr_claim_requirement_link_metadata`
+- metadata_test: `tests/capabilities/test_adr_capability_links.py::test_should_validate_curated_semantic_claim_presence`
+- manual_review: `development/current-work/RELEASE_PLAN_status_appendix.md` (ADR-036 section)
+
+Test IDs:
+- `test_should_validate_adr_claim_requirement_link_metadata`
+- `test_should_validate_curated_semantic_claim_presence`
+- `test_should_require_behavioral_requirements_to_name_concrete_evidence`
+- `test_should_prevent_runtime_obligations_from_using_documentation_boundary_type`
+
+## Evidence required
+
+| Field | Required |
+|---|---|
+| commit_sha | yes |
+| package_version | yes |
+| test_id | yes |
+| result | yes (pass/fail/partial) |
+
+## Assumption boundary
+
+This requirement captures the normative ADR obligation and its evidence chain. It does not
+claim that metadata checks alone prove runtime correctness; behavior remains verified by the
+specific source, test, documentation, or quality-script evidence maintained for `ADR-036`.

--- a/development/capabilities/requirements/CE-REQ-PLOTSPEC-GOV-001.md
+++ b/development/capabilities/requirements/CE-REQ-PLOTSPEC-GOV-001.md
@@ -1,0 +1,55 @@
+# CE-REQ-PLOTSPEC-GOV-001 — ADR Governance Linkage Contract
+
+## Metadata
+
+| Field | Value |
+|---|---|
+| requirement_id | CE-REQ-PLOTSPEC-GOV-001 |
+| obligation_type | documentation_boundary |
+| claim_refs | CE-CAP-PLOTSPEC-001 |
+| adr_refs | ADR-036, ADR-037 |
+| status | active |
+
+## Scope
+
+Development governance artifacts under `development/adrs/` and
+`development/capabilities/` for ADR-036, ADR-037.
+
+## Observable behavior
+
+The governed ADR claim chain MUST remain navigable in-place:
+
+1. Each owning ADR MUST list `CE-CAP-PLOTSPEC-001` in its `## Governed claims` section.
+2. `CE-CAP-PLOTSPEC-001` MUST list its owning ADRs in `adr_links`.
+3. `CE-CAP-PLOTSPEC-001` MUST list `CE-REQ-PLOTSPEC-GOV-001` in `requirements`.
+4. This requirement MUST list `CE-CAP-PLOTSPEC-001` in `claim_refs`.
+5. Linked test references MUST point to existing tests or explicit metadata checks.
+
+## Acceptance criterion
+
+The capability traceability validation test passes for this ADR/claim/requirement
+chain without relying on a standalone traceability table or generated matrix.
+
+## Verification method
+
+Automated pytest test in `tests/capabilities/`.
+
+Test ID:
+- `test_should_validate_adr_claim_requirement_link_metadata`
+
+(in `tests/capabilities/test_adr_capability_links.py`)
+
+## Evidence required
+
+| Field | Required |
+|---|---|
+| commit_sha | yes |
+| package_version | yes |
+| test_id | yes |
+| result | yes (pass/fail) |
+
+## Assumption boundary
+
+This requirement verifies governance linkage and metadata consistency. It does not
+prove every runtime behavior implied by the owning ADR; runtime behavior remains
+covered by the specific implementation tests referenced by feature requirements.

--- a/development/capabilities/requirements/CE-REQ-PLUGIN-AUDIT-EVENTS-001.md
+++ b/development/capabilities/requirements/CE-REQ-PLUGIN-AUDIT-EVENTS-001.md
@@ -1,0 +1,66 @@
+# CE-REQ-PLUGIN-AUDIT-EVENTS-001 — Plugin trust and registration decisions emit warnings or governance audit events where ADR-006 requires visibility.
+
+## Metadata
+
+| Field | Value |
+|---|---|
+| requirement_id | CE-REQ-PLUGIN-AUDIT-EVENTS-001 |
+| obligation_type | static_policy |
+| claim_refs | CE-CAP-PLUGIN-AUDIT-EVENTS-001 |
+| adr_refs | ADR-006 |
+| status | active |
+| verification_status | manual_review_required |
+
+## Scope
+
+ADR-governed implementation, documentation, and verification artifacts for `ADR-006`.
+
+## Observable behavior
+
+Plugin trust, deny, compatibility, and fallback decisions MUST emit visible warnings or governance events according to ADR-006 and ADR-028 visibility rules.
+
+## Acceptance criterion
+
+Behavioral acceptance for this requirement is the ADR-specific obligation itself:
+
+- Plugin trust, deny, compatibility, and fallback decisions MUST emit visible warnings or governance events according to ADR-006 and ADR-028 visibility rules.
+- Automated metadata tests MAY prove that the requirement is linked, but MUST NOT be
+  treated as proof that the behavioral obligation is satisfied.
+- Until a named runtime, static-policy, serialization, schema, or quality-gate check below
+  directly verifies the obligation, the verification status remains `manual_review_required`.
+
+## Verification method
+
+Verification method: `manual_review` plus the concrete source, documentation, schema,
+quality-script, or pytest targets listed below. Metadata tests are linkage guards only.
+
+## Verification targets
+
+- source: `development/adrs/ADR-006*.md`
+- quality_script: `scripts/quality/check_trust_mutation_primitive.py`
+- docs: `docs/api/plugins.md`
+- docs: `docs/practitioner/advanced/modality-plugins.md`
+- metadata_test: `tests/capabilities/test_adr_capability_links.py::test_should_validate_adr_claim_requirement_link_metadata`
+- metadata_test: `tests/capabilities/test_adr_capability_links.py::test_should_validate_curated_semantic_claim_presence`
+- manual_review: `development/current-work/RELEASE_PLAN_status_appendix.md` (ADR-006 section)
+
+Test IDs:
+- `test_should_validate_adr_claim_requirement_link_metadata`
+- `test_should_validate_curated_semantic_claim_presence`
+- `test_should_require_behavioral_requirements_to_name_concrete_evidence`
+- `test_should_prevent_runtime_obligations_from_using_documentation_boundary_type`
+
+## Evidence required
+
+| Field | Required |
+|---|---|
+| commit_sha | yes |
+| package_version | yes |
+| test_id | yes |
+| result | yes (pass/fail/partial) |
+
+## Assumption boundary
+
+This requirement captures the normative ADR obligation and its evidence chain. It does not
+claim that metadata checks alone prove runtime correctness; behavior remains verified by the
+specific source, test, documentation, or quality-script evidence maintained for `ADR-006`.

--- a/development/capabilities/requirements/CE-REQ-PLUGIN-DISCOVERY-REPORT-001.md
+++ b/development/capabilities/requirements/CE-REQ-PLUGIN-DISCOVERY-REPORT-001.md
@@ -1,0 +1,66 @@
+# CE-REQ-PLUGIN-DISCOVERY-REPORT-001 — Plugin discovery reports expose plugin metadata and trust status without executing untrusted plugin behavior.
+
+## Metadata
+
+| Field | Value |
+|---|---|
+| requirement_id | CE-REQ-PLUGIN-DISCOVERY-REPORT-001 |
+| obligation_type | static_policy |
+| claim_refs | CE-CAP-PLUGIN-DISCOVERY-REPORT-001 |
+| adr_refs | ADR-006 |
+| status | active |
+| verification_status | manual_review_required |
+
+## Scope
+
+ADR-governed implementation, documentation, and verification artifacts for `ADR-006`.
+
+## Observable behavior
+
+Plugin discovery/listing MUST expose metadata and trust status in a way that supports audit without implicitly executing untrusted plugin behavior.
+
+## Acceptance criterion
+
+Behavioral acceptance for this requirement is the ADR-specific obligation itself:
+
+- Plugin discovery/listing MUST expose metadata and trust status in a way that supports audit without implicitly executing untrusted plugin behavior.
+- Automated metadata tests MAY prove that the requirement is linked, but MUST NOT be
+  treated as proof that the behavioral obligation is satisfied.
+- Until a named runtime, static-policy, serialization, schema, or quality-gate check below
+  directly verifies the obligation, the verification status remains `manual_review_required`.
+
+## Verification method
+
+Verification method: `manual_review` plus the concrete source, documentation, schema,
+quality-script, or pytest targets listed below. Metadata tests are linkage guards only.
+
+## Verification targets
+
+- source: `development/adrs/ADR-006*.md`
+- quality_script: `scripts/quality/check_trust_mutation_primitive.py`
+- docs: `docs/api/plugins.md`
+- docs: `docs/practitioner/advanced/modality-plugins.md`
+- metadata_test: `tests/capabilities/test_adr_capability_links.py::test_should_validate_adr_claim_requirement_link_metadata`
+- metadata_test: `tests/capabilities/test_adr_capability_links.py::test_should_validate_curated_semantic_claim_presence`
+- manual_review: `development/current-work/RELEASE_PLAN_status_appendix.md` (ADR-006 section)
+
+Test IDs:
+- `test_should_validate_adr_claim_requirement_link_metadata`
+- `test_should_validate_curated_semantic_claim_presence`
+- `test_should_require_behavioral_requirements_to_name_concrete_evidence`
+- `test_should_prevent_runtime_obligations_from_using_documentation_boundary_type`
+
+## Evidence required
+
+| Field | Required |
+|---|---|
+| commit_sha | yes |
+| package_version | yes |
+| test_id | yes |
+| result | yes (pass/fail/partial) |
+
+## Assumption boundary
+
+This requirement captures the normative ADR obligation and its evidence chain. It does not
+claim that metadata checks alone prove runtime correctness; behavior remains verified by the
+specific source, test, documentation, or quality-script evidence maintained for `ADR-006`.

--- a/development/capabilities/requirements/CE-REQ-PLUGIN-DOC-001.md
+++ b/development/capabilities/requirements/CE-REQ-PLUGIN-DOC-001.md
@@ -7,6 +7,7 @@
 | requirement_id | CE-REQ-PLUGIN-DOC-001 |
 | obligation_type | documentation_boundary |
 | claim_refs | CE-CAP-PLUGIN-001 |
+| adr_refs | ADR-006, ADR-013, ADR-015, ADR-026, ADR-033 |
 | status | active |
 
 ## Scope

--- a/development/capabilities/requirements/CE-REQ-PLUGIN-TRUST-POLICY-001.md
+++ b/development/capabilities/requirements/CE-REQ-PLUGIN-TRUST-POLICY-001.md
@@ -1,0 +1,66 @@
+# CE-REQ-PLUGIN-TRUST-POLICY-001 — Plugin loading follows explicit trust policy controls, allow and deny lists, and documented trust precedence.
+
+## Metadata
+
+| Field | Value |
+|---|---|
+| requirement_id | CE-REQ-PLUGIN-TRUST-POLICY-001 |
+| obligation_type | static_policy |
+| claim_refs | CE-CAP-PLUGIN-TRUST-POLICY-001 |
+| adr_refs | ADR-006 |
+| status | active |
+| verification_status | manual_review_required |
+
+## Scope
+
+ADR-governed implementation, documentation, and verification artifacts for `ADR-006`.
+
+## Observable behavior
+
+Third-party plugin activation MUST require explicit trust and MUST resolve trust using the ADR-006 precedence order for API overrides, environment, pyproject allowlists, denylists, and defaults.
+
+## Acceptance criterion
+
+Behavioral acceptance for this requirement is the ADR-specific obligation itself:
+
+- Third-party plugin activation MUST require explicit trust and MUST resolve trust using the ADR-006 precedence order for API overrides, environment, pyproject allowlists, denylists, and defaults.
+- Automated metadata tests MAY prove that the requirement is linked, but MUST NOT be
+  treated as proof that the behavioral obligation is satisfied.
+- Until a named runtime, static-policy, serialization, schema, or quality-gate check below
+  directly verifies the obligation, the verification status remains `manual_review_required`.
+
+## Verification method
+
+Verification method: `manual_review` plus the concrete source, documentation, schema,
+quality-script, or pytest targets listed below. Metadata tests are linkage guards only.
+
+## Verification targets
+
+- source: `development/adrs/ADR-006*.md`
+- quality_script: `scripts/quality/check_trust_mutation_primitive.py`
+- docs: `docs/api/plugins.md`
+- docs: `docs/practitioner/advanced/modality-plugins.md`
+- metadata_test: `tests/capabilities/test_adr_capability_links.py::test_should_validate_adr_claim_requirement_link_metadata`
+- metadata_test: `tests/capabilities/test_adr_capability_links.py::test_should_validate_curated_semantic_claim_presence`
+- manual_review: `development/current-work/RELEASE_PLAN_status_appendix.md` (ADR-006 section)
+
+Test IDs:
+- `test_should_validate_adr_claim_requirement_link_metadata`
+- `test_should_validate_curated_semantic_claim_presence`
+- `test_should_require_behavioral_requirements_to_name_concrete_evidence`
+- `test_should_prevent_runtime_obligations_from_using_documentation_boundary_type`
+
+## Evidence required
+
+| Field | Required |
+|---|---|
+| commit_sha | yes |
+| package_version | yes |
+| test_id | yes |
+| result | yes (pass/fail/partial) |
+
+## Assumption boundary
+
+This requirement captures the normative ADR obligation and its evidence chain. It does not
+claim that metadata checks alone prove runtime correctness; behavior remains verified by the
+specific source, test, documentation, or quality-script evidence maintained for `ADR-006`.

--- a/development/capabilities/requirements/CE-REQ-PRED-API-001.md
+++ b/development/capabilities/requirements/CE-REQ-PRED-API-001.md
@@ -7,6 +7,7 @@
 | requirement_id | CE-REQ-PRED-API-001 |
 | obligation_type | api_contract |
 | claim_refs | CE-CAP-PRED-001 |
+| adr_refs | ADR-013, ADR-021 |
 | status | active |
 
 ## Scope

--- a/development/capabilities/requirements/CE-REQ-PRED-CLASS-API-001.md
+++ b/development/capabilities/requirements/CE-REQ-PRED-CLASS-API-001.md
@@ -7,6 +7,7 @@
 | requirement_id | CE-REQ-PRED-CLASS-API-001 |
 | obligation_type | api_contract |
 | claim_refs | CE-CAP-PRED-CLASS-001 |
+| adr_refs | ADR-021 |
 | status | active |
 
 ## Scope

--- a/development/capabilities/requirements/CE-REQ-PRED-INTERVAL-BOUNDS-001.md
+++ b/development/capabilities/requirements/CE-REQ-PRED-INTERVAL-BOUNDS-001.md
@@ -7,6 +7,7 @@
 | requirement_id | CE-REQ-PRED-INTERVAL-BOUNDS-001 |
 | obligation_type | api_contract |
 | claim_refs | CE-CAP-PRED-001 |
+| adr_refs | ADR-013, ADR-021 |
 | status | active |
 
 ## Scope

--- a/development/capabilities/requirements/CE-REQ-PRED-PROB-API-001.md
+++ b/development/capabilities/requirements/CE-REQ-PRED-PROB-API-001.md
@@ -7,6 +7,7 @@
 | requirement_id | CE-REQ-PRED-PROB-API-001 |
 | obligation_type | api_contract |
 | claim_refs | CE-CAP-PRED-PROB-001 |
+| adr_refs | ADR-021 |
 | status | active |
 
 ## Scope

--- a/development/capabilities/requirements/CE-REQ-PREPROC-GOV-001.md
+++ b/development/capabilities/requirements/CE-REQ-PREPROC-GOV-001.md
@@ -1,0 +1,55 @@
+# CE-REQ-PREPROC-GOV-001 — ADR Governance Linkage Contract
+
+## Metadata
+
+| Field | Value |
+|---|---|
+| requirement_id | CE-REQ-PREPROC-GOV-001 |
+| obligation_type | documentation_boundary |
+| claim_refs | CE-CAP-PREPROC-001 |
+| adr_refs | ADR-009 |
+| status | active |
+
+## Scope
+
+Development governance artifacts under `development/adrs/` and
+`development/capabilities/` for ADR-009.
+
+## Observable behavior
+
+The governed ADR claim chain MUST remain navigable in-place:
+
+1. Each owning ADR MUST list `CE-CAP-PREPROC-001` in its `## Governed claims` section.
+2. `CE-CAP-PREPROC-001` MUST list its owning ADRs in `adr_links`.
+3. `CE-CAP-PREPROC-001` MUST list `CE-REQ-PREPROC-GOV-001` in `requirements`.
+4. This requirement MUST list `CE-CAP-PREPROC-001` in `claim_refs`.
+5. Linked test references MUST point to existing tests or explicit metadata checks.
+
+## Acceptance criterion
+
+The capability traceability validation test passes for this ADR/claim/requirement
+chain without relying on a standalone traceability table or generated matrix.
+
+## Verification method
+
+Automated pytest test in `tests/capabilities/`.
+
+Test ID:
+- `test_should_validate_adr_claim_requirement_link_metadata`
+
+(in `tests/capabilities/test_adr_capability_links.py`)
+
+## Evidence required
+
+| Field | Required |
+|---|---|
+| commit_sha | yes |
+| package_version | yes |
+| test_id | yes |
+| result | yes (pass/fail) |
+
+## Assumption boundary
+
+This requirement verifies governance linkage and metadata consistency. It does not
+prove every runtime behavior implied by the owning ADR; runtime behavior remains
+covered by the specific implementation tests referenced by feature requirements.

--- a/development/capabilities/requirements/CE-REQ-REJECT-API-001.md
+++ b/development/capabilities/requirements/CE-REQ-REJECT-API-001.md
@@ -7,6 +7,7 @@
 | requirement_id | CE-REQ-REJECT-API-001 |
 | obligation_type | api_contract |
 | claim_refs | CE-CAP-REJECT-001 |
+| adr_refs | ADR-029, ADR-038 |
 | status | active |
 
 ## Scope

--- a/development/capabilities/requirements/CE-REQ-REJECT-DEFAULT-OFF-001.md
+++ b/development/capabilities/requirements/CE-REQ-REJECT-DEFAULT-OFF-001.md
@@ -1,0 +1,65 @@
+# CE-REQ-REJECT-DEFAULT-OFF-001 — Reject integration is disabled by default and legacy behavior is unchanged unless explicitly enabled.
+
+## Metadata
+
+| Field | Value |
+|---|---|
+| requirement_id | CE-REQ-REJECT-DEFAULT-OFF-001 |
+| obligation_type | api_contract |
+| claim_refs | CE-CAP-REJECT-DEFAULT-OFF-001 |
+| adr_refs | ADR-029 |
+| status | active |
+| verification_status | manual_review_required |
+
+## Scope
+
+ADR-governed implementation, documentation, and verification artifacts for `ADR-029`.
+
+## Observable behavior
+
+Reject orchestration MUST be disabled by default and MUST preserve legacy explanation behavior unless reject policy activation is explicit.
+
+## Acceptance criterion
+
+Behavioral acceptance for this requirement is the ADR-specific obligation itself:
+
+- Reject orchestration MUST be disabled by default and MUST preserve legacy explanation behavior unless reject policy activation is explicit.
+- Automated metadata tests MAY prove that the requirement is linked, but MUST NOT be
+  treated as proof that the behavioral obligation is satisfied.
+- Until a named runtime, static-policy, serialization, schema, or quality-gate check below
+  directly verifies the obligation, the verification status remains `manual_review_required`.
+
+## Verification method
+
+Verification method: `manual_review` plus the concrete source, documentation, schema,
+quality-script, or pytest targets listed below. Metadata tests are linkage guards only.
+
+## Verification targets
+
+- source: `development/adrs/ADR-029*.md`
+- docs: `docs/practitioner/advanced/reject-policy.md`
+- docs: `docs/contributor/reject_policy_usage.md`
+- metadata_test: `tests/capabilities/test_adr_capability_links.py::test_should_validate_adr_claim_requirement_link_metadata`
+- metadata_test: `tests/capabilities/test_adr_capability_links.py::test_should_validate_curated_semantic_claim_presence`
+- manual_review: `development/current-work/RELEASE_PLAN_status_appendix.md` (ADR-029 section)
+
+Test IDs:
+- `test_should_validate_adr_claim_requirement_link_metadata`
+- `test_should_validate_curated_semantic_claim_presence`
+- `test_should_require_behavioral_requirements_to_name_concrete_evidence`
+- `test_should_prevent_runtime_obligations_from_using_documentation_boundary_type`
+
+## Evidence required
+
+| Field | Required |
+|---|---|
+| commit_sha | yes |
+| package_version | yes |
+| test_id | yes |
+| result | yes (pass/fail/partial) |
+
+## Assumption boundary
+
+This requirement captures the normative ADR obligation and its evidence chain. It does not
+claim that metadata checks alone prove runtime correctness; behavior remains verified by the
+specific source, test, documentation, or quality-script evidence maintained for `ADR-029`.

--- a/development/capabilities/requirements/CE-REQ-REJECT-NO-VIZ-001.md
+++ b/development/capabilities/requirements/CE-REQ-REJECT-NO-VIZ-001.md
@@ -1,0 +1,65 @@
+# CE-REQ-REJECT-NO-VIZ-001 — Reject visualization is intentionally not integrated unless a future ADR changes that decision.
+
+## Metadata
+
+| Field | Value |
+|---|---|
+| requirement_id | CE-REQ-REJECT-NO-VIZ-001 |
+| obligation_type | static_policy |
+| claim_refs | CE-CAP-REJECT-NO-VIZ-001 |
+| adr_refs | ADR-029 |
+| status | active |
+| verification_status | manual_review_required |
+
+## Scope
+
+ADR-governed implementation, documentation, and verification artifacts for `ADR-029`.
+
+## Observable behavior
+
+Reject integration MUST NOT add visualization behavior unless a future ADR explicitly governs that visualization surface.
+
+## Acceptance criterion
+
+Behavioral acceptance for this requirement is the ADR-specific obligation itself:
+
+- Reject integration MUST NOT add visualization behavior unless a future ADR explicitly governs that visualization surface.
+- Automated metadata tests MAY prove that the requirement is linked, but MUST NOT be
+  treated as proof that the behavioral obligation is satisfied.
+- Until a named runtime, static-policy, serialization, schema, or quality-gate check below
+  directly verifies the obligation, the verification status remains `manual_review_required`.
+
+## Verification method
+
+Verification method: `manual_review` plus the concrete source, documentation, schema,
+quality-script, or pytest targets listed below. Metadata tests are linkage guards only.
+
+## Verification targets
+
+- source: `development/adrs/ADR-029*.md`
+- schema: `development/schemas/plotspec_schema.json`
+- docs: `docs/foundations/how-to/plot_with_plotspec.md`
+- metadata_test: `tests/capabilities/test_adr_capability_links.py::test_should_validate_adr_claim_requirement_link_metadata`
+- metadata_test: `tests/capabilities/test_adr_capability_links.py::test_should_validate_curated_semantic_claim_presence`
+- manual_review: `development/current-work/RELEASE_PLAN_status_appendix.md` (ADR-029 section)
+
+Test IDs:
+- `test_should_validate_adr_claim_requirement_link_metadata`
+- `test_should_validate_curated_semantic_claim_presence`
+- `test_should_require_behavioral_requirements_to_name_concrete_evidence`
+- `test_should_prevent_runtime_obligations_from_using_documentation_boundary_type`
+
+## Evidence required
+
+| Field | Required |
+|---|---|
+| commit_sha | yes |
+| package_version | yes |
+| test_id | yes |
+| result | yes (pass/fail/partial) |
+
+## Assumption boundary
+
+This requirement captures the normative ADR obligation and its evidence chain. It does not
+claim that metadata checks alone prove runtime correctness; behavior remains verified by the
+specific source, test, documentation, or quality-script evidence maintained for `ADR-029`.

--- a/development/capabilities/requirements/CE-REQ-REJECT-POLICY-ENUM-001.md
+++ b/development/capabilities/requirements/CE-REQ-REJECT-POLICY-ENUM-001.md
@@ -1,0 +1,65 @@
+# CE-REQ-REJECT-POLICY-ENUM-001 — RejectPolicy NONE, FLAG, ONLY_REJECTED, and ONLY_ACCEPTED have stable semantics.
+
+## Metadata
+
+| Field | Value |
+|---|---|
+| requirement_id | CE-REQ-REJECT-POLICY-ENUM-001 |
+| obligation_type | api_contract |
+| claim_refs | CE-CAP-REJECT-POLICY-ENUM-001 |
+| adr_refs | ADR-029 |
+| status | active |
+| verification_status | manual_review_required |
+
+## Scope
+
+ADR-governed implementation, documentation, and verification artifacts for `ADR-029`.
+
+## Observable behavior
+
+RejectPolicy members NONE, FLAG, ONLY_REJECTED, and ONLY_ACCEPTED MUST keep their documented selection and filtering semantics stable.
+
+## Acceptance criterion
+
+Behavioral acceptance for this requirement is the ADR-specific obligation itself:
+
+- RejectPolicy members NONE, FLAG, ONLY_REJECTED, and ONLY_ACCEPTED MUST keep their documented selection and filtering semantics stable.
+- Automated metadata tests MAY prove that the requirement is linked, but MUST NOT be
+  treated as proof that the behavioral obligation is satisfied.
+- Until a named runtime, static-policy, serialization, schema, or quality-gate check below
+  directly verifies the obligation, the verification status remains `manual_review_required`.
+
+## Verification method
+
+Verification method: `manual_review` plus the concrete source, documentation, schema,
+quality-script, or pytest targets listed below. Metadata tests are linkage guards only.
+
+## Verification targets
+
+- source: `development/adrs/ADR-029*.md`
+- docs: `docs/practitioner/advanced/reject-policy.md`
+- docs: `docs/contributor/reject_policy_usage.md`
+- metadata_test: `tests/capabilities/test_adr_capability_links.py::test_should_validate_adr_claim_requirement_link_metadata`
+- metadata_test: `tests/capabilities/test_adr_capability_links.py::test_should_validate_curated_semantic_claim_presence`
+- manual_review: `development/current-work/RELEASE_PLAN_status_appendix.md` (ADR-029 section)
+
+Test IDs:
+- `test_should_validate_adr_claim_requirement_link_metadata`
+- `test_should_validate_curated_semantic_claim_presence`
+- `test_should_require_behavioral_requirements_to_name_concrete_evidence`
+- `test_should_prevent_runtime_obligations_from_using_documentation_boundary_type`
+
+## Evidence required
+
+| Field | Required |
+|---|---|
+| commit_sha | yes |
+| package_version | yes |
+| test_id | yes |
+| result | yes (pass/fail/partial) |
+
+## Assumption boundary
+
+This requirement captures the normative ADR obligation and its evidence chain. It does not
+claim that metadata checks alone prove runtime correctness; behavior remains verified by the
+specific source, test, documentation, or quality-script evidence maintained for `ADR-029`.

--- a/development/capabilities/requirements/CE-REQ-REJECT-RESULT-ENVELOPE-001.md
+++ b/development/capabilities/requirements/CE-REQ-REJECT-RESULT-ENVELOPE-001.md
@@ -1,0 +1,65 @@
+# CE-REQ-REJECT-RESULT-ENVELOPE-001 — Reject-aware outputs use a structured RejectResult envelope when reject integration is active.
+
+## Metadata
+
+| Field | Value |
+|---|---|
+| requirement_id | CE-REQ-REJECT-RESULT-ENVELOPE-001 |
+| obligation_type | api_contract |
+| claim_refs | CE-CAP-REJECT-RESULT-ENVELOPE-001 |
+| adr_refs | ADR-029 |
+| status | active |
+| verification_status | manual_review_required |
+
+## Scope
+
+ADR-governed implementation, documentation, and verification artifacts for `ADR-029`.
+
+## Observable behavior
+
+When reject integration is active, reject-aware outputs MUST expose structured RejectResult information rather than unstructured ad-hoc status fields.
+
+## Acceptance criterion
+
+Behavioral acceptance for this requirement is the ADR-specific obligation itself:
+
+- When reject integration is active, reject-aware outputs MUST expose structured RejectResult information rather than unstructured ad-hoc status fields.
+- Automated metadata tests MAY prove that the requirement is linked, but MUST NOT be
+  treated as proof that the behavioral obligation is satisfied.
+- Until a named runtime, static-policy, serialization, schema, or quality-gate check below
+  directly verifies the obligation, the verification status remains `manual_review_required`.
+
+## Verification method
+
+Verification method: `manual_review` plus the concrete source, documentation, schema,
+quality-script, or pytest targets listed below. Metadata tests are linkage guards only.
+
+## Verification targets
+
+- source: `development/adrs/ADR-029*.md`
+- docs: `docs/practitioner/advanced/reject-policy.md`
+- docs: `docs/contributor/reject_policy_usage.md`
+- metadata_test: `tests/capabilities/test_adr_capability_links.py::test_should_validate_adr_claim_requirement_link_metadata`
+- metadata_test: `tests/capabilities/test_adr_capability_links.py::test_should_validate_curated_semantic_claim_presence`
+- manual_review: `development/current-work/RELEASE_PLAN_status_appendix.md` (ADR-029 section)
+
+Test IDs:
+- `test_should_validate_adr_claim_requirement_link_metadata`
+- `test_should_validate_curated_semantic_claim_presence`
+- `test_should_require_behavioral_requirements_to_name_concrete_evidence`
+- `test_should_prevent_runtime_obligations_from_using_documentation_boundary_type`
+
+## Evidence required
+
+| Field | Required |
+|---|---|
+| commit_sha | yes |
+| package_version | yes |
+| test_id | yes |
+| result | yes (pass/fail/partial) |
+
+## Assumption boundary
+
+This requirement captures the normative ADR obligation and its evidence chain. It does not
+claim that metadata checks alone prove runtime correctness; behavior remains verified by the
+specific source, test, documentation, or quality-script evidence maintained for `ADR-029`.

--- a/development/capabilities/requirements/CE-REQ-REJECT-STRATEGY-REGISTRY-001.md
+++ b/development/capabilities/requirements/CE-REQ-REJECT-STRATEGY-REGISTRY-001.md
@@ -1,0 +1,65 @@
+# CE-REQ-REJECT-STRATEGY-REGISTRY-001 — Reject strategies are managed by a lightweight RejectOrchestrator registry.
+
+## Metadata
+
+| Field | Value |
+|---|---|
+| requirement_id | CE-REQ-REJECT-STRATEGY-REGISTRY-001 |
+| obligation_type | api_contract |
+| claim_refs | CE-CAP-REJECT-STRATEGY-REGISTRY-001 |
+| adr_refs | ADR-029 |
+| status | active |
+| verification_status | manual_review_required |
+
+## Scope
+
+ADR-governed implementation, documentation, and verification artifacts for `ADR-029`.
+
+## Observable behavior
+
+Reject strategies MUST be registered and resolved through the lightweight RejectOrchestrator registry, including the built-in default strategy.
+
+## Acceptance criterion
+
+Behavioral acceptance for this requirement is the ADR-specific obligation itself:
+
+- Reject strategies MUST be registered and resolved through the lightweight RejectOrchestrator registry, including the built-in default strategy.
+- Automated metadata tests MAY prove that the requirement is linked, but MUST NOT be
+  treated as proof that the behavioral obligation is satisfied.
+- Until a named runtime, static-policy, serialization, schema, or quality-gate check below
+  directly verifies the obligation, the verification status remains `manual_review_required`.
+
+## Verification method
+
+Verification method: `manual_review` plus the concrete source, documentation, schema,
+quality-script, or pytest targets listed below. Metadata tests are linkage guards only.
+
+## Verification targets
+
+- source: `development/adrs/ADR-029*.md`
+- docs: `docs/practitioner/advanced/reject-policy.md`
+- docs: `docs/contributor/reject_policy_usage.md`
+- metadata_test: `tests/capabilities/test_adr_capability_links.py::test_should_validate_adr_claim_requirement_link_metadata`
+- metadata_test: `tests/capabilities/test_adr_capability_links.py::test_should_validate_curated_semantic_claim_presence`
+- manual_review: `development/current-work/RELEASE_PLAN_status_appendix.md` (ADR-029 section)
+
+Test IDs:
+- `test_should_validate_adr_claim_requirement_link_metadata`
+- `test_should_validate_curated_semantic_claim_presence`
+- `test_should_require_behavioral_requirements_to_name_concrete_evidence`
+- `test_should_prevent_runtime_obligations_from_using_documentation_boundary_type`
+
+## Evidence required
+
+| Field | Required |
+|---|---|
+| commit_sha | yes |
+| package_version | yes |
+| test_id | yes |
+| result | yes (pass/fail/partial) |
+
+## Assumption boundary
+
+This requirement captures the normative ADR obligation and its evidence chain. It does not
+claim that metadata checks alone prove runtime correctness; behavior remains verified by the
+specific source, test, documentation, or quality-script evidence maintained for `ADR-029`.

--- a/development/capabilities/requirements/CE-REQ-REQ-AS-CODE-EVIDENCE-001.md
+++ b/development/capabilities/requirements/CE-REQ-REQ-AS-CODE-EVIDENCE-001.md
@@ -1,0 +1,72 @@
+# CE-REQ-REQ-AS-CODE-EVIDENCE-001 — Behavioral requirements require executable evidence
+
+## Metadata
+
+| Field | Value |
+|---|---|
+| requirement_id | CE-REQ-REQ-AS-CODE-EVIDENCE-001 |
+| obligation_type | quality_gate |
+| claim_refs | CE-CAP-REQ-AS-CODE-001 |
+| adr_refs | ADR-030, ADR-035 |
+| status | active |
+| verification_status | verified |
+
+## Scope
+
+All active ADR-governed capability requirements under
+`development/capabilities/requirements/`, all capability claims under
+`development/capabilities/claims/`, and the executable tests they cite.
+
+## Observable behavior
+
+The ADR-to-claim-to-requirement chain MUST terminate in executable evidence for every
+active behavioral requirement:
+
+1. Behavioral requirements MUST name at least one executable pytest target.
+2. Documentation, source files, schemas, standards, and metadata-linkage tests MAY support
+   interpretation, but MUST NOT be the only evidence for a behavioral requirement.
+3. A cited pytest target MUST resolve to an existing test function.
+4. Human or manual verification MUST NOT be used as a test method for implemented
+   requirements.
+5. If the requirement is not implemented, the requirement MUST use `verification_status`
+   `adr_gap_open` or `not_implemented`, include `gap_ref` or `adr_gap_ref`, and the gap
+   MUST be registered in `development/current-work/RELEASE_PLAN_status_appendix.md`.
+
+## Acceptance criterion
+
+The requirements-as-code governance integration tests pass without accepting metadata-only
+or human verification as behavioral proof.
+
+## Verification method
+
+Automated pytest tests in `tests/capabilities/`.
+
+## Verification targets
+
+- pytest: `tests/capabilities/test_adr_capability_links.py::test_should_require_behavioral_requirements_to_name_concrete_evidence`
+- pytest: `tests/capabilities/test_adr_capability_links.py::test_should_reject_human_verification_without_registered_adr_gap`
+- pytest: `tests/capabilities/test_adr_capability_links.py::test_should_require_claimed_pytest_targets_to_be_real_tests`
+- pytest: `tests/capabilities/test_adr_capability_links.py::test_should_validate_curated_semantic_claim_presence`
+
+Test IDs:
+- `test_should_require_behavioral_requirements_to_name_concrete_evidence`
+- `test_should_reject_human_verification_without_registered_adr_gap`
+- `test_should_require_claimed_pytest_targets_to_be_real_tests`
+- `test_should_validate_curated_semantic_claim_presence`
+
+## Evidence required
+
+| Field | Required |
+|---|---|
+| commit_sha | yes |
+| package_version | yes |
+| test_id | yes |
+| result | yes (pass/fail) |
+| failing_requirement_ids | yes when failing |
+| gap_ref | yes when requirement is not implemented |
+
+## Assumption boundary
+
+This requirement verifies the requirements-as-code evidence contract. It does not by
+itself prove every feature behavior. Feature behavior remains proven by the concrete
+pytest or quality-gate tests cited by each feature requirement.

--- a/development/capabilities/requirements/CE-REQ-SCHEMA-EXTENSION-SURFACE-001.md
+++ b/development/capabilities/requirements/CE-REQ-SCHEMA-EXTENSION-SURFACE-001.md
@@ -1,0 +1,66 @@
+# CE-REQ-SCHEMA-EXTENSION-SURFACE-001 — Provenance and metadata are the governed optional extension surfaces; top-level envelope validation remains deferred.
+
+## Metadata
+
+| Field | Value |
+|---|---|
+| requirement_id | CE-REQ-SCHEMA-EXTENSION-SURFACE-001 |
+| obligation_type | payload_schema |
+| claim_refs | CE-CAP-SCHEMA-EXTENSION-SURFACE-001 |
+| adr_refs | ADR-005 |
+| status | active |
+| verification_status | manual_review_required |
+
+## Scope
+
+ADR-governed implementation, documentation, and verification artifacts for `ADR-005`.
+
+## Observable behavior
+
+Payload extensions MUST use governed provenance and metadata surfaces, while top-level envelope validation remains deferred unless a later ADR makes it mandatory.
+
+## Acceptance criterion
+
+Behavioral acceptance for this requirement is the ADR-specific obligation itself:
+
+- Payload extensions MUST use governed provenance and metadata surfaces, while top-level envelope validation remains deferred unless a later ADR makes it mandatory.
+- Automated metadata tests MAY prove that the requirement is linked, but MUST NOT be
+  treated as proof that the behavioral obligation is satisfied.
+- Until a named runtime, static-policy, serialization, schema, or quality-gate check below
+  directly verifies the obligation, the verification status remains `manual_review_required`.
+
+## Verification method
+
+Verification method: `manual_review` plus the concrete source, documentation, schema,
+quality-script, or pytest targets listed below. Metadata tests are linkage guards only.
+
+## Verification targets
+
+- source: `development/adrs/ADR-005*.md`
+- schema: `development/schemas/primitives_schema.json`
+- docs: `docs/schema_v1.md`
+- docs: `docs/foundations/concepts/explanation_structures.md`
+- metadata_test: `tests/capabilities/test_adr_capability_links.py::test_should_validate_adr_claim_requirement_link_metadata`
+- metadata_test: `tests/capabilities/test_adr_capability_links.py::test_should_validate_curated_semantic_claim_presence`
+- manual_review: `development/current-work/RELEASE_PLAN_status_appendix.md` (ADR-005 section)
+
+Test IDs:
+- `test_should_validate_adr_claim_requirement_link_metadata`
+- `test_should_validate_curated_semantic_claim_presence`
+- `test_should_require_behavioral_requirements_to_name_concrete_evidence`
+- `test_should_prevent_runtime_obligations_from_using_documentation_boundary_type`
+
+## Evidence required
+
+| Field | Required |
+|---|---|
+| commit_sha | yes |
+| package_version | yes |
+| test_id | yes |
+| result | yes (pass/fail/partial) |
+
+## Assumption boundary
+
+This requirement captures the normative ADR obligation and its evidence chain. It does not
+claim that metadata checks alone prove runtime correctness; behavior remains verified by the
+specific source, test, documentation, or quality-script evidence maintained for `ADR-005`.

--- a/development/capabilities/requirements/CE-REQ-SCHEMA-GOV-001.md
+++ b/development/capabilities/requirements/CE-REQ-SCHEMA-GOV-001.md
@@ -1,0 +1,55 @@
+# CE-REQ-SCHEMA-GOV-001 — ADR Governance Linkage Contract
+
+## Metadata
+
+| Field | Value |
+|---|---|
+| requirement_id | CE-REQ-SCHEMA-GOV-001 |
+| obligation_type | documentation_boundary |
+| claim_refs | CE-CAP-SCHEMA-001 |
+| adr_refs | ADR-005, ADR-008 |
+| status | active |
+
+## Scope
+
+Development governance artifacts under `development/adrs/` and
+`development/capabilities/` for ADR-005, ADR-008.
+
+## Observable behavior
+
+The governed ADR claim chain MUST remain navigable in-place:
+
+1. Each owning ADR MUST list `CE-CAP-SCHEMA-001` in its `## Governed claims` section.
+2. `CE-CAP-SCHEMA-001` MUST list its owning ADRs in `adr_links`.
+3. `CE-CAP-SCHEMA-001` MUST list `CE-REQ-SCHEMA-GOV-001` in `requirements`.
+4. This requirement MUST list `CE-CAP-SCHEMA-001` in `claim_refs`.
+5. Linked test references MUST point to existing tests or explicit metadata checks.
+
+## Acceptance criterion
+
+The capability traceability validation test passes for this ADR/claim/requirement
+chain without relying on a standalone traceability table or generated matrix.
+
+## Verification method
+
+Automated pytest test in `tests/capabilities/`.
+
+Test ID:
+- `test_should_validate_adr_claim_requirement_link_metadata`
+
+(in `tests/capabilities/test_adr_capability_links.py`)
+
+## Evidence required
+
+| Field | Required |
+|---|---|
+| commit_sha | yes |
+| package_version | yes |
+| test_id | yes |
+| result | yes (pass/fail) |
+
+## Assumption boundary
+
+This requirement verifies governance linkage and metadata consistency. It does not
+prove every runtime behavior implied by the owning ADR; runtime behavior remains
+covered by the specific implementation tests referenced by feature requirements.

--- a/development/capabilities/requirements/CE-REQ-SCHEMA-PAYLOAD-V1-001.md
+++ b/development/capabilities/requirements/CE-REQ-SCHEMA-PAYLOAD-V1-001.md
@@ -1,0 +1,66 @@
+# CE-REQ-SCHEMA-PAYLOAD-V1-001 — Explanation payload schema v1 defines the required CE-first fields for serialized instance-level explanations.
+
+## Metadata
+
+| Field | Value |
+|---|---|
+| requirement_id | CE-REQ-SCHEMA-PAYLOAD-V1-001 |
+| obligation_type | payload_schema |
+| claim_refs | CE-CAP-SCHEMA-PAYLOAD-V1-001 |
+| adr_refs | ADR-005 |
+| status | active |
+| verification_status | manual_review_required |
+
+## Scope
+
+ADR-governed implementation, documentation, and verification artifacts for `ADR-005`.
+
+## Observable behavior
+
+Explanation payload serialization MUST include the ADR-005 v1 fields required for task, index, explanation type, prediction interval, and rules.
+
+## Acceptance criterion
+
+Behavioral acceptance for this requirement is the ADR-specific obligation itself:
+
+- Explanation payload serialization MUST include the ADR-005 v1 fields required for task, index, explanation type, prediction interval, and rules.
+- Automated metadata tests MAY prove that the requirement is linked, but MUST NOT be
+  treated as proof that the behavioral obligation is satisfied.
+- Until a named runtime, static-policy, serialization, schema, or quality-gate check below
+  directly verifies the obligation, the verification status remains `manual_review_required`.
+
+## Verification method
+
+Verification method: `manual_review` plus the concrete source, documentation, schema,
+quality-script, or pytest targets listed below. Metadata tests are linkage guards only.
+
+## Verification targets
+
+- source: `development/adrs/ADR-005*.md`
+- schema: `development/schemas/primitives_schema.json`
+- docs: `docs/schema_v1.md`
+- docs: `docs/foundations/concepts/explanation_structures.md`
+- metadata_test: `tests/capabilities/test_adr_capability_links.py::test_should_validate_adr_claim_requirement_link_metadata`
+- metadata_test: `tests/capabilities/test_adr_capability_links.py::test_should_validate_curated_semantic_claim_presence`
+- manual_review: `development/current-work/RELEASE_PLAN_status_appendix.md` (ADR-005 section)
+
+Test IDs:
+- `test_should_validate_adr_claim_requirement_link_metadata`
+- `test_should_validate_curated_semantic_claim_presence`
+- `test_should_require_behavioral_requirements_to_name_concrete_evidence`
+- `test_should_prevent_runtime_obligations_from_using_documentation_boundary_type`
+
+## Evidence required
+
+| Field | Required |
+|---|---|
+| commit_sha | yes |
+| package_version | yes |
+| test_id | yes |
+| result | yes (pass/fail/partial) |
+
+## Assumption boundary
+
+This requirement captures the normative ADR obligation and its evidence chain. It does not
+claim that metadata checks alone prove runtime correctness; behavior remains verified by the
+specific source, test, documentation, or quality-script evidence maintained for `ADR-005`.

--- a/development/capabilities/requirements/CE-REQ-SCHEMA-VALIDATION-001.md
+++ b/development/capabilities/requirements/CE-REQ-SCHEMA-VALIDATION-001.md
@@ -1,0 +1,66 @@
+# CE-REQ-SCHEMA-VALIDATION-001 — Schema validation enforces semver schema versions and interval invariants where payload validation is invoked.
+
+## Metadata
+
+| Field | Value |
+|---|---|
+| requirement_id | CE-REQ-SCHEMA-VALIDATION-001 |
+| obligation_type | payload_schema |
+| claim_refs | CE-CAP-SCHEMA-VALIDATION-001 |
+| adr_refs | ADR-005 |
+| status | active |
+| verification_status | manual_review_required |
+
+## Scope
+
+ADR-governed implementation, documentation, and verification artifacts for `ADR-005`.
+
+## Observable behavior
+
+Schema validation MUST enforce schema version compatibility and MUST reject invalid prediction interval ordering where payload validation is invoked.
+
+## Acceptance criterion
+
+Behavioral acceptance for this requirement is the ADR-specific obligation itself:
+
+- Schema validation MUST enforce schema version compatibility and MUST reject invalid prediction interval ordering where payload validation is invoked.
+- Automated metadata tests MAY prove that the requirement is linked, but MUST NOT be
+  treated as proof that the behavioral obligation is satisfied.
+- Until a named runtime, static-policy, serialization, schema, or quality-gate check below
+  directly verifies the obligation, the verification status remains `manual_review_required`.
+
+## Verification method
+
+Verification method: `manual_review` plus the concrete source, documentation, schema,
+quality-script, or pytest targets listed below. Metadata tests are linkage guards only.
+
+## Verification targets
+
+- source: `development/adrs/ADR-005*.md`
+- schema: `development/schemas/primitives_schema.json`
+- docs: `docs/schema_v1.md`
+- docs: `docs/foundations/concepts/explanation_structures.md`
+- metadata_test: `tests/capabilities/test_adr_capability_links.py::test_should_validate_adr_claim_requirement_link_metadata`
+- metadata_test: `tests/capabilities/test_adr_capability_links.py::test_should_validate_curated_semantic_claim_presence`
+- manual_review: `development/current-work/RELEASE_PLAN_status_appendix.md` (ADR-005 section)
+
+Test IDs:
+- `test_should_validate_adr_claim_requirement_link_metadata`
+- `test_should_validate_curated_semantic_claim_presence`
+- `test_should_require_behavioral_requirements_to_name_concrete_evidence`
+- `test_should_prevent_runtime_obligations_from_using_documentation_boundary_type`
+
+## Evidence required
+
+| Field | Required |
+|---|---|
+| commit_sha | yes |
+| package_version | yes |
+| test_id | yes |
+| result | yes (pass/fail/partial) |
+
+## Assumption boundary
+
+This requirement captures the normative ADR obligation and its evidence chain. It does not
+claim that metadata checks alone prove runtime correctness; behavior remains verified by the
+specific source, test, documentation, or quality-script evidence maintained for `ADR-005`.

--- a/development/capabilities/requirements/CE-REQ-SERIAL-FAIL-FAST-VERSIONING-001.md
+++ b/development/capabilities/requirements/CE-REQ-SERIAL-FAIL-FAST-VERSIONING-001.md
@@ -1,0 +1,65 @@
+# CE-REQ-SERIAL-FAIL-FAST-VERSIONING-001 — Serialization rejects unsupported or incompatible schema versions with explicit errors.
+
+## Metadata
+
+| Field | Value |
+|---|---|
+| requirement_id | CE-REQ-SERIAL-FAIL-FAST-VERSIONING-001 |
+| obligation_type | serialization_contract |
+| claim_refs | CE-CAP-SERIAL-FAIL-FAST-VERSIONING-001 |
+| adr_refs | ADR-031 |
+| status | active |
+| verification_status | manual_review_required |
+
+## Scope
+
+ADR-governed implementation, documentation, and verification artifacts for `ADR-031`.
+
+## Observable behavior
+
+Serialization load paths MUST fail fast on unsupported or incompatible schema versions rather than constructing partial state.
+
+## Acceptance criterion
+
+Behavioral acceptance for this requirement is the ADR-specific obligation itself:
+
+- Serialization load paths MUST fail fast on unsupported or incompatible schema versions rather than constructing partial state.
+- Automated metadata tests MAY prove that the requirement is linked, but MUST NOT be
+  treated as proof that the behavioral obligation is satisfied.
+- Until a named runtime, static-policy, serialization, schema, or quality-gate check below
+  directly verifies the obligation, the verification status remains `manual_review_required`.
+
+## Verification method
+
+Verification method: `manual_review` plus the concrete source, documentation, schema,
+quality-script, or pytest targets listed below. Metadata tests are linkage guards only.
+
+## Verification targets
+
+- source: `development/adrs/ADR-031*.md`
+- docs: `docs/api/serialization.md`
+- schema: `development/schemas/primitives_schema.json`
+- metadata_test: `tests/capabilities/test_adr_capability_links.py::test_should_validate_adr_claim_requirement_link_metadata`
+- metadata_test: `tests/capabilities/test_adr_capability_links.py::test_should_validate_curated_semantic_claim_presence`
+- manual_review: `development/current-work/RELEASE_PLAN_status_appendix.md` (ADR-031 section)
+
+Test IDs:
+- `test_should_validate_adr_claim_requirement_link_metadata`
+- `test_should_validate_curated_semantic_claim_presence`
+- `test_should_require_behavioral_requirements_to_name_concrete_evidence`
+- `test_should_prevent_runtime_obligations_from_using_documentation_boundary_type`
+
+## Evidence required
+
+| Field | Required |
+|---|---|
+| commit_sha | yes |
+| package_version | yes |
+| test_id | yes |
+| result | yes (pass/fail/partial) |
+
+## Assumption boundary
+
+This requirement captures the normative ADR obligation and its evidence chain. It does not
+claim that metadata checks alone prove runtime correctness; behavior remains verified by the
+specific source, test, documentation, or quality-script evidence maintained for `ADR-031`.

--- a/development/capabilities/requirements/CE-REQ-SERIAL-GOV-001.md
+++ b/development/capabilities/requirements/CE-REQ-SERIAL-GOV-001.md
@@ -1,0 +1,55 @@
+# CE-REQ-SERIAL-GOV-001 — ADR Governance Linkage Contract
+
+## Metadata
+
+| Field | Value |
+|---|---|
+| requirement_id | CE-REQ-SERIAL-GOV-001 |
+| obligation_type | documentation_boundary |
+| claim_refs | CE-CAP-SERIAL-001 |
+| adr_refs | ADR-031 |
+| status | active |
+
+## Scope
+
+Development governance artifacts under `development/adrs/` and
+`development/capabilities/` for ADR-031.
+
+## Observable behavior
+
+The governed ADR claim chain MUST remain navigable in-place:
+
+1. Each owning ADR MUST list `CE-CAP-SERIAL-001` in its `## Governed claims` section.
+2. `CE-CAP-SERIAL-001` MUST list its owning ADRs in `adr_links`.
+3. `CE-CAP-SERIAL-001` MUST list `CE-REQ-SERIAL-GOV-001` in `requirements`.
+4. This requirement MUST list `CE-CAP-SERIAL-001` in `claim_refs`.
+5. Linked test references MUST point to existing tests or explicit metadata checks.
+
+## Acceptance criterion
+
+The capability traceability validation test passes for this ADR/claim/requirement
+chain without relying on a standalone traceability table or generated matrix.
+
+## Verification method
+
+Automated pytest test in `tests/capabilities/`.
+
+Test ID:
+- `test_should_validate_adr_claim_requirement_link_metadata`
+
+(in `tests/capabilities/test_adr_capability_links.py`)
+
+## Evidence required
+
+| Field | Required |
+|---|---|
+| commit_sha | yes |
+| package_version | yes |
+| test_id | yes |
+| result | yes (pass/fail) |
+
+## Assumption boundary
+
+This requirement verifies governance linkage and metadata consistency. It does not
+prove every runtime behavior implied by the owning ADR; runtime behavior remains
+covered by the specific implementation tests referenced by feature requirements.

--- a/development/capabilities/requirements/CE-REQ-SERIAL-ROUNDTRIP-INVARIANTS-001.md
+++ b/development/capabilities/requirements/CE-REQ-SERIAL-ROUNDTRIP-INVARIANTS-001.md
@@ -1,0 +1,65 @@
+# CE-REQ-SERIAL-ROUNDTRIP-INVARIANTS-001 — Serialization round trips preserve ADR-021 interval semantics and ADR-009 preprocessing semantics.
+
+## Metadata
+
+| Field | Value |
+|---|---|
+| requirement_id | CE-REQ-SERIAL-ROUNDTRIP-INVARIANTS-001 |
+| obligation_type | serialization_contract |
+| claim_refs | CE-CAP-SERIAL-ROUNDTRIP-INVARIANTS-001 |
+| adr_refs | ADR-031 |
+| status | active |
+| verification_status | manual_review_required |
+
+## Scope
+
+ADR-governed implementation, documentation, and verification artifacts for `ADR-031`.
+
+## Observable behavior
+
+Serialization round trips MUST preserve interval ordering semantics and preprocessing/mapping semantics across save and load.
+
+## Acceptance criterion
+
+Behavioral acceptance for this requirement is the ADR-specific obligation itself:
+
+- Serialization round trips MUST preserve interval ordering semantics and preprocessing/mapping semantics across save and load.
+- Automated metadata tests MAY prove that the requirement is linked, but MUST NOT be
+  treated as proof that the behavioral obligation is satisfied.
+- Until a named runtime, static-policy, serialization, schema, or quality-gate check below
+  directly verifies the obligation, the verification status remains `manual_review_required`.
+
+## Verification method
+
+Verification method: `manual_review` plus the concrete source, documentation, schema,
+quality-script, or pytest targets listed below. Metadata tests are linkage guards only.
+
+## Verification targets
+
+- source: `development/adrs/ADR-031*.md`
+- docs: `docs/api/serialization.md`
+- schema: `development/schemas/primitives_schema.json`
+- metadata_test: `tests/capabilities/test_adr_capability_links.py::test_should_validate_adr_claim_requirement_link_metadata`
+- metadata_test: `tests/capabilities/test_adr_capability_links.py::test_should_validate_curated_semantic_claim_presence`
+- manual_review: `development/current-work/RELEASE_PLAN_status_appendix.md` (ADR-031 section)
+
+Test IDs:
+- `test_should_validate_adr_claim_requirement_link_metadata`
+- `test_should_validate_curated_semantic_claim_presence`
+- `test_should_require_behavioral_requirements_to_name_concrete_evidence`
+- `test_should_prevent_runtime_obligations_from_using_documentation_boundary_type`
+
+## Evidence required
+
+| Field | Required |
+|---|---|
+| commit_sha | yes |
+| package_version | yes |
+| test_id | yes |
+| result | yes (pass/fail/partial) |
+
+## Assumption boundary
+
+This requirement captures the normative ADR obligation and its evidence chain. It does not
+claim that metadata checks alone prove runtime correctness; behavior remains verified by the
+specific source, test, documentation, or quality-script evidence maintained for `ADR-031`.

--- a/development/capabilities/requirements/CE-REQ-TEST-GOV-001.md
+++ b/development/capabilities/requirements/CE-REQ-TEST-GOV-001.md
@@ -1,0 +1,55 @@
+# CE-REQ-TEST-GOV-001 — ADR Governance Linkage Contract
+
+## Metadata
+
+| Field | Value |
+|---|---|
+| requirement_id | CE-REQ-TEST-GOV-001 |
+| obligation_type | documentation_boundary |
+| claim_refs | CE-CAP-TEST-001 |
+| adr_refs | ADR-023, ADR-030 |
+| status | active |
+
+## Scope
+
+Development governance artifacts under `development/adrs/` and
+`development/capabilities/` for ADR-023, ADR-030.
+
+## Observable behavior
+
+The governed ADR claim chain MUST remain navigable in-place:
+
+1. Each owning ADR MUST list `CE-CAP-TEST-001` in its `## Governed claims` section.
+2. `CE-CAP-TEST-001` MUST list its owning ADRs in `adr_links`.
+3. `CE-CAP-TEST-001` MUST list `CE-REQ-TEST-GOV-001` in `requirements`.
+4. This requirement MUST list `CE-CAP-TEST-001` in `claim_refs`.
+5. Linked test references MUST point to existing tests or explicit metadata checks.
+
+## Acceptance criterion
+
+The capability traceability validation test passes for this ADR/claim/requirement
+chain without relying on a standalone traceability table or generated matrix.
+
+## Verification method
+
+Automated pytest test in `tests/capabilities/`.
+
+Test ID:
+- `test_should_validate_adr_claim_requirement_link_metadata`
+
+(in `tests/capabilities/test_adr_capability_links.py`)
+
+## Evidence required
+
+| Field | Required |
+|---|---|
+| commit_sha | yes |
+| package_version | yes |
+| test_id | yes |
+| result | yes (pass/fail) |
+
+## Assumption boundary
+
+This requirement verifies governance linkage and metadata consistency. It does not
+prove every runtime behavior implied by the owning ADR; runtime behavior remains
+covered by the specific implementation tests referenced by feature requirements.

--- a/development/capabilities/requirements/CE-REQ-VALID-EXCEPTION-001.md
+++ b/development/capabilities/requirements/CE-REQ-VALID-EXCEPTION-001.md
@@ -1,0 +1,55 @@
+# CE-REQ-VALID-EXCEPTION-001 — ADR Governance Linkage Contract
+
+## Metadata
+
+| Field | Value |
+|---|---|
+| requirement_id | CE-REQ-VALID-EXCEPTION-001 |
+| obligation_type | documentation_boundary |
+| claim_refs | CE-CAP-VALID-001 |
+| adr_refs | ADR-002 |
+| status | active |
+
+## Scope
+
+Development governance artifacts under `development/adrs/` and
+`development/capabilities/` for ADR-002.
+
+## Observable behavior
+
+The governed ADR claim chain MUST remain navigable in-place:
+
+1. Each owning ADR MUST list `CE-CAP-VALID-001` in its `## Governed claims` section.
+2. `CE-CAP-VALID-001` MUST list its owning ADRs in `adr_links`.
+3. `CE-CAP-VALID-001` MUST list `CE-REQ-VALID-EXCEPTION-001` in `requirements`.
+4. This requirement MUST list `CE-CAP-VALID-001` in `claim_refs`.
+5. Linked test references MUST point to existing tests or explicit metadata checks.
+
+## Acceptance criterion
+
+The capability traceability validation test passes for this ADR/claim/requirement
+chain without relying on a standalone traceability table or generated matrix.
+
+## Verification method
+
+Automated pytest test in `tests/capabilities/`.
+
+Test ID:
+- `test_should_validate_adr_claim_requirement_link_metadata`
+
+(in `tests/capabilities/test_adr_capability_links.py`)
+
+## Evidence required
+
+| Field | Required |
+|---|---|
+| commit_sha | yes |
+| package_version | yes |
+| test_id | yes |
+| result | yes (pass/fail) |
+
+## Assumption boundary
+
+This requirement verifies governance linkage and metadata consistency. It does not
+prove every runtime behavior implied by the owning ADR; runtime behavior remains
+covered by the specific implementation tests referenced by feature requirements.

--- a/development/capabilities/requirements/CE-REQ-VIZ-DEFAULT-PLOTSPEC-PATH-001.md
+++ b/development/capabilities/requirements/CE-REQ-VIZ-DEFAULT-PLOTSPEC-PATH-001.md
@@ -1,0 +1,65 @@
+# CE-REQ-VIZ-DEFAULT-PLOTSPEC-PATH-001 — PlotSpec is the default user-facing plotting path after accepted promotion, with legacy rendering only as explicit opt-out or visible fallback.
+
+## Metadata
+
+| Field | Value |
+|---|---|
+| requirement_id | CE-REQ-VIZ-DEFAULT-PLOTSPEC-PATH-001 |
+| obligation_type | static_policy |
+| claim_refs | CE-CAP-VIZ-DEFAULT-PLOTSPEC-PATH-001 |
+| adr_refs | ADR-037 |
+| status | active |
+| verification_status | manual_review_required |
+
+## Scope
+
+ADR-governed implementation, documentation, and verification artifacts for `ADR-037`.
+
+## Observable behavior
+
+The default plotting path MUST use PlotSpec after promotion, while legacy rendering MUST remain only an explicit opt-out or visible fallback path.
+
+## Acceptance criterion
+
+Behavioral acceptance for this requirement is the ADR-specific obligation itself:
+
+- The default plotting path MUST use PlotSpec after promotion, while legacy rendering MUST remain only an explicit opt-out or visible fallback path.
+- Automated metadata tests MAY prove that the requirement is linked, but MUST NOT be
+  treated as proof that the behavioral obligation is satisfied.
+- Until a named runtime, static-policy, serialization, schema, or quality-gate check below
+  directly verifies the obligation, the verification status remains `manual_review_required`.
+
+## Verification method
+
+Verification method: `manual_review` plus the concrete source, documentation, schema,
+quality-script, or pytest targets listed below. Metadata tests are linkage guards only.
+
+## Verification targets
+
+- source: `development/adrs/ADR-037*.md`
+- schema: `development/schemas/plotspec_schema.json`
+- docs: `docs/foundations/how-to/plot_with_plotspec.md`
+- metadata_test: `tests/capabilities/test_adr_capability_links.py::test_should_validate_adr_claim_requirement_link_metadata`
+- metadata_test: `tests/capabilities/test_adr_capability_links.py::test_should_validate_curated_semantic_claim_presence`
+- manual_review: `development/current-work/RELEASE_PLAN_status_appendix.md` (ADR-037 section)
+
+Test IDs:
+- `test_should_validate_adr_claim_requirement_link_metadata`
+- `test_should_validate_curated_semantic_claim_presence`
+- `test_should_require_behavioral_requirements_to_name_concrete_evidence`
+- `test_should_prevent_runtime_obligations_from_using_documentation_boundary_type`
+
+## Evidence required
+
+| Field | Required |
+|---|---|
+| commit_sha | yes |
+| package_version | yes |
+| test_id | yes |
+| result | yes (pass/fail/partial) |
+
+## Assumption boundary
+
+This requirement captures the normative ADR obligation and its evidence chain. It does not
+claim that metadata checks alone prove runtime correctness; behavior remains verified by the
+specific source, test, documentation, or quality-script evidence maintained for `ADR-037`.

--- a/development/capabilities/requirements/CE-REQ-VIZ-EXTENSION-METADATA-001.md
+++ b/development/capabilities/requirements/CE-REQ-VIZ-EXTENSION-METADATA-001.md
@@ -1,0 +1,65 @@
+# CE-REQ-VIZ-EXTENSION-METADATA-001 — Visualization extensions provide deterministic builder/renderer governance metadata.
+
+## Metadata
+
+| Field | Value |
+|---|---|
+| requirement_id | CE-REQ-VIZ-EXTENSION-METADATA-001 |
+| obligation_type | static_policy |
+| claim_refs | CE-CAP-VIZ-EXTENSION-METADATA-001 |
+| adr_refs | ADR-037 |
+| status | active |
+| verification_status | manual_review_required |
+
+## Scope
+
+ADR-governed implementation, documentation, and verification artifacts for `ADR-037`.
+
+## Observable behavior
+
+Visualization extension descriptors MUST provide stable identifiers, extension type, plot kind support, priority, and compatibility metadata sufficient for deterministic resolution.
+
+## Acceptance criterion
+
+Behavioral acceptance for this requirement is the ADR-specific obligation itself:
+
+- Visualization extension descriptors MUST provide stable identifiers, extension type, plot kind support, priority, and compatibility metadata sufficient for deterministic resolution.
+- Automated metadata tests MAY prove that the requirement is linked, but MUST NOT be
+  treated as proof that the behavioral obligation is satisfied.
+- Until a named runtime, static-policy, serialization, schema, or quality-gate check below
+  directly verifies the obligation, the verification status remains `manual_review_required`.
+
+## Verification method
+
+Verification method: `manual_review` plus the concrete source, documentation, schema,
+quality-script, or pytest targets listed below. Metadata tests are linkage guards only.
+
+## Verification targets
+
+- source: `development/adrs/ADR-037*.md`
+- schema: `development/schemas/plotspec_schema.json`
+- docs: `docs/foundations/how-to/plot_with_plotspec.md`
+- metadata_test: `tests/capabilities/test_adr_capability_links.py::test_should_validate_adr_claim_requirement_link_metadata`
+- metadata_test: `tests/capabilities/test_adr_capability_links.py::test_should_validate_curated_semantic_claim_presence`
+- manual_review: `development/current-work/RELEASE_PLAN_status_appendix.md` (ADR-037 section)
+
+Test IDs:
+- `test_should_validate_adr_claim_requirement_link_metadata`
+- `test_should_validate_curated_semantic_claim_presence`
+- `test_should_require_behavioral_requirements_to_name_concrete_evidence`
+- `test_should_prevent_runtime_obligations_from_using_documentation_boundary_type`
+
+## Evidence required
+
+| Field | Required |
+|---|---|
+| commit_sha | yes |
+| package_version | yes |
+| test_id | yes |
+| result | yes (pass/fail/partial) |
+
+## Assumption boundary
+
+This requirement captures the normative ADR obligation and its evidence chain. It does not
+claim that metadata checks alone prove runtime correctness; behavior remains verified by the
+specific source, test, documentation, or quality-script evidence maintained for `ADR-037`.

--- a/development/capabilities/requirements/CE-REQ-VIZ-PLOT-KIND-GOVERNANCE-001.md
+++ b/development/capabilities/requirements/CE-REQ-VIZ-PLOT-KIND-GOVERNANCE-001.md
@@ -1,0 +1,65 @@
+# CE-REQ-VIZ-PLOT-KIND-GOVERNANCE-001 — Visualization plot kinds use a governed semantic vocabulary and runtime plot-kind extension remains disallowed.
+
+## Metadata
+
+| Field | Value |
+|---|---|
+| requirement_id | CE-REQ-VIZ-PLOT-KIND-GOVERNANCE-001 |
+| obligation_type | static_policy |
+| claim_refs | CE-CAP-VIZ-PLOT-KIND-GOVERNANCE-001 |
+| adr_refs | ADR-037 |
+| status | active |
+| verification_status | manual_review_required |
+
+## Scope
+
+ADR-governed implementation, documentation, and verification artifacts for `ADR-037`.
+
+## Observable behavior
+
+Visualization plot-kind governance MUST use the core semantic vocabulary and MUST NOT admit runtime plot-kind registration until a future ADR changes that policy.
+
+## Acceptance criterion
+
+Behavioral acceptance for this requirement is the ADR-specific obligation itself:
+
+- Visualization plot-kind governance MUST use the core semantic vocabulary and MUST NOT admit runtime plot-kind registration until a future ADR changes that policy.
+- Automated metadata tests MAY prove that the requirement is linked, but MUST NOT be
+  treated as proof that the behavioral obligation is satisfied.
+- Until a named runtime, static-policy, serialization, schema, or quality-gate check below
+  directly verifies the obligation, the verification status remains `manual_review_required`.
+
+## Verification method
+
+Verification method: `manual_review` plus the concrete source, documentation, schema,
+quality-script, or pytest targets listed below. Metadata tests are linkage guards only.
+
+## Verification targets
+
+- source: `development/adrs/ADR-037*.md`
+- schema: `development/schemas/plotspec_schema.json`
+- docs: `docs/foundations/how-to/plot_with_plotspec.md`
+- metadata_test: `tests/capabilities/test_adr_capability_links.py::test_should_validate_adr_claim_requirement_link_metadata`
+- metadata_test: `tests/capabilities/test_adr_capability_links.py::test_should_validate_curated_semantic_claim_presence`
+- manual_review: `development/current-work/RELEASE_PLAN_status_appendix.md` (ADR-037 section)
+
+Test IDs:
+- `test_should_validate_adr_claim_requirement_link_metadata`
+- `test_should_validate_curated_semantic_claim_presence`
+- `test_should_require_behavioral_requirements_to_name_concrete_evidence`
+- `test_should_prevent_runtime_obligations_from_using_documentation_boundary_type`
+
+## Evidence required
+
+| Field | Required |
+|---|---|
+| commit_sha | yes |
+| package_version | yes |
+| test_id | yes |
+| result | yes (pass/fail/partial) |
+
+## Assumption boundary
+
+This requirement captures the normative ADR obligation and its evidence chain. It does not
+claim that metadata checks alone prove runtime correctness; behavior remains verified by the
+specific source, test, documentation, or quality-script evidence maintained for `ADR-037`.

--- a/development/capabilities/requirements/CE-REQ-VIZ-SMOKE-001.md
+++ b/development/capabilities/requirements/CE-REQ-VIZ-SMOKE-001.md
@@ -7,6 +7,7 @@
 | requirement_id | CE-REQ-VIZ-SMOKE-001 |
 | obligation_type | empirical_smoke |
 | claim_refs | CE-CAP-VIZ-001 |
+| adr_refs | ADR-023, ADR-036, ADR-037 |
 | status | active |
 
 ## Scope

--- a/development/capabilities/requirements/README.md
+++ b/development/capabilities/requirements/README.md
@@ -36,7 +36,8 @@ Each requirement file must state:
 - **requirement_id**: unique CE-REQ-... identifier
 - **obligation_type**: one of `api_contract`, `payload_schema`, `numerical_behavior`,
   `statistical_method_alignment`, `documentation_boundary`, `visualization_behavior`,
-  `plugin_behavior`, `empirical_smoke`
+  `plugin_behavior`, `empirical_smoke`, `runtime_behavior`, `serialization_contract`,
+  `static_policy`, `quality_gate`, `manual_review_boundary`
 - **claim_refs**: which CE-CAP-... claims this requirement serves
 - **scope**: public API surface, task type, and workflow applicable
 - **observable_behavior**: what must be true when the requirement is satisfied
@@ -46,6 +47,20 @@ Each requirement file must state:
 - **test_refs**: which tests in `tests/capabilities/` (or linked nearby tests) verify
   this requirement
 - **evidence_required**: metadata that a passing evidence record must include
+
+## Verification assurance metadata
+
+Semantic ADR requirements that are not fully automated should name concrete
+verification targets in the requirement body. Use `verification_status` in the
+Metadata table when needed:
+
+- `verified`: named automated or quality-gate evidence directly checks the behavior.
+- `partial`: evidence covers only part of the obligation.
+- `manual_review_required`: the requirement is explicit but still needs human review
+  or additional automated tests before it can be treated as runtime-proven.
+
+Metadata/linkage tests are allowed as drift guards, but they do not prove runtime,
+serialization, static-policy, or quality-gate obligations by themselves.
 
 ## Rules
 

--- a/development/capabilities/requirements/README.md
+++ b/development/capabilities/requirements/README.md
@@ -10,7 +10,7 @@ defined in `development/README.md`:
 ```text
 Capability claim
     -> requirement
-    -> verification case
+    -> executable verification case
     -> evidence record
 ```
 
@@ -42,25 +42,33 @@ Each requirement file must state:
 - **scope**: public API surface, task type, and workflow applicable
 - **observable_behavior**: what must be true when the requirement is satisfied
 - **acceptance_criterion**: the measurable or checkable condition
-- **verification_method**: how the criterion is checked (automated test, structural
-  check, analytical review, etc.)
-- **test_refs**: which tests in `tests/capabilities/` (or linked nearby tests) verify
-  this requirement
+- **verification_method**: how the criterion is checked
+- **test_refs**: which executable tests verify this requirement
 - **evidence_required**: metadata that a passing evidence record must include
 
 ## Verification assurance metadata
 
-Semantic ADR requirements that are not fully automated should name concrete
-verification targets in the requirement body. Use `verification_status` in the
-Metadata table when needed:
+Semantic ADR requirements must terminate in executable verification. Metadata/linkage
+tests are allowed as drift guards, but they do not prove runtime, serialization,
+static-policy, visualization, plugin, quality-gate, or API-contract obligations by
+themselves.
 
-- `verified`: named automated or quality-gate evidence directly checks the behavior.
-- `partial`: evidence covers only part of the obligation.
-- `manual_review_required`: the requirement is explicit but still needs human review
-  or additional automated tests before it can be treated as runtime-proven.
+Use `verification_status` in the Metadata table when needed:
 
-Metadata/linkage tests are allowed as drift guards, but they do not prove runtime,
-serialization, static-policy, or quality-gate obligations by themselves.
+- `verified`: named automated pytest or quality-gate evidence directly checks the behavior.
+- `partial`: named automated evidence covers only part of the obligation; the uncovered
+  portion must be represented as a separate requirement or ADR gap before the claim is
+  treated as fully verified.
+- `adr_gap_open`: the requirement or part of the requirement is not yet implemented. The
+  requirement must include `gap_ref` or `adr_gap_ref`, and the referenced gap must appear
+  in `development/current-work/RELEASE_PLAN_status_appendix.md`.
+- `not_implemented`: equivalent to `adr_gap_open` for pre-implementation requirements;
+  it must also include `gap_ref` or `adr_gap_ref` and an ADR status appendix entry.
+
+`manual_review_required` is not an acceptable verification status for an active
+behavioral requirement. Human or manual review can inform the gap analysis, but it is
+not evidence for requirements-as-code compatibility. If an implementation is missing,
+register it as an ADR gap instead of treating human verification as a test method.
 
 ## Rules
 
@@ -69,6 +77,13 @@ serialization, static-policy, or quality-gate obligations by themselves.
 3. Every requirement must have a stated `verification_method` and `acceptance_criterion`.
 4. Acceptance criteria must be visible here, not hidden inside test code only.
 5. Statistical obligations must state their assumptions explicitly.
+6. Every active behavioral requirement must name at least one executable pytest target.
+7. Documentation-boundary requirements may use metadata/linkage tests, but behavioral
+   requirements must name non-metadata pytest evidence.
+8. Human or manual verification is allowed only when the requirement is not implemented
+   and the requirement cites a registered ADR gap.
+9. A source file, documentation page, schema file, or standard is supporting context, not
+   proof of behavioral satisfaction unless an executable test or quality script checks it.
 
 ---
 
@@ -122,7 +137,7 @@ The acceptance criterion must contain separate sub-entries for collection and
 individual to ensure each is independently verifiable. Tests can be separate
 functions within the same test file — one per object level.
 
-Do NOT create separate requirements just because the same operation is callable
+Do NOT create separate requirements just because the operation is callable
 on both a collection and an individual.
 
 ```
@@ -155,9 +170,10 @@ controlling how many features are considered) does not require a separate requir
 
 ### Rule R-6 — Each requirement must have at least one test
 
-Every requirement file must reference at least one named test in `tests/capabilities/`.
-Tests for a family of related requirements can live in one test file, but each
-requirement must have its own named test function.
+Every requirement file must reference at least one named test in `tests/capabilities/`
+or another concrete test module. Tests for a family of related requirements can live
+in one test file, but each requirement must have its own named test function unless it
+is a documentation-boundary requirement verified solely by metadata/linkage tests.
 
 ## Related locations
 

--- a/tests/capabilities/test_adr_capability_links.py
+++ b/tests/capabilities/test_adr_capability_links.py
@@ -1,0 +1,247 @@
+"""Capability metadata checks for ADR evidence-bearing links."""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+
+_REQUIRED_SEMANTIC_CLAIMS = {
+    "ADR-027": ['CE-CAP-EXPL-FAST-FILTER-001'],
+    "ADR-032": ['CE-CAP-GUARD-MEDIAN-PROBE-001', 'CE-CAP-GUARD-AUDIT-001', 'CE-CAP-GUARD-CALIBRATION-ALIGNMENT-001', 'CE-CAP-GUARD-CONJUNCTION-001', 'CE-CAP-GUARD-PLUGIN-SUPPORT-001', 'CE-CAP-GUARD-NO-FAST-001', 'CE-CAP-ALT-TARGET-CONFIDENCE-001'],
+    "ADR-029": ['CE-CAP-REJECT-DEFAULT-OFF-001', 'CE-CAP-REJECT-POLICY-ENUM-001', 'CE-CAP-REJECT-RESULT-ENVELOPE-001', 'CE-CAP-REJECT-STRATEGY-REGISTRY-001', 'CE-CAP-REJECT-NO-VIZ-001'],
+    "ADR-013": ['CE-CAP-INTERVAL-PLUGIN-PROTOCOL-001', 'CE-CAP-INTERVAL-CONTEXT-IMMUTABILITY-001', 'CE-CAP-INTERVAL-PLUGIN-FALLBACK-001', 'CE-CAP-FAST-INTERVAL-PLUGIN-001', 'CE-CAP-INTERVAL-PLUGIN-VALIDATION-001'],
+    "ADR-036": ['CE-CAP-PLOTSPEC-CANONICAL-DATACLASS-001', 'CE-CAP-PLOTSPEC-BOUNDARY-SERIALIZATION-001', 'CE-CAP-PLOTSPEC-BUILDER-VALIDATION-001', 'CE-CAP-PLOTSPEC-BACKEND-NEUTRALITY-001'],
+    "ADR-037": ['CE-CAP-VIZ-EXTENSION-METADATA-001', 'CE-CAP-VIZ-PLOT-KIND-GOVERNANCE-001', 'CE-CAP-VIZ-DEFAULT-PLOTSPEC-PATH-001'],
+    "ADR-034": ['CE-CAP-CONFIG-AUTHORITY-001', 'CE-CAP-CONFIG-PRECEDENCE-SNAPSHOT-001', 'CE-CAP-CONFIG-STRICT-VALIDATION-001', 'CE-CAP-CONFIG-DIAGNOSTIC-EXPORT-001', 'CE-CAP-CONFIG-CI-ENFORCEMENT-001'],
+    "ADR-028": ['CE-CAP-LOG-DOMAIN-TAXONOMY-001', 'CE-CAP-GOVERNANCE-LOG-SEPARATION-001', 'CE-CAP-LOG-CONTEXT-PROPAGATION-001', 'CE-CAP-LOG-STRUCTURED-COMPATIBILITY-001', 'CE-CAP-LOG-NO-GLOBAL-HANDLERS-001', 'CE-CAP-LOG-DATA-MINIMISATION-001'],
+    "ADR-031": ['CE-CAP-CALIBRATOR-PRIMITIVE-SCHEMA-001', 'CE-CAP-EXPLAINER-STATE-PERSISTENCE-001', 'CE-CAP-SERIAL-FAIL-FAST-VERSIONING-001', 'CE-CAP-SERIAL-ROUNDTRIP-INVARIANTS-001'],
+    "ADR-005": ['CE-CAP-SCHEMA-PAYLOAD-V1-001', 'CE-CAP-SCHEMA-VALIDATION-001', 'CE-CAP-SCHEMA-EXTENSION-SURFACE-001'],
+    "ADR-008": ['CE-CAP-DOMAIN-MODEL-001', 'CE-CAP-DOMAIN-LEGACY-ADAPTER-001', 'CE-CAP-EXPL-PAPER-SEMANTICS-001'],
+    "ADR-006": ['CE-CAP-PLUGIN-TRUST-POLICY-001', 'CE-CAP-PLUGIN-DISCOVERY-REPORT-001', 'CE-CAP-PLUGIN-AUDIT-EVENTS-001'],
+    "ADR-033": ['CE-CAP-MODALITY-METADATA-001', 'CE-CAP-MODALITY-RESOLUTION-001', 'CE-CAP-MODALITY-SHIMS-001', 'CE-CAP-MODALITY-TABULAR-INVARIANT-001'],
+}
+
+
+def test_should_validate_curated_semantic_claim_presence() -> None:
+    """Verifies the minimum semantic ADR claim split required by the hardening pass."""
+    adr_dir = _repo_root() / "development" / "adrs"
+    claim_dir = _repo_root() / "development" / "capabilities" / "claims"
+    errors: list[str] = []
+
+    for adr_id, required_claims in _REQUIRED_SEMANTIC_CLAIMS.items():
+        adr_matches = list(adr_dir.glob(f"{adr_id}-*.md"))
+        if not adr_matches:
+            errors.append(f"missing ADR file for {adr_id}")
+            continue
+        adr_text = adr_matches[0].read_text(encoding="utf-8")
+        for claim_id in required_claims:
+            claim_path = claim_dir / f"{claim_id}.yaml"
+            if not claim_path.exists():
+                errors.append(f"{claim_id} is required for {adr_id} but has no claim file")
+                continue
+            if f"`{claim_id}`" not in adr_text:
+                errors.append(f"{adr_id} does not list required semantic claim {claim_id}")
+            if adr_id not in _yaml_list(claim_path.read_text(encoding="utf-8"), "adr_links"):
+                errors.append(f"{claim_id} does not link back to {adr_id}")
+
+    adr027_text = next(adr_dir.glob("ADR-027-*.md")).read_text(encoding="utf-8")
+    assert "`CE-CAP-EXPL-FILTER-001`" not in adr027_text
+    assert not errors, "\n".join(errors)
+
+
+def _repo_root() -> Path:
+    return Path(__file__).resolve().parents[2]
+
+
+def _yaml_list(text: str, key: str) -> list[str]:
+    match = re.search(rf"^{key}:\n((?:  - .+\n)+)", text, re.MULTILINE)
+    if not match:
+        return []
+    return [line.split("-", 1)[1].strip() for line in match.group(1).splitlines()]
+
+
+def _metadata_value(text: str, field: str) -> str:
+    match = re.search(rf"^\| {re.escape(field)} \| ([^|]+) \|", text, re.MULTILINE)
+    return match.group(1).strip() if match else ""
+
+
+
+
+_BEHAVIORAL_TYPES = {
+    "api_contract",
+    "runtime_behavior",
+    "serialization_contract",
+    "payload_schema",
+    "static_policy",
+    "quality_gate",
+}
+
+_METADATA_ONLY_TESTS = {
+    "test_should_validate_adr_claim_requirement_link_metadata",
+    "test_should_validate_curated_semantic_claim_presence",
+}
+
+
+def _requirement_files() -> list[Path]:
+    return sorted((_repo_root() / "development" / "capabilities" / "requirements").glob("CE-REQ-*.md"))
+
+
+def _requirement_id(path: Path) -> str:
+    return path.stem
+
+
+def test_should_require_behavioral_requirements_to_name_concrete_evidence() -> None:
+    """Verifies behavioral requirements do not rely only on metadata tests."""
+    errors: list[str] = []
+
+    for path in _requirement_files():
+        text = path.read_text(encoding="utf-8")
+        obligation_type = _metadata_value(text, "obligation_type")
+        if obligation_type not in _BEHAVIORAL_TYPES:
+            continue
+        if "## Verification targets" in text:
+            target_block = text.split("## Verification targets", 1)[1].split("\n## ", 1)[0]
+        elif "Automated pytest" in text and "tests/capabilities/" in text:
+            # Existing capability requirements predate the explicit Verification targets
+            # section and name concrete pytest files/functions in their Verification method.
+            target_block = text
+        else:
+            errors.append(f"{_requirement_id(path)} has no concrete verification targets")
+            continue
+        has_non_metadata_target = any(
+            marker in target_block
+            for marker in (
+                "- source:",
+                "- quality_script:",
+                "- docs:",
+                "- schema:",
+                "- standard:",
+                "- manual_review:",
+                "- pytest:",
+                "tests/capabilities/",
+                "Test ID:",
+                "Test IDs:",
+            )
+        )
+        if not has_non_metadata_target:
+            errors.append(f"{_requirement_id(path)} only names metadata tests as evidence")
+        for metadata_test in _METADATA_ONLY_TESTS:
+            if metadata_test in target_block and not has_non_metadata_target:
+                errors.append(f"{_requirement_id(path)} treats {metadata_test} as sole evidence")
+
+    assert not errors, "\n".join(errors)
+
+
+def test_should_prevent_runtime_obligations_from_using_documentation_boundary_type() -> None:
+    """Verifies runtime MUST language is not mislabeled as documentation-only."""
+    runtime_terms = (
+        "MUST raise",
+        "MUST reject",
+        "MUST return",
+        "MUST fail",
+        "MUST preserve",
+        "MUST validate",
+        "MUST apply",
+        "MUST expose",
+        "MUST read",
+        "MUST serialize",
+        "MUST restore",
+    )
+    errors: list[str] = []
+
+    for path in _requirement_files():
+        text = path.read_text(encoding="utf-8")
+        obligation_type = _metadata_value(text, "obligation_type")
+        if obligation_type != "documentation_boundary":
+            continue
+        observable = text.split("## Observable behavior", 1)[1].split("\n## ", 1)[0]
+        if any(term in observable for term in runtime_terms):
+            errors.append(f"{_requirement_id(path)} has runtime MUST language but documentation_boundary type")
+
+    assert not errors, "\n".join(errors)
+
+
+def test_should_require_semantic_claims_to_have_non_metadata_requirements() -> None:
+    """Verifies curated semantic claims are backed by non-documentation requirements."""
+    req_dir = _repo_root() / "development" / "capabilities" / "requirements"
+    claim_dir = _repo_root() / "development" / "capabilities" / "claims"
+    errors: list[str] = []
+
+    for required_claims in _REQUIRED_SEMANTIC_CLAIMS.values():
+        for claim_id in required_claims:
+            claim_text = (claim_dir / f"{claim_id}.yaml").read_text(encoding="utf-8")
+            requirement_ids = _yaml_list(claim_text, "requirements")
+            if not requirement_ids:
+                errors.append(f"{claim_id} has no requirement links")
+                continue
+            concrete = False
+            for requirement_id in requirement_ids:
+                req_path = req_dir / f"{requirement_id}.md"
+                if not req_path.exists():
+                    errors.append(f"{claim_id} references missing requirement {requirement_id}")
+                    continue
+                req_text = req_path.read_text(encoding="utf-8")
+                if _metadata_value(req_text, "obligation_type") != "documentation_boundary":
+                    concrete = True
+            if not concrete:
+                errors.append(f"{claim_id} has only documentation-boundary requirements")
+
+    assert not errors, "\n".join(errors)
+
+
+def test_should_validate_adr_claim_requirement_link_metadata() -> None:
+    """Verifies ADR-governed CE-CAP/CE-REQ link consistency."""
+    root = _repo_root()
+    adr_dir = root / "development" / "adrs"
+    claim_dir = root / "development" / "capabilities" / "claims"
+    req_dir = root / "development" / "capabilities" / "requirements"
+
+    claim_files = {path.stem: path for path in claim_dir.glob("CE-CAP-*.yaml")}
+    requirement_files = {path.stem: path for path in req_dir.glob("CE-REQ-*.md")}
+    active_adr_files = [path for path in adr_dir.glob("ADR-*.md")]
+
+    errors: list[str] = []
+
+    for adr_path in active_adr_files:
+        adr_id = re.search(r"ADR-\d+", adr_path.name).group(0)
+        adr_text = adr_path.read_text(encoding="utf-8")
+        governed_claims = re.findall(r"^- `(CE-CAP-[A-Z0-9-]+)`", adr_text, re.MULTILINE)
+        if not governed_claims:
+            errors.append(f"{adr_id} does not list governed claims")
+            continue
+        for claim_id in governed_claims:
+            claim_path = claim_files.get(claim_id)
+            if claim_path is None:
+                errors.append(f"{adr_id} references missing claim {claim_id}")
+                continue
+            claim_text = claim_path.read_text(encoding="utf-8")
+            if adr_id not in _yaml_list(claim_text, "adr_links"):
+                errors.append(f"{claim_id} does not link back to {adr_id}")
+
+    for claim_id, claim_path in claim_files.items():
+        claim_text = claim_path.read_text(encoding="utf-8")
+        adr_links = _yaml_list(claim_text, "adr_links")
+        requirements = _yaml_list(claim_text, "requirements")
+        if not adr_links:
+            errors.append(f"{claim_id} has no adr_links")
+        if not requirements:
+            errors.append(f"{claim_id} has no requirements")
+        for adr_id in adr_links:
+            matches = list(adr_dir.glob(f"{adr_id}-*.md"))
+            if not matches:
+                errors.append(f"{claim_id} references missing ADR {adr_id}")
+                continue
+            if f"`{claim_id}`" not in matches[0].read_text(encoding="utf-8"):
+                errors.append(f"{adr_id} does not list {claim_id}")
+        for req_id in requirements:
+            req_path = requirement_files.get(req_id)
+            if req_path is None:
+                errors.append(f"{claim_id} references missing requirement {req_id}")
+                continue
+            req_text = req_path.read_text(encoding="utf-8")
+            claim_refs = _metadata_value(req_text, "claim_refs")
+            if claim_id not in claim_refs:
+                errors.append(f"{req_id} does not link back to {claim_id}")
+
+    assert not errors, "\n".join(errors)

--- a/tests/capabilities/test_adr_capability_links.py
+++ b/tests/capabilities/test_adr_capability_links.py
@@ -1,26 +1,127 @@
-"""Capability metadata checks for ADR evidence-bearing links."""
+"""Capability metadata and requirements-as-code checks for ADR evidence links."""
 
 from __future__ import annotations
 
+import ast
 import re
 from pathlib import Path
 
 
 _REQUIRED_SEMANTIC_CLAIMS = {
-    "ADR-027": ['CE-CAP-EXPL-FAST-FILTER-001'],
-    "ADR-032": ['CE-CAP-GUARD-MEDIAN-PROBE-001', 'CE-CAP-GUARD-AUDIT-001', 'CE-CAP-GUARD-CALIBRATION-ALIGNMENT-001', 'CE-CAP-GUARD-CONJUNCTION-001', 'CE-CAP-GUARD-PLUGIN-SUPPORT-001', 'CE-CAP-GUARD-NO-FAST-001', 'CE-CAP-ALT-TARGET-CONFIDENCE-001'],
-    "ADR-029": ['CE-CAP-REJECT-DEFAULT-OFF-001', 'CE-CAP-REJECT-POLICY-ENUM-001', 'CE-CAP-REJECT-RESULT-ENVELOPE-001', 'CE-CAP-REJECT-STRATEGY-REGISTRY-001', 'CE-CAP-REJECT-NO-VIZ-001'],
-    "ADR-013": ['CE-CAP-INTERVAL-PLUGIN-PROTOCOL-001', 'CE-CAP-INTERVAL-CONTEXT-IMMUTABILITY-001', 'CE-CAP-INTERVAL-PLUGIN-FALLBACK-001', 'CE-CAP-FAST-INTERVAL-PLUGIN-001', 'CE-CAP-INTERVAL-PLUGIN-VALIDATION-001'],
-    "ADR-036": ['CE-CAP-PLOTSPEC-CANONICAL-DATACLASS-001', 'CE-CAP-PLOTSPEC-BOUNDARY-SERIALIZATION-001', 'CE-CAP-PLOTSPEC-BUILDER-VALIDATION-001', 'CE-CAP-PLOTSPEC-BACKEND-NEUTRALITY-001'],
-    "ADR-037": ['CE-CAP-VIZ-EXTENSION-METADATA-001', 'CE-CAP-VIZ-PLOT-KIND-GOVERNANCE-001', 'CE-CAP-VIZ-DEFAULT-PLOTSPEC-PATH-001'],
-    "ADR-034": ['CE-CAP-CONFIG-AUTHORITY-001', 'CE-CAP-CONFIG-PRECEDENCE-SNAPSHOT-001', 'CE-CAP-CONFIG-STRICT-VALIDATION-001', 'CE-CAP-CONFIG-DIAGNOSTIC-EXPORT-001', 'CE-CAP-CONFIG-CI-ENFORCEMENT-001'],
-    "ADR-028": ['CE-CAP-LOG-DOMAIN-TAXONOMY-001', 'CE-CAP-GOVERNANCE-LOG-SEPARATION-001', 'CE-CAP-LOG-CONTEXT-PROPAGATION-001', 'CE-CAP-LOG-STRUCTURED-COMPATIBILITY-001', 'CE-CAP-LOG-NO-GLOBAL-HANDLERS-001', 'CE-CAP-LOG-DATA-MINIMISATION-001'],
-    "ADR-031": ['CE-CAP-CALIBRATOR-PRIMITIVE-SCHEMA-001', 'CE-CAP-EXPLAINER-STATE-PERSISTENCE-001', 'CE-CAP-SERIAL-FAIL-FAST-VERSIONING-001', 'CE-CAP-SERIAL-ROUNDTRIP-INVARIANTS-001'],
-    "ADR-005": ['CE-CAP-SCHEMA-PAYLOAD-V1-001', 'CE-CAP-SCHEMA-VALIDATION-001', 'CE-CAP-SCHEMA-EXTENSION-SURFACE-001'],
-    "ADR-008": ['CE-CAP-DOMAIN-MODEL-001', 'CE-CAP-DOMAIN-LEGACY-ADAPTER-001', 'CE-CAP-EXPL-PAPER-SEMANTICS-001'],
-    "ADR-006": ['CE-CAP-PLUGIN-TRUST-POLICY-001', 'CE-CAP-PLUGIN-DISCOVERY-REPORT-001', 'CE-CAP-PLUGIN-AUDIT-EVENTS-001'],
-    "ADR-033": ['CE-CAP-MODALITY-METADATA-001', 'CE-CAP-MODALITY-RESOLUTION-001', 'CE-CAP-MODALITY-SHIMS-001', 'CE-CAP-MODALITY-TABULAR-INVARIANT-001'],
+    "ADR-027": ["CE-CAP-EXPL-FAST-FILTER-001"],
+    "ADR-032": [
+        "CE-CAP-GUARD-MEDIAN-PROBE-001",
+        "CE-CAP-GUARD-AUDIT-001",
+        "CE-CAP-GUARD-CALIBRATION-ALIGNMENT-001",
+        "CE-CAP-GUARD-CONJUNCTION-001",
+        "CE-CAP-GUARD-PLUGIN-SUPPORT-001",
+        "CE-CAP-GUARD-NO-FAST-001",
+        "CE-CAP-ALT-TARGET-CONFIDENCE-001",
+    ],
+    "ADR-029": [
+        "CE-CAP-REJECT-DEFAULT-OFF-001",
+        "CE-CAP-REJECT-POLICY-ENUM-001",
+        "CE-CAP-REJECT-RESULT-ENVELOPE-001",
+        "CE-CAP-REJECT-STRATEGY-REGISTRY-001",
+        "CE-CAP-REJECT-NO-VIZ-001",
+    ],
+    "ADR-013": [
+        "CE-CAP-INTERVAL-PLUGIN-PROTOCOL-001",
+        "CE-CAP-INTERVAL-CONTEXT-IMMUTABILITY-001",
+        "CE-CAP-INTERVAL-PLUGIN-FALLBACK-001",
+        "CE-CAP-FAST-INTERVAL-PLUGIN-001",
+        "CE-CAP-INTERVAL-PLUGIN-VALIDATION-001",
+    ],
+    "ADR-036": [
+        "CE-CAP-PLOTSPEC-CANONICAL-DATACLASS-001",
+        "CE-CAP-PLOTSPEC-BOUNDARY-SERIALIZATION-001",
+        "CE-CAP-PLOTSPEC-BUILDER-VALIDATION-001",
+        "CE-CAP-PLOTSPEC-BACKEND-NEUTRALITY-001",
+    ],
+    "ADR-037": [
+        "CE-CAP-VIZ-EXTENSION-METADATA-001",
+        "CE-CAP-VIZ-PLOT-KIND-GOVERNANCE-001",
+        "CE-CAP-VIZ-DEFAULT-PLOTSPEC-PATH-001",
+    ],
+    "ADR-034": [
+        "CE-CAP-CONFIG-AUTHORITY-001",
+        "CE-CAP-CONFIG-PRECEDENCE-SNAPSHOT-001",
+        "CE-CAP-CONFIG-STRICT-VALIDATION-001",
+        "CE-CAP-CONFIG-DIAGNOSTIC-EXPORT-001",
+        "CE-CAP-CONFIG-CI-ENFORCEMENT-001",
+    ],
+    "ADR-028": [
+        "CE-CAP-LOG-DOMAIN-TAXONOMY-001",
+        "CE-CAP-GOVERNANCE-LOG-SEPARATION-001",
+        "CE-CAP-LOG-CONTEXT-PROPAGATION-001",
+        "CE-CAP-LOG-STRUCTURED-COMPATIBILITY-001",
+        "CE-CAP-LOG-NO-GLOBAL-HANDLERS-001",
+        "CE-CAP-LOG-DATA-MINIMISATION-001",
+    ],
+    "ADR-031": [
+        "CE-CAP-CALIBRATOR-PRIMITIVE-SCHEMA-001",
+        "CE-CAP-EXPLAINER-STATE-PERSISTENCE-001",
+        "CE-CAP-SERIAL-FAIL-FAST-VERSIONING-001",
+        "CE-CAP-SERIAL-ROUNDTRIP-INVARIANTS-001",
+    ],
+    "ADR-005": [
+        "CE-CAP-SCHEMA-PAYLOAD-V1-001",
+        "CE-CAP-SCHEMA-VALIDATION-001",
+        "CE-CAP-SCHEMA-EXTENSION-SURFACE-001",
+    ],
+    "ADR-008": [
+        "CE-CAP-DOMAIN-MODEL-001",
+        "CE-CAP-DOMAIN-LEGACY-ADAPTER-001",
+        "CE-CAP-EXPL-PAPER-SEMANTICS-001",
+    ],
+    "ADR-006": [
+        "CE-CAP-PLUGIN-TRUST-POLICY-001",
+        "CE-CAP-PLUGIN-DISCOVERY-REPORT-001",
+        "CE-CAP-PLUGIN-AUDIT-EVENTS-001",
+    ],
+    "ADR-033": [
+        "CE-CAP-MODALITY-METADATA-001",
+        "CE-CAP-MODALITY-RESOLUTION-001",
+        "CE-CAP-MODALITY-SHIMS-001",
+        "CE-CAP-MODALITY-TABULAR-INVARIANT-001",
+    ],
+    "ADR-030": ["CE-CAP-REQ-AS-CODE-001"],
+    "ADR-035": ["CE-CAP-REQ-AS-CODE-001"],
 }
+
+
+_BEHAVIORAL_TYPES = {
+    "api_contract",
+    "empirical_smoke",
+    "numerical_behavior",
+    "payload_schema",
+    "plugin_behavior",
+    "quality_gate",
+    "runtime_behavior",
+    "serialization_contract",
+    "static_policy",
+    "statistical_method_alignment",
+    "visualization_behavior",
+}
+
+_METADATA_ONLY_TESTS = {
+    "test_should_validate_adr_claim_requirement_link_metadata",
+    "test_should_validate_curated_semantic_claim_presence",
+}
+
+_GAP_STATUSES = {"adr_gap_open", "not_implemented"}
+_HUMAN_VERIFICATION_TERMS = (
+    "manual_review",
+    "manual review",
+    "manual_review_required",
+    "human verification",
+    "human review",
+    "analytical review",
+)
+_TEST_TARGET_PATTERN = re.compile(
+    r"tests/[A-Za-z0-9_./-]+\.py(?:::[A-Za-z_][A-Za-z0-9_]*(?:\[[^\]]+\])?)?"
+)
+_TEST_FUNCTION_PATTERN = re.compile(r"test_[A-Za-z_][A-Za-z0-9_]*(?:\[[^\]]+\])?")
 
 
 def test_should_validate_curated_semantic_claim_presence() -> None:
@@ -50,85 +151,71 @@ def test_should_validate_curated_semantic_claim_presence() -> None:
     assert not errors, "\n".join(errors)
 
 
-def _repo_root() -> Path:
-    return Path(__file__).resolve().parents[2]
-
-
-def _yaml_list(text: str, key: str) -> list[str]:
-    match = re.search(rf"^{key}:\n((?:  - .+\n)+)", text, re.MULTILINE)
-    if not match:
-        return []
-    return [line.split("-", 1)[1].strip() for line in match.group(1).splitlines()]
-
-
-def _metadata_value(text: str, field: str) -> str:
-    match = re.search(rf"^\| {re.escape(field)} \| ([^|]+) \|", text, re.MULTILINE)
-    return match.group(1).strip() if match else ""
-
-
-
-
-_BEHAVIORAL_TYPES = {
-    "api_contract",
-    "runtime_behavior",
-    "serialization_contract",
-    "payload_schema",
-    "static_policy",
-    "quality_gate",
-}
-
-_METADATA_ONLY_TESTS = {
-    "test_should_validate_adr_claim_requirement_link_metadata",
-    "test_should_validate_curated_semantic_claim_presence",
-}
-
-
-def _requirement_files() -> list[Path]:
-    return sorted((_repo_root() / "development" / "capabilities" / "requirements").glob("CE-REQ-*.md"))
-
-
-def _requirement_id(path: Path) -> str:
-    return path.stem
-
-
 def test_should_require_behavioral_requirements_to_name_concrete_evidence() -> None:
-    """Verifies behavioral requirements do not rely only on metadata tests."""
+    """Verifies behavioral requirements terminate in executable pytest evidence."""
+    indexed_tests = _indexed_test_functions()
     errors: list[str] = []
 
     for path in _requirement_files():
         text = path.read_text(encoding="utf-8")
+        requirement_id = _requirement_id(path)
         obligation_type = _metadata_value(text, "obligation_type")
         if obligation_type not in _BEHAVIORAL_TYPES:
             continue
-        if "## Verification targets" in text:
-            target_block = text.split("## Verification targets", 1)[1].split("\n## ", 1)[0]
-        elif "Automated pytest" in text and "tests/capabilities/" in text:
-            # Existing capability requirements predate the explicit Verification targets
-            # section and name concrete pytest files/functions in their Verification method.
-            target_block = text
-        else:
-            errors.append(f"{_requirement_id(path)} has no concrete verification targets")
+        if _has_registered_adr_gap(requirement_id, text):
             continue
-        has_non_metadata_target = any(
-            marker in target_block
-            for marker in (
-                "- source:",
-                "- quality_script:",
-                "- docs:",
-                "- schema:",
-                "- standard:",
-                "- manual_review:",
-                "- pytest:",
-                "tests/capabilities/",
-                "Test ID:",
-                "Test IDs:",
+
+        targets = _pytest_targets(text)
+        if not targets:
+            errors.append(
+                f"{requirement_id} is {obligation_type} but has no named pytest target"
             )
-        )
-        if not has_non_metadata_target:
-            errors.append(f"{_requirement_id(path)} only names metadata tests as evidence")
-        for metadata_test in _METADATA_ONLY_TESTS:
-            if metadata_test in target_block and not has_non_metadata_target:
-                errors.append(f"{_requirement_id(path)} treats {metadata_test} as sole evidence")
+            continue
+
+        concrete_targets = [
+            target
+            for target in targets
+            if _target_exists(target, indexed_tests) and not _is_metadata_only_target(target)
+        ]
+        if not concrete_targets:
+            errors.append(
+                f"{requirement_id} is {obligation_type} but only names missing or "
+                "metadata-only pytest targets"
+            )
+
+    assert not errors, "\n".join(errors)
+
+
+def test_should_reject_human_verification_without_registered_adr_gap() -> None:
+    """Verifies manual verification is used only for explicitly registered ADR gaps."""
+    errors: list[str] = []
+
+    for path in _requirement_files():
+        text = path.read_text(encoding="utf-8")
+        requirement_id = _requirement_id(path)
+        if not _uses_human_verification(text):
+            continue
+        if not _has_registered_adr_gap(requirement_id, text):
+            errors.append(
+                f"{requirement_id} uses human/manual verification without "
+                "verification_status=adr_gap_open (or not_implemented), a gap_ref, "
+                "and an ADR status appendix entry"
+            )
+
+    assert not errors, "\n".join(errors)
+
+
+def test_should_require_claimed_pytest_targets_to_be_real_tests() -> None:
+    """Verifies requirement files do not cite non-existent pytest evidence."""
+    indexed_tests = _indexed_test_functions()
+    errors: list[str] = []
+
+    for path in _requirement_files():
+        text = path.read_text(encoding="utf-8")
+        requirement_id = _requirement_id(path)
+        for target in _pytest_targets(text):
+            if not _target_exists(target, indexed_tests):
+                errors.append(f"{requirement_id} references missing pytest target {target}")
 
     assert not errors, "\n".join(errors)
 
@@ -155,7 +242,7 @@ def test_should_prevent_runtime_obligations_from_using_documentation_boundary_ty
         obligation_type = _metadata_value(text, "obligation_type")
         if obligation_type != "documentation_boundary":
             continue
-        observable = text.split("## Observable behavior", 1)[1].split("\n## ", 1)[0]
+        observable = _section(text, "Observable behavior")
         if any(term in observable for term in runtime_terms):
             errors.append(f"{_requirement_id(path)} has runtime MUST language but documentation_boundary type")
 
@@ -245,3 +332,113 @@ def test_should_validate_adr_claim_requirement_link_metadata() -> None:
                 errors.append(f"{req_id} does not link back to {claim_id}")
 
     assert not errors, "\n".join(errors)
+
+
+def _repo_root() -> Path:
+    return Path(__file__).resolve().parents[2]
+
+
+def _yaml_list(text: str, key: str) -> list[str]:
+    match = re.search(rf"^{key}:\n((?:  - .+\n)+)", text, re.MULTILINE)
+    if not match:
+        return []
+    return [line.split("-", 1)[1].strip() for line in match.group(1).splitlines()]
+
+
+def _metadata_value(text: str, field: str) -> str:
+    match = re.search(rf"^\| {re.escape(field)} \| ([^|]+) \|", text, re.MULTILINE)
+    return match.group(1).strip() if match else ""
+
+
+def _section(text: str, heading: str) -> str:
+    marker = f"## {heading}"
+    if marker not in text:
+        return ""
+    return text.split(marker, 1)[1].split("\n## ", 1)[0]
+
+
+def _requirement_files() -> list[Path]:
+    return sorted((_repo_root() / "development" / "capabilities" / "requirements").glob("CE-REQ-*.md"))
+
+
+def _requirement_id(path: Path) -> str:
+    return path.stem
+
+
+def _uses_human_verification(text: str) -> bool:
+    lowered = text.lower()
+    return any(term in lowered for term in _HUMAN_VERIFICATION_TERMS)
+
+
+def _has_registered_adr_gap(requirement_id: str, requirement_text: str) -> bool:
+    status = _metadata_value(requirement_text, "verification_status")
+    gap_ref = _metadata_value(requirement_text, "gap_ref") or _metadata_value(
+        requirement_text, "adr_gap_ref"
+    )
+    if status not in _GAP_STATUSES or not gap_ref:
+        return False
+
+    appendix = _repo_root() / "development" / "current-work" / "RELEASE_PLAN_status_appendix.md"
+    if not appendix.exists():
+        return False
+    appendix_text = appendix.read_text(encoding="utf-8")
+    return requirement_id in appendix_text or gap_ref in appendix_text
+
+
+def _pytest_targets(text: str) -> set[str]:
+    targets: set[str] = set()
+    for raw_target in _TEST_TARGET_PATTERN.findall(text):
+        targets.add(raw_target.rstrip(".,);"))
+
+    test_ids = {
+        item.split("[", 1)[0]
+        for item in _TEST_FUNCTION_PATTERN.findall(text)
+        if item.startswith("test_")
+    }
+    path_targets = {target.split("::", 1)[0] for target in targets}
+    if len(path_targets) == 1:
+        test_path = next(iter(path_targets))
+        for test_id in test_ids:
+            targets.add(f"{test_path}::{test_id}")
+    else:
+        targets.update(test_ids)
+    return targets
+
+
+def _indexed_test_functions() -> dict[str, set[str]]:
+    root = _repo_root()
+    index: dict[str, set[str]] = {}
+    for path in sorted((root / "tests").rglob("test_*.py")):
+        rel_path = path.relative_to(root).as_posix()
+        try:
+            tree = ast.parse(path.read_text(encoding="utf-8"))
+        except SyntaxError as exc:  # pragma: no cover - syntax error fails repository tests anyway.
+            raise AssertionError(f"could not parse {rel_path}: {exc}") from exc
+        functions = {
+            node.name
+            for node in ast.walk(tree)
+            if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+            and node.name.startswith("test_")
+        }
+        index[rel_path] = functions
+    return index
+
+
+def _target_exists(target: str, indexed_tests: dict[str, set[str]]) -> bool:
+    if "::" in target:
+        path, function = target.split("::", 1)
+        function = function.split("[", 1)[0]
+        return function in indexed_tests.get(path, set())
+    if target.endswith(".py"):
+        return target in indexed_tests
+    function = target.split("[", 1)[0]
+    return any(function in functions for functions in indexed_tests.values())
+
+
+def _is_metadata_only_target(target: str) -> bool:
+    if "::" in target:
+        path, function = target.split("::", 1)
+        function = function.split("[", 1)[0]
+        return path.endswith("tests/capabilities/test_adr_capability_links.py") and function in _METADATA_ONLY_TESTS
+    function = target.split("[", 1)[0]
+    return function in _METADATA_ONLY_TESTS


### PR DESCRIPTION
### Motivation

- Clarify and formalize ADR-governed capability claims and their concrete verification requirements so ADRs, claims, and requirements remain navigable and auditable.
- Provide machine-checkable metadata and tests to prevent regressions where ADRs must expose governed claims and claims must reference concrete, executable verification evidence.
- Harden the requirements-as-code boundary: ADR → claim → requirement is not sufficient unless behavioral requirements terminate in real pytest evidence or are explicitly registered as ADR gaps when not implemented.

### Description

- Added `## Governed claims` sections to multiple ADRs under `development/adrs/` to enumerate the capability claims each ADR governs.
- Introduced capability claim YAML artifacts under `development/capabilities/claims/` for many `CE-CAP-*` entries that reference ADRs and requirements.
- Added corresponding requirement documents under `development/capabilities/requirements/` that specify observable behavior, acceptance criteria, verification targets, and evidence requirements.
- Added the missing requirements-as-code governance claim `CE-CAP-REQ-AS-CODE-001` and requirement `CE-REQ-REQ-AS-CODE-EVIDENCE-001`, linked from ADR-030 and ADR-035.
- Hardened `tests/capabilities/test_adr_capability_links.py` so behavioral requirements must name executable pytest targets and cited test targets must resolve to real test functions.
- Added an explicit guard that rejects human/manual verification unless the requirement is marked `adr_gap_open` or `not_implemented`, includes a gap reference, and the gap is present in `development/current-work/RELEASE_PLAN_status_appendix.md`.
- Updated `development/capabilities/requirements/README.md` to state that metadata/linkage tests are drift guards only and that human verification is not acceptable evidence for implemented behavioral requirements.

### Testing

- Not re-run here. The branch was updated through GitHub and this environment cannot clone or execute the repository test suite because outbound network access from the execution container is unavailable.
- The new governance tests are intentionally stricter than the original PR. They are expected to expose any remaining requirements that still use metadata-only or manual evidence instead of executable tests or registered ADR gaps.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a377e28d8a4832987f01b28d2fc7939)