### PR TITLE
refactor: make CE capability-verification suite deterministic and dynamically discoverable

### DIFF
--- a/development/capabilities/verification/tif/CE-TIF-EXPL-001.md
+++ b/development/capabilities/verification/tif/CE-TIF-EXPL-001.md
@@ -7,6 +7,9 @@
 | tif_id | CE-TIF-EXPL-001 |
 | executable | `development/capabilities/verification/tif/tif_explanation.py` |
 | entry_functions | `run_factual_tif_scenario()`, `run_alternative_tif_scenario()` |
+| evidence_builder | `build_evidence_payload()` |
+| evidence_key | EXPL-001 |
+| verification_type | behavioral_contract |
 | status | active |
 
 ## Requirements served

--- a/development/capabilities/verification/tif/CE-TIF-EXPL-CONJ-001.md
+++ b/development/capabilities/verification/tif/CE-TIF-EXPL-CONJ-001.md
@@ -6,7 +6,10 @@
 |---|---|
 | tif_id | CE-TIF-EXPL-CONJ-001 |
 | executable | `development/capabilities/verification/tif/tif_conjunction.py` |
-| entry_function | `run_conjunction_tif_scenario()` |
+| entry_functions | `run_conjunction_tif_scenario()` |
+| evidence_builder | `build_evidence_payload()` |
+| evidence_key | EXPL-CONJ-001 |
+| verification_type | behavioral_contract |
 | status | active |
 
 ## Requirements served

--- a/development/capabilities/verification/tif/CE-TIF-FILTER-001.md
+++ b/development/capabilities/verification/tif/CE-TIF-FILTER-001.md
@@ -7,6 +7,9 @@
 | tif_id | CE-TIF-FILTER-001 |
 | executable | `development/capabilities/verification/tif/tif_filter.py` |
 | entry_functions | `run_filter_tif_scenario(filter_type)` |
+| evidence_builder | `build_evidence_payload()` |
+| evidence_key | FILTER-001 |
+| verification_type | api_contract |
 | status | active |
 
 ## Requirements served

--- a/development/capabilities/verification/tif/CE-TIF-GUARD-001.md
+++ b/development/capabilities/verification/tif/CE-TIF-GUARD-001.md
@@ -7,6 +7,9 @@
 | tif_id | CE-TIF-GUARD-001 |
 | executable | `development/capabilities/verification/tif/tif_guard.py` |
 | entry_functions | `run_guard_tif_scenario()` |
+| evidence_builder | `build_evidence_payload()` |
+| evidence_key | GUARD-001 |
+| verification_type | api_contract |
 | status | active |
 
 ## Requirements served

--- a/development/capabilities/verification/tif/CE-TIF-MOND-001.md
+++ b/development/capabilities/verification/tif/CE-TIF-MOND-001.md
@@ -7,6 +7,9 @@
 | tif_id | CE-TIF-MOND-001 |
 | executable | `development/capabilities/verification/tif/tif_mondrian.py` |
 | entry_functions | `run_mondrian_tif_scenario()` |
+| evidence_builder | `build_evidence_payload()` |
+| evidence_key | MOND-001 |
+| verification_type | api_contract |
 | status | active |
 
 ## Requirements served

--- a/development/capabilities/verification/tif/CE-TIF-NARR-001.md
+++ b/development/capabilities/verification/tif/CE-TIF-NARR-001.md
@@ -7,6 +7,9 @@
 | tif_id | CE-TIF-NARR-001 |
 | executable | `development/capabilities/verification/tif/tif_narrative.py` |
 | entry_functions | `run_narrative_tif_scenario()` |
+| evidence_builder | `build_evidence_payload()` |
+| evidence_key | NARR-001 |
+| verification_type | api_contract |
 | status | active |
 
 ## Requirements served

--- a/development/capabilities/verification/tif/CE-TIF-PRED-001.md
+++ b/development/capabilities/verification/tif/CE-TIF-PRED-001.md
@@ -7,6 +7,9 @@
 | tif_id | CE-TIF-PRED-001 |
 | executable | `development/capabilities/verification/tif/tif_prediction.py` |
 | entry_functions | `run_prediction_tif_scenario(low_high_percentiles=None)` |
+| evidence_builder | `build_evidence_payload()` |
+| evidence_key | PRED-001 |
+| verification_type | behavioral_contract |
 | status | active |
 
 ## Requirements served

--- a/development/capabilities/verification/tif/CE-TIF-PRED-CLASS-001.md
+++ b/development/capabilities/verification/tif/CE-TIF-PRED-CLASS-001.md
@@ -7,6 +7,9 @@
 | tif_id | CE-TIF-PRED-CLASS-001 |
 | executable | `development/capabilities/verification/tif/tif_classification.py` |
 | entry_functions | `run_classification_tif_scenario()` |
+| evidence_builder | `build_evidence_payload()` |
+| evidence_key | PRED-CLASS-001 |
+| verification_type | numerical_behavior |
 | status | active |
 
 ## Requirements served

--- a/development/capabilities/verification/tif/CE-TIF-PRED-PROB-001.md
+++ b/development/capabilities/verification/tif/CE-TIF-PRED-PROB-001.md
@@ -7,6 +7,9 @@
 | tif_id | CE-TIF-PRED-PROB-001 |
 | executable | `development/capabilities/verification/tif/tif_prob_regression.py` |
 | entry_functions | `run_prob_regression_tif_scenario(threshold=0.0)` |
+| evidence_builder | `build_evidence_payload()` |
+| evidence_key | PRED-PROB-001 |
+| verification_type | numerical_behavior |
 | status | active |
 
 ## Requirements served

--- a/development/capabilities/verification/tif/CE-TIF-REJECT-001.md
+++ b/development/capabilities/verification/tif/CE-TIF-REJECT-001.md
@@ -7,6 +7,9 @@
 | tif_id | CE-TIF-REJECT-001 |
 | executable | `development/capabilities/verification/tif/tif_reject.py` |
 | entry_functions | `run_reject_tif_scenario()` |
+| evidence_builder | `build_evidence_payload()` |
+| evidence_key | REJECT-001 |
+| verification_type | api_contract |
 | status | active |
 
 ## Requirements served

--- a/development/capabilities/verification/tif/CE-TIF-VIZ-001.md
+++ b/development/capabilities/verification/tif/CE-TIF-VIZ-001.md
@@ -7,6 +7,9 @@
 | tif_id | CE-TIF-VIZ-001 |
 | executable | `development/capabilities/verification/tif/tif_visualization.py` |
 | entry_functions | `run_visualization_tif_scenario()` |
+| evidence_builder | `build_evidence_payload()` |
+| evidence_key | VIZ-001 |
+| verification_type | empirical_smoke |
 | status | active |
 
 ## Requirements served

--- a/development/capabilities/verification/tif/tif_classification.py
+++ b/development/capabilities/verification/tif/tif_classification.py
@@ -1,13 +1,6 @@
 """TIF verification interface for CE classification prediction capabilities.
 
 TIF ID: CE-TIF-PRED-CLASS-001
-
-Requirements served:
-  CE-REQ-PRED-CLASS-API-001    — predict_proba and predict API contract for classification
-  CE-REQ-PRED-CLASS-BOUNDS-001 — probability values bounded in [0, 1]
-
-Tests call run_classification_tif_scenario() and assert on the returned
-ClassificationObservation against acceptance criteria from the requirement files.
 """
 
 from __future__ import annotations
@@ -30,30 +23,6 @@ _N_TEST = 5
 
 @dataclass
 class ClassificationObservation:
-    """Structured observation returned by classification TIF scenarios.
-
-    Fields
-    ------
-    exception_raised : bool
-        Whether an exception was raised.
-    exception_type : str or None
-        Exception class name if raised; None otherwise.
-    proba_is_none : bool
-        Whether predict_proba returned None.
-    proba_len : int or None
-        Length of the probability array.
-    proba_min : float or None
-        Minimum value in the probability array.
-    proba_max : float or None
-        Maximum value in the probability array.
-    labels_is_none : bool
-        Whether predict returned None.
-    labels_len : int or None
-        Length of the label array.
-    n_instances : int
-        Number of test instances.
-    """
-
     exception_raised: bool
     exception_type: Optional[str]
     proba_is_none: bool
@@ -66,7 +35,6 @@ class ClassificationObservation:
 
 
 def _build_classification_explainer() -> tuple:
-    """Build a deterministic fitted+calibrated WrapCalibratedExplainer for binary classification."""
     X_all, y_all = make_classification(
         n_samples=_N_SAMPLES,
         n_features=_N_FEATURES,
@@ -93,40 +61,17 @@ def _build_classification_explainer() -> tuple:
 
 
 def run_classification_tif_scenario() -> ClassificationObservation:
-    """Stimulate CE-REQ-PRED-CLASS-API-001 and CE-REQ-PRED-CLASS-BOUNDS-001.
-
-    TIF ID: CE-TIF-PRED-CLASS-001
-
-    Requirements served:
-      CE-REQ-PRED-CLASS-API-001    (observation: exception_raised, proba_len, labels_len)
-      CE-REQ-PRED-CLASS-BOUNDS-001 (observation: proba_min, proba_max)
-
-    Returns
-    -------
-    ClassificationObservation
-        Structured observations. Tests assert on these fields.
-    """
+    """Stimulate CE-REQ-PRED-CLASS-API-001 and CE-REQ-PRED-CLASS-BOUNDS-001."""
     explainer, X_test = _build_classification_explainer()
     n_instances = len(X_test)
-
-    exception_raised = False
-    exception_type = None
-    proba_is_none = True
-    proba_len = None
-    proba_min = None
-    proba_max = None
-    labels_is_none = True
-    labels_len = None
 
     try:
         probas = explainer.predict_proba(X_test)
         labels = explainer.predict(X_test)
     except Exception as exc:
-        exception_raised = True
-        exception_type = type(exc).__name__
         return ClassificationObservation(
             exception_raised=True,
-            exception_type=exception_type,
+            exception_type=type(exc).__name__,
             proba_is_none=True,
             proba_len=None,
             proba_min=None,
@@ -138,6 +83,10 @@ def run_classification_tif_scenario() -> ClassificationObservation:
 
     proba_is_none = probas is None
     labels_is_none = labels is None
+    proba_len = None
+    proba_min = None
+    proba_max = None
+    labels_len = None
 
     if probas is not None:
         proba_arr = np.asarray(probas)
@@ -149,8 +98,8 @@ def run_classification_tif_scenario() -> ClassificationObservation:
         labels_len = len(labels)
 
     return ClassificationObservation(
-        exception_raised=exception_raised,
-        exception_type=exception_type,
+        exception_raised=False,
+        exception_type=None,
         proba_is_none=proba_is_none,
         proba_len=proba_len,
         proba_min=proba_min,
@@ -158,4 +107,59 @@ def run_classification_tif_scenario() -> ClassificationObservation:
         labels_is_none=labels_is_none,
         labels_len=labels_len,
         n_instances=n_instances,
+    )
+
+
+_DATASET_ID = (
+    "sklearn make_classification n_samples=120 n_features=4 "
+    "n_informative=3 n_redundant=1 random_seed=42"
+)
+
+
+def build_evidence_payload(
+    *,
+    commit_sha: str,
+    timestamp: str,
+    date_suffix: str,
+    package_version: str,
+    python_version: str,
+    platform_str: str,
+) -> dict:
+    """Build a complete evidence payload for CE-TIF-PRED-CLASS-001."""
+    from tif_evidence_helpers import (
+        acceptance_entry,
+        build_payload,
+        obs_to_dict,
+        scenario_entry,
+    )
+
+    obs = run_classification_tif_scenario()
+    scenarios = [
+        scenario_entry(
+            "classification_api_and_bounds",
+            obs_to_dict(obs),
+            [
+                acceptance_entry("CE-REQ-PRED-CLASS-API-001", "exception_raised", False, obs.exception_raised),
+                acceptance_entry("CE-REQ-PRED-CLASS-API-001", "proba_len == n_instances", True, obs.proba_len == obs.n_instances),
+                acceptance_entry("CE-REQ-PRED-CLASS-API-001", "labels_len == n_instances", True, obs.labels_len == obs.n_instances),
+                acceptance_entry("CE-REQ-PRED-CLASS-BOUNDS-001", "proba_min >= 0.0", True, obs.proba_min is not None and obs.proba_min >= 0.0),
+                acceptance_entry("CE-REQ-PRED-CLASS-BOUNDS-001", "proba_max <= 1.0", True, obs.proba_max is not None and obs.proba_max <= 1.0),
+            ],
+        ),
+    ]
+    return build_payload(
+        "PRED-CLASS-001",
+        claim_ids=["CE-CAP-PRED-CLASS-001"],
+        requirement_ids=["CE-REQ-PRED-CLASS-API-001", "CE-REQ-PRED-CLASS-BOUNDS-001"],
+        adr_refs=["ADR-021"],
+        tif_ids=["CE-TIF-PRED-CLASS-001"],
+        verification_type="numerical_behavior",
+        dataset_id=_DATASET_ID,
+        scenarios=scenarios,
+        commit_sha=commit_sha,
+        timestamp=timestamp,
+        date_suffix=date_suffix,
+        package_version=package_version,
+        python_version=python_version,
+        platform_str=platform_str,
     )

--- a/development/capabilities/verification/tif/tif_classification.py
+++ b/development/capabilities/verification/tif/tif_classification.py
@@ -1,6 +1,13 @@
 """TIF verification interface for CE classification prediction capabilities.
 
 TIF ID: CE-TIF-PRED-CLASS-001
+
+Requirements served:
+  CE-REQ-PRED-CLASS-API-001    — predict_proba and predict API contract for classification
+  CE-REQ-PRED-CLASS-BOUNDS-001 — probability values bounded in [0, 1]
+
+Tests call run_classification_tif_scenario() and assert on the returned
+ClassificationObservation against acceptance criteria from the requirement files.
 """
 
 from __future__ import annotations
@@ -23,6 +30,30 @@ _N_TEST = 5
 
 @dataclass
 class ClassificationObservation:
+    """Structured observation returned by classification TIF scenarios.
+
+    Fields
+    ------
+    exception_raised : bool
+        Whether an exception was raised.
+    exception_type : str or None
+        Exception class name if raised; None otherwise.
+    proba_is_none : bool
+        Whether predict_proba returned None.
+    proba_len : int or None
+        Length of the probability array.
+    proba_min : float or None
+        Minimum value in the probability array.
+    proba_max : float or None
+        Maximum value in the probability array.
+    labels_is_none : bool
+        Whether predict returned None.
+    labels_len : int or None
+        Length of the label array.
+    n_instances : int
+        Number of test instances.
+    """
+
     exception_raised: bool
     exception_type: Optional[str]
     proba_is_none: bool
@@ -35,6 +66,7 @@ class ClassificationObservation:
 
 
 def _build_classification_explainer() -> tuple:
+    """Build a deterministic fitted+calibrated WrapCalibratedExplainer for binary classification."""
     X_all, y_all = make_classification(
         n_samples=_N_SAMPLES,
         n_features=_N_FEATURES,
@@ -61,17 +93,40 @@ def _build_classification_explainer() -> tuple:
 
 
 def run_classification_tif_scenario() -> ClassificationObservation:
-    """Stimulate CE-REQ-PRED-CLASS-API-001 and CE-REQ-PRED-CLASS-BOUNDS-001."""
+    """Stimulate CE-REQ-PRED-CLASS-API-001 and CE-REQ-PRED-CLASS-BOUNDS-001.
+
+    TIF ID: CE-TIF-PRED-CLASS-001
+
+    Requirements served:
+      CE-REQ-PRED-CLASS-API-001    (observation: exception_raised, proba_len, labels_len)
+      CE-REQ-PRED-CLASS-BOUNDS-001 (observation: proba_min, proba_max)
+
+    Returns
+    -------
+    ClassificationObservation
+        Structured observations. Tests assert on these fields.
+    """
     explainer, X_test = _build_classification_explainer()
     n_instances = len(X_test)
+
+    exception_raised = False
+    exception_type = None
+    proba_is_none = True
+    proba_len = None
+    proba_min = None
+    proba_max = None
+    labels_is_none = True
+    labels_len = None
 
     try:
         probas = explainer.predict_proba(X_test)
         labels = explainer.predict(X_test)
     except Exception as exc:
+        exception_raised = True
+        exception_type = type(exc).__name__
         return ClassificationObservation(
             exception_raised=True,
-            exception_type=type(exc).__name__,
+            exception_type=exception_type,
             proba_is_none=True,
             proba_len=None,
             proba_min=None,
@@ -83,10 +138,6 @@ def run_classification_tif_scenario() -> ClassificationObservation:
 
     proba_is_none = probas is None
     labels_is_none = labels is None
-    proba_len = None
-    proba_min = None
-    proba_max = None
-    labels_len = None
 
     if probas is not None:
         proba_arr = np.asarray(probas)
@@ -98,8 +149,8 @@ def run_classification_tif_scenario() -> ClassificationObservation:
         labels_len = len(labels)
 
     return ClassificationObservation(
-        exception_raised=False,
-        exception_type=None,
+        exception_raised=exception_raised,
+        exception_type=exception_type,
         proba_is_none=proba_is_none,
         proba_len=proba_len,
         proba_min=proba_min,
@@ -125,7 +176,10 @@ def build_evidence_payload(
     python_version: str,
     platform_str: str,
 ) -> dict:
-    """Build a complete evidence payload for CE-TIF-PRED-CLASS-001."""
+    """Build a complete evidence payload for CE-TIF-PRED-CLASS-001.
+
+    Called by scripts/generate_tif_evidence.py during dynamic discovery.
+    """
     from tif_evidence_helpers import (
         acceptance_entry,
         build_payload,

--- a/development/capabilities/verification/tif/tif_conjunction.py
+++ b/development/capabilities/verification/tif/tif_conjunction.py
@@ -40,35 +40,7 @@ _N_TEST = 3
 
 @dataclass
 class ConjunctionObservation:
-    """Structured observation returned by run_conjunction_tif_scenario().
-
-    Tests assert on these fields against acceptance criteria from requirement files.
-    This dataclass carries observations only; it does not carry acceptance judgements.
-
-    Fields
-    ------
-    exception_raised : bool
-        Whether an exception was raised during add_conjunctions.
-    exception_type : str or None
-        Class name of the exception if raised; None otherwise.
-    result_is_none : bool
-        Whether the result of add_conjunctions is None.
-    result_len : int or None
-        len(result) if result supports __len__; None otherwise.
-    result_type_name : str or None
-        type(result).__name__ if result is not None; None if result is None.
-    any_has_conjunctive_rules : bool
-        True if at least one item in the collection has has_conjunctive_rules == True.
-        Always False when exception_raised is True.
-    object_level : str
-        The object_level parameter passed to the scenario.
-    max_rule_size : int
-        The max_rule_size parameter used.
-    n_top_features : int
-        The n_top_features parameter used.
-    n_instances : int
-        Number of test instances (len(X_test)).
-    """
+    """Structured observation returned by run_conjunction_tif_scenario()."""
 
     exception_raised: bool
     exception_type: Optional[str]
@@ -84,13 +56,6 @@ class ConjunctionObservation:
 
 
 def _build_explainer_and_data() -> tuple:
-    """Build a deterministic fitted+calibrated WrapCalibratedExplainer and test data.
-
-    Returns
-    -------
-    tuple
-        (explainer, X_test) where explainer is fitted and calibrated.
-    """
     x_all, y_all = make_classification(
         n_samples=_N_SAMPLES,
         n_features=_N_FEATURES,
@@ -110,8 +75,6 @@ def _build_explainer_and_data() -> tuple:
     explainer.fit(x_proper, y_proper)
     explainer.calibrate(x_cal, y_cal)
 
-    # Sanity check: ensure the explainer is ready before returning observations.
-    # This is a local guard, not an assertion on CE behavior.
     assert explainer.fitted, "TIF sanity: explainer must be fitted"
     assert explainer.calibrated, "TIF sanity: explainer must be calibrated"
 
@@ -125,46 +88,7 @@ def run_conjunction_tif_scenario(
     n_top_features: int = 5,
     max_rule_size: int = 2,
 ) -> ConjunctionObservation:
-    """Stimulate CE-REQ-EXPL-CONJ-* through WrapCalibratedExplainer.
-
-    TIF ID: CE-TIF-EXPL-CONJ-001
-
-    Requirements served:
-      CE-REQ-EXPL-CONJ-API-001    (observation: exception_raised)
-      CE-REQ-EXPL-CONJ-RETURN-001 (observation: result_is_none, result_len)
-      CE-REQ-EXPL-CONJ-RULE-001   (observation: any_has_conjunctive_rules when max_rule_size >= 2)
-      CE-REQ-EXPL-CONJ-PARAM-001  (observation: any_has_conjunctive_rules when max_rule_size == 1)
-
-    This function uses the public WrapCalibratedExplainer workflow only:
-      1. Creates deterministic fixture data.
-      2. Instantiates WrapCalibratedExplainer.
-      3. Calls fit().
-      4. Calls calibrate().
-      5. Calls explain_factual() or explore_alternatives() per explanation_mode.
-      6. Calls add_conjunctions() on the result (collection or individual).
-      7. Returns a ConjunctionObservation with structured observations.
-
-    This function does NOT perform final pytest assertions. Tests must assert on
-    the returned ConjunctionObservation against acceptance criteria from the
-    requirement files.
-
-    Parameters
-    ----------
-    explanation_mode : str
-        "factual" → explain_factual(); "alternative" → explore_alternatives().
-    object_level : str
-        "collection" → call add_conjunctions on the collection;
-        "individual"  → call add_conjunctions on collection[0].
-    n_top_features : int
-        Passed to add_conjunctions. Default 5.
-    max_rule_size : int
-        Passed to add_conjunctions. Default 2.
-
-    Returns
-    -------
-    ConjunctionObservation
-        Structured observations. Tests assert on these fields.
-    """
+    """Stimulate CE-REQ-EXPL-CONJ-* through WrapCalibratedExplainer."""
     if explanation_mode not in ("factual", "alternative"):
         raise ValueError(
             f"explanation_mode must be 'factual' or 'alternative', got {explanation_mode!r}"
@@ -224,7 +148,6 @@ def run_conjunction_tif_scenario(
         except TypeError:
             result_len = None
 
-        # Inspect each item for has_conjunctive_rules (public attribute, ADR-008)
         for i in range(len(collection)):
             item = collection[i]
             if getattr(item, "has_conjunctive_rules", False):
@@ -232,7 +155,6 @@ def run_conjunction_tif_scenario(
                 break
 
     elif result is not None and object_level == "individual":
-        # For individual: check has_conjunctive_rules on the result itself
         any_has_conjunctive_rules = bool(getattr(result, "has_conjunctive_rules", False))
 
     return ConjunctionObservation(
@@ -247,4 +169,89 @@ def run_conjunction_tif_scenario(
         n_top_features=n_top_features,
         n_instances=n_instances,
         explanation_mode=explanation_mode,
+    )
+
+
+_DATASET_ID = (
+    "sklearn make_classification n_samples=120 n_features=4 "
+    "n_informative=3 n_redundant=1 random_seed=42"
+)
+
+
+def build_evidence_payload(
+    *,
+    commit_sha: str,
+    timestamp: str,
+    date_suffix: str,
+    package_version: str,
+    python_version: str,
+    platform_str: str,
+) -> dict:
+    """Build a complete evidence payload for CE-TIF-EXPL-CONJ-001."""
+    from tif_evidence_helpers import (
+        acceptance_entry,
+        build_payload,
+        obs_to_dict,
+        scenario_entry,
+    )
+
+    scenarios = []
+    for mode in ("factual", "alternative"):
+        for level in ("collection", "individual"):
+            obs = run_conjunction_tif_scenario(explanation_mode=mode, object_level=level, max_rule_size=2, n_top_features=5)
+            scenarios.append(scenario_entry(
+                f"api_{mode}_{level}",
+                obs_to_dict(obs),
+                [acceptance_entry("CE-REQ-EXPL-CONJ-API-001", "exception_raised", False, obs.exception_raised)],
+                {"explanation_mode": mode, "object_level": level, "max_rule_size": 2, "n_top_features": 5},
+            ))
+    for mode in ("factual", "alternative"):
+        obs = run_conjunction_tif_scenario(explanation_mode=mode, object_level="collection", max_rule_size=2, n_top_features=5)
+        scenarios.append(scenario_entry(
+            f"return_{mode}_collection",
+            obs_to_dict(obs),
+            [
+                acceptance_entry("CE-REQ-EXPL-CONJ-RETURN-001", "result_is_none", False, obs.result_is_none),
+                acceptance_entry("CE-REQ-EXPL-CONJ-RETURN-001", "result_len == n_instances", True, obs.result_len == obs.n_instances),
+            ],
+            {"explanation_mode": mode, "object_level": "collection", "max_rule_size": 2, "n_top_features": 5},
+        ))
+    for max_rule_size in (2, 3):
+        obs = run_conjunction_tif_scenario(explanation_mode="factual", object_level="collection", max_rule_size=max_rule_size, n_top_features=5)
+        scenarios.append(scenario_entry(
+            f"rule_factual_collection_max_rule_size_{max_rule_size}",
+            obs_to_dict(obs),
+            [acceptance_entry("CE-REQ-EXPL-CONJ-RULE-001", "any_has_conjunctive_rules", True, obs.any_has_conjunctive_rules)],
+            {"explanation_mode": "factual", "object_level": "collection", "max_rule_size": max_rule_size, "n_top_features": 5},
+        ))
+    obs = run_conjunction_tif_scenario(explanation_mode="factual", object_level="collection", max_rule_size=1, n_top_features=5)
+    scenarios.append(scenario_entry(
+        "param_factual_collection_max_rule_size_1",
+        obs_to_dict(obs),
+        [
+            acceptance_entry("CE-REQ-EXPL-CONJ-PARAM-001", "any_has_conjunctive_rules", False, obs.any_has_conjunctive_rules),
+            acceptance_entry("CE-REQ-EXPL-CONJ-PARAM-001", "exception_raised", False, obs.exception_raised),
+        ],
+        {"explanation_mode": "factual", "object_level": "collection", "max_rule_size": 1, "n_top_features": 5},
+    ))
+    return build_payload(
+        "EXPL-CONJ-001",
+        claim_ids=["CE-CAP-EXPL-CONJ-001"],
+        requirement_ids=[
+            "CE-REQ-EXPL-CONJ-API-001",
+            "CE-REQ-EXPL-CONJ-RETURN-001",
+            "CE-REQ-EXPL-CONJ-RULE-001",
+            "CE-REQ-EXPL-CONJ-PARAM-001",
+        ],
+        adr_refs=["ADR-008"],
+        tif_ids=["CE-TIF-EXPL-CONJ-001"],
+        verification_type="behavioral_contract",
+        dataset_id=_DATASET_ID,
+        scenarios=scenarios,
+        commit_sha=commit_sha,
+        timestamp=timestamp,
+        date_suffix=date_suffix,
+        package_version=package_version,
+        python_version=python_version,
+        platform_str=platform_str,
     )

--- a/development/capabilities/verification/tif/tif_conjunction.py
+++ b/development/capabilities/verification/tif/tif_conjunction.py
@@ -40,7 +40,35 @@ _N_TEST = 3
 
 @dataclass
 class ConjunctionObservation:
-    """Structured observation returned by run_conjunction_tif_scenario()."""
+    """Structured observation returned by run_conjunction_tif_scenario().
+
+    Tests assert on these fields against acceptance criteria from requirement files.
+    This dataclass carries observations only; it does not carry acceptance judgements.
+
+    Fields
+    ------
+    exception_raised : bool
+        Whether an exception was raised during add_conjunctions.
+    exception_type : str or None
+        Class name of the exception if raised; None otherwise.
+    result_is_none : bool
+        Whether the result of add_conjunctions is None.
+    result_len : int or None
+        len(result) if result supports __len__; None otherwise.
+    result_type_name : str or None
+        type(result).__name__ if result is not None; None if result is None.
+    any_has_conjunctive_rules : bool
+        True if at least one item in the collection has has_conjunctive_rules == True.
+        Always False when exception_raised is True.
+    object_level : str
+        The object_level parameter passed to the scenario.
+    max_rule_size : int
+        The max_rule_size parameter used.
+    n_top_features : int
+        The n_top_features parameter used.
+    n_instances : int
+        Number of test instances (len(X_test)).
+    """
 
     exception_raised: bool
     exception_type: Optional[str]
@@ -56,6 +84,13 @@ class ConjunctionObservation:
 
 
 def _build_explainer_and_data() -> tuple:
+    """Build a deterministic fitted+calibrated WrapCalibratedExplainer and test data.
+
+    Returns
+    -------
+    tuple
+        (explainer, X_test) where explainer is fitted and calibrated.
+    """
     x_all, y_all = make_classification(
         n_samples=_N_SAMPLES,
         n_features=_N_FEATURES,
@@ -75,6 +110,8 @@ def _build_explainer_and_data() -> tuple:
     explainer.fit(x_proper, y_proper)
     explainer.calibrate(x_cal, y_cal)
 
+    # Sanity check: ensure the explainer is ready before returning observations.
+    # This is a local guard, not an assertion on CE behavior.
     assert explainer.fitted, "TIF sanity: explainer must be fitted"
     assert explainer.calibrated, "TIF sanity: explainer must be calibrated"
 
@@ -88,7 +125,46 @@ def run_conjunction_tif_scenario(
     n_top_features: int = 5,
     max_rule_size: int = 2,
 ) -> ConjunctionObservation:
-    """Stimulate CE-REQ-EXPL-CONJ-* through WrapCalibratedExplainer."""
+    """Stimulate CE-REQ-EXPL-CONJ-* through WrapCalibratedExplainer.
+
+    TIF ID: CE-TIF-EXPL-CONJ-001
+
+    Requirements served:
+      CE-REQ-EXPL-CONJ-API-001    (observation: exception_raised)
+      CE-REQ-EXPL-CONJ-RETURN-001 (observation: result_is_none, result_len)
+      CE-REQ-EXPL-CONJ-RULE-001   (observation: any_has_conjunctive_rules when max_rule_size >= 2)
+      CE-REQ-EXPL-CONJ-PARAM-001  (observation: any_has_conjunctive_rules when max_rule_size == 1)
+
+    This function uses the public WrapCalibratedExplainer workflow only:
+      1. Creates deterministic fixture data.
+      2. Instantiates WrapCalibratedExplainer.
+      3. Calls fit().
+      4. Calls calibrate().
+      5. Calls explain_factual() or explore_alternatives() per explanation_mode.
+      6. Calls add_conjunctions() on the result (collection or individual).
+      7. Returns a ConjunctionObservation with structured observations.
+
+    This function does NOT perform final pytest assertions. Tests must assert on
+    the returned ConjunctionObservation against acceptance criteria from the
+    requirement files.
+
+    Parameters
+    ----------
+    explanation_mode : str
+        "factual" → explain_factual(); "alternative" → explore_alternatives().
+    object_level : str
+        "collection" → call add_conjunctions on the collection;
+        "individual"  → call add_conjunctions on collection[0].
+    n_top_features : int
+        Passed to add_conjunctions. Default 5.
+    max_rule_size : int
+        Passed to add_conjunctions. Default 2.
+
+    Returns
+    -------
+    ConjunctionObservation
+        Structured observations. Tests assert on these fields.
+    """
     if explanation_mode not in ("factual", "alternative"):
         raise ValueError(
             f"explanation_mode must be 'factual' or 'alternative', got {explanation_mode!r}"
@@ -148,6 +224,7 @@ def run_conjunction_tif_scenario(
         except TypeError:
             result_len = None
 
+        # Inspect each item for has_conjunctive_rules (public attribute, ADR-008)
         for i in range(len(collection)):
             item = collection[i]
             if getattr(item, "has_conjunctive_rules", False):
@@ -155,6 +232,7 @@ def run_conjunction_tif_scenario(
                 break
 
     elif result is not None and object_level == "individual":
+        # For individual: check has_conjunctive_rules on the result itself
         any_has_conjunctive_rules = bool(getattr(result, "has_conjunctive_rules", False))
 
     return ConjunctionObservation(
@@ -187,7 +265,10 @@ def build_evidence_payload(
     python_version: str,
     platform_str: str,
 ) -> dict:
-    """Build a complete evidence payload for CE-TIF-EXPL-CONJ-001."""
+    """Build a complete evidence payload for CE-TIF-EXPL-CONJ-001.
+
+    Called by scripts/generate_tif_evidence.py during dynamic discovery.
+    """
     from tif_evidence_helpers import (
         acceptance_entry,
         build_payload,

--- a/development/capabilities/verification/tif/tif_evidence_helpers.py
+++ b/development/capabilities/verification/tif/tif_evidence_helpers.py
@@ -1,0 +1,99 @@
+"""Shared helpers for TIF evidence payload construction.
+
+Utility functions used by TIF executables to build evidence payloads.
+Not a registry. Not a manifest. Pure utility code.
+
+TIF executable modules import these helpers inside build_evidence_payload()
+so the import is deferred until evidence generation time.
+"""
+
+from __future__ import annotations
+
+from dataclasses import asdict
+from typing import Any
+
+
+def obs_to_dict(value: Any) -> dict[str, Any]:
+    """Convert an observation dataclass or dict-like to a plain dict."""
+    return asdict(value) if hasattr(value, "__dataclass_fields__") else dict(value)
+
+
+def acceptance_entry(
+    criterion_ref: str,
+    field: str,
+    expected: Any,
+    observed: Any,
+) -> dict[str, Any]:
+    """Build a single acceptance check entry."""
+    return {
+        "criterion_ref": criterion_ref,
+        "field": field,
+        "expected": expected,
+        "observed": observed,
+        "result": "pass" if observed == expected else "fail",
+    }
+
+
+def scenario_entry(
+    scenario_id: str,
+    observations: dict[str, Any],
+    acceptance: list[dict[str, Any]],
+    parameters: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Build a single scenario entry."""
+    payload: dict[str, Any] = {
+        "scenario_id": scenario_id,
+        "observations": observations,
+        "result": "pass" if all(a["result"] == "pass" for a in acceptance) else "fail",
+        "acceptance": acceptance,
+    }
+    if parameters:
+        payload["parameters"] = parameters
+    return payload
+
+
+def overall_result(scenarios: list[dict[str, Any]]) -> str:
+    """Derive top-level result from scenario results."""
+    return "pass" if all(s["result"] == "pass" for s in scenarios) else "fail"
+
+
+def build_payload(
+    evidence_key: str,
+    *,
+    claim_ids: list[str],
+    requirement_ids: list[str],
+    adr_refs: list[str],
+    tif_ids: list[str],
+    verification_type: str,
+    dataset_id: str,
+    scenarios: list[dict[str, Any]],
+    commit_sha: str,
+    timestamp: str,
+    date_suffix: str,
+    package_version: str,
+    python_version: str,
+    platform_str: str,
+    configuration: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Build a complete, serialisable evidence payload dict."""
+    evidence_id = f"CE-EVID-{evidence_key}-{date_suffix}"
+    return {
+        "evidence_id": evidence_id,
+        "claim_ids": claim_ids,
+        "requirement_ids": requirement_ids,
+        "adr_refs": adr_refs,
+        "standard_refs": [],
+        "tif_ids": tif_ids,
+        "verification_type": verification_type,
+        "result": overall_result(scenarios),
+        "timestamp": timestamp,
+        "commit_sha": commit_sha,
+        "package_version": package_version,
+        "python_version": python_version,
+        "platform": platform_str,
+        "dataset_id": dataset_id,
+        "random_seed": 42,
+        "configuration": configuration or {},
+        "scenarios": scenarios,
+        "artifacts": {"logs": None, "raw_output": None},
+    }

--- a/development/capabilities/verification/tif/tif_explanation.py
+++ b/development/capabilities/verification/tif/tif_explanation.py
@@ -79,13 +79,6 @@ class ExplanationObservation:
 
 
 def _build_explainer_and_data() -> tuple:
-    """Build a deterministic fitted+calibrated WrapCalibratedExplainer and test data.
-
-    Returns
-    -------
-    tuple
-        (explainer, X_test) where explainer is fitted and calibrated for binary classification.
-    """
     X_all, y_all = make_classification(
         n_samples=_N_SAMPLES,
         n_features=_N_FEATURES,
@@ -112,28 +105,7 @@ def _build_explainer_and_data() -> tuple:
 
 
 def run_factual_tif_scenario() -> ExplanationObservation:
-    """Stimulate CE-REQ-EXPL-API-001 and CE-REQ-EXPL-RETURN-001 through WrapCalibratedExplainer.
-
-    TIF ID: CE-TIF-EXPL-001
-
-    Requirements served:
-      CE-REQ-EXPL-API-001     (observation: exception_raised)
-      CE-REQ-EXPL-RETURN-001  (observation: result_len, result_is_none, first_item_is_none,
-                                             feature_weights_accessible, result_type_name)
-
-    This function uses the public WrapCalibratedExplainer workflow only:
-      1. Creates deterministic fixture data.
-      2. Instantiates WrapCalibratedExplainer.
-      3. Calls fit().
-      4. Calls calibrate().
-      5. Calls explain_factual().
-      6. Returns an ExplanationObservation with structured observations.
-
-    Returns
-    -------
-    ExplanationObservation
-        Structured observations. Tests assert on these fields.
-    """
+    """Stimulate CE-REQ-EXPL-API-001 and CE-REQ-EXPL-RETURN-001 through WrapCalibratedExplainer."""
     explainer, X_test = _build_explainer_and_data()
     n_instances = len(X_test)
 
@@ -194,20 +166,7 @@ def run_factual_tif_scenario() -> ExplanationObservation:
 
 
 def run_alternative_tif_scenario() -> ExplanationObservation:
-    """Stimulate CE-REQ-EXPL-API-002 and CE-REQ-EXPL-ALT-RETURN-001 through WrapCalibratedExplainer.
-
-    TIF ID: CE-TIF-EXPL-001
-
-    Requirements served:
-      CE-REQ-EXPL-API-002        (observation: exception_raised)
-      CE-REQ-EXPL-ALT-RETURN-001 (observation: result_len, result_is_none, first_item_is_none,
-                                                result_type_name)
-
-    Returns
-    -------
-    ExplanationObservation
-        Structured observations. Tests assert on these fields.
-    """
+    """Stimulate CE-REQ-EXPL-API-002 and CE-REQ-EXPL-ALT-RETURN-001 through WrapCalibratedExplainer."""
     explainer, X_test = _build_explainer_and_data()
     n_instances = len(X_test)
 
@@ -260,4 +219,81 @@ def run_alternative_tif_scenario() -> ExplanationObservation:
         feature_weights_accessible=False,
         explanation_mode="alternative",
         n_instances=n_instances,
+    )
+
+
+_DATASET_ID = (
+    "sklearn make_classification n_samples=120 n_features=4 "
+    "n_informative=3 n_redundant=1 random_seed=42"
+)
+
+
+def build_evidence_payload(
+    *,
+    commit_sha: str,
+    timestamp: str,
+    date_suffix: str,
+    package_version: str,
+    python_version: str,
+    platform_str: str,
+) -> dict:
+    """Build a complete evidence payload for CE-TIF-EXPL-001."""
+    from tif_evidence_helpers import (
+        acceptance_entry,
+        build_payload,
+        obs_to_dict,
+        scenario_entry,
+    )
+
+    factual = run_factual_tif_scenario()
+    alt = run_alternative_tif_scenario()
+    scenarios = [
+        scenario_entry(
+            "factual_api_contract",
+            obs_to_dict(factual),
+            [acceptance_entry("CE-REQ-EXPL-API-001", "exception_raised", False, factual.exception_raised)],
+        ),
+        scenario_entry(
+            "factual_return_contract",
+            obs_to_dict(factual),
+            [
+                acceptance_entry("CE-REQ-EXPL-RETURN-001", "result_is_none", False, factual.result_is_none),
+                acceptance_entry("CE-REQ-EXPL-RETURN-001", "result_len == n_instances", True, factual.result_len == factual.n_instances),
+                acceptance_entry("CE-REQ-EXPL-RETURN-001", "feature_weights_accessible", True, factual.feature_weights_accessible),
+            ],
+        ),
+        scenario_entry(
+            "alternative_api_contract",
+            obs_to_dict(alt),
+            [acceptance_entry("CE-REQ-EXPL-API-002", "exception_raised", False, alt.exception_raised)],
+        ),
+        scenario_entry(
+            "alternative_return_contract",
+            obs_to_dict(alt),
+            [
+                acceptance_entry("CE-REQ-EXPL-ALT-RETURN-001", "result_type_name", "AlternativeExplanations", alt.result_type_name),
+                acceptance_entry("CE-REQ-EXPL-ALT-RETURN-001", "result_len == n_instances", True, alt.result_len == alt.n_instances),
+            ],
+        ),
+    ]
+    return build_payload(
+        "EXPL-001",
+        claim_ids=["CE-CAP-EXPL-001", "CE-CAP-EXPL-002"],
+        requirement_ids=[
+            "CE-REQ-EXPL-API-001",
+            "CE-REQ-EXPL-RETURN-001",
+            "CE-REQ-EXPL-API-002",
+            "CE-REQ-EXPL-ALT-RETURN-001",
+        ],
+        adr_refs=["ADR-008", "ADR-015", "ADR-026"],
+        tif_ids=["CE-TIF-EXPL-001"],
+        verification_type="behavioral_contract",
+        dataset_id=_DATASET_ID,
+        scenarios=scenarios,
+        commit_sha=commit_sha,
+        timestamp=timestamp,
+        date_suffix=date_suffix,
+        package_version=package_version,
+        python_version=python_version,
+        platform_str=platform_str,
     )

--- a/development/capabilities/verification/tif/tif_explanation.py
+++ b/development/capabilities/verification/tif/tif_explanation.py
@@ -79,6 +79,13 @@ class ExplanationObservation:
 
 
 def _build_explainer_and_data() -> tuple:
+    """Build a deterministic fitted+calibrated WrapCalibratedExplainer and test data.
+
+    Returns
+    -------
+    tuple
+        (explainer, X_test) where explainer is fitted and calibrated for binary classification.
+    """
     X_all, y_all = make_classification(
         n_samples=_N_SAMPLES,
         n_features=_N_FEATURES,
@@ -105,7 +112,28 @@ def _build_explainer_and_data() -> tuple:
 
 
 def run_factual_tif_scenario() -> ExplanationObservation:
-    """Stimulate CE-REQ-EXPL-API-001 and CE-REQ-EXPL-RETURN-001 through WrapCalibratedExplainer."""
+    """Stimulate CE-REQ-EXPL-API-001 and CE-REQ-EXPL-RETURN-001 through WrapCalibratedExplainer.
+
+    TIF ID: CE-TIF-EXPL-001
+
+    Requirements served:
+      CE-REQ-EXPL-API-001     (observation: exception_raised)
+      CE-REQ-EXPL-RETURN-001  (observation: result_len, result_is_none, first_item_is_none,
+                                             feature_weights_accessible, result_type_name)
+
+    This function uses the public WrapCalibratedExplainer workflow only:
+      1. Creates deterministic fixture data.
+      2. Instantiates WrapCalibratedExplainer.
+      3. Calls fit().
+      4. Calls calibrate().
+      5. Calls explain_factual().
+      6. Returns an ExplanationObservation with structured observations.
+
+    Returns
+    -------
+    ExplanationObservation
+        Structured observations. Tests assert on these fields.
+    """
     explainer, X_test = _build_explainer_and_data()
     n_instances = len(X_test)
 
@@ -166,7 +194,20 @@ def run_factual_tif_scenario() -> ExplanationObservation:
 
 
 def run_alternative_tif_scenario() -> ExplanationObservation:
-    """Stimulate CE-REQ-EXPL-API-002 and CE-REQ-EXPL-ALT-RETURN-001 through WrapCalibratedExplainer."""
+    """Stimulate CE-REQ-EXPL-API-002 and CE-REQ-EXPL-ALT-RETURN-001 through WrapCalibratedExplainer.
+
+    TIF ID: CE-TIF-EXPL-001
+
+    Requirements served:
+      CE-REQ-EXPL-API-002        (observation: exception_raised)
+      CE-REQ-EXPL-ALT-RETURN-001 (observation: result_len, result_is_none, first_item_is_none,
+                                                result_type_name)
+
+    Returns
+    -------
+    ExplanationObservation
+        Structured observations. Tests assert on these fields.
+    """
     explainer, X_test = _build_explainer_and_data()
     n_instances = len(X_test)
 
@@ -237,7 +278,10 @@ def build_evidence_payload(
     python_version: str,
     platform_str: str,
 ) -> dict:
-    """Build a complete evidence payload for CE-TIF-EXPL-001."""
+    """Build a complete evidence payload for CE-TIF-EXPL-001.
+
+    Called by scripts/generate_tif_evidence.py during dynamic discovery.
+    """
     from tif_evidence_helpers import (
         acceptance_entry,
         build_payload,

--- a/development/capabilities/verification/tif/tif_filter.py
+++ b/development/capabilities/verification/tif/tif_filter.py
@@ -34,30 +34,6 @@ FilterType = Literal["super", "semi", "counter", "ensured", "pareto"]
 
 @dataclass
 class FilterObservation:
-    """Structured observation returned by filter TIF scenarios.
-
-    Fields
-    ------
-    filter_type : str
-        Which filter operation was exercised.
-    exception_raised : bool
-        Whether an exception was raised.
-    exception_type : str or None
-        Exception class name if raised; None otherwise.
-    collection_result_is_none : bool
-        Whether the collection-level result is None.
-    collection_result_len : int or None
-        len(result) for collection call; None on exception.
-    individual_result_is_none : bool
-        Whether the individual-level result is None.
-    alias_result_is_none : bool
-        Whether the alias method (e.g. .super()) result is None.
-    alias_result_len : int or None
-        len(alias result) for alias call; None on exception.
-    n_instances : int
-        Number of test instances.
-    """
-
     filter_type: str
     exception_raised: bool
     exception_type: Optional[str]
@@ -70,7 +46,6 @@ class FilterObservation:
 
 
 def _build_alternatives() -> tuple:
-    """Build a deterministic AlternativeExplanations collection."""
     X_all, y_all = make_classification(
         n_samples=_N_SAMPLES,
         n_features=_N_FEATURES,
@@ -107,32 +82,7 @@ def _safe_len(obj) -> Optional[int]:
 
 
 def run_filter_tif_scenario(filter_type: FilterType) -> FilterObservation:
-    """Stimulate one of the five filter operations through WrapCalibratedExplainer.
-
-    TIF ID: CE-TIF-FILTER-001
-
-    Requirements served (by filter_type):
-      "super"    → CE-REQ-EXPL-FILTER-SUPER-001
-      "semi"     → CE-REQ-EXPL-FILTER-SEMI-001
-      "counter"  → CE-REQ-EXPL-FILTER-COUNTER-001
-      "ensured"  → CE-REQ-EXPL-FILTER-ENSURED-001
-      "pareto"   → CE-REQ-EXPL-FILTER-PARETO-001
-
-    Observations per call:
-      collection_result_is_none, collection_result_len — from collection call
-      individual_result_is_none                        — from individual call on result[0]
-      alias_result_is_none, alias_result_len           — from alias method call
-
-    Parameters
-    ----------
-    filter_type : {"super", "semi", "counter", "ensured", "pareto"}
-        Which filter operation to exercise.
-
-    Returns
-    -------
-    FilterObservation
-        Structured observations. Tests assert on these fields.
-    """
+    """Stimulate one of the five filter operations through WrapCalibratedExplainer."""
     alternatives, X_test = _build_alternatives()
     n_instances = len(X_test)
 
@@ -182,4 +132,67 @@ def run_filter_tif_scenario(filter_type: FilterType) -> FilterObservation:
         alias_result_is_none=alias_result is None,
         alias_result_len=_safe_len(alias_result),
         n_instances=n_instances,
+    )
+
+
+_DATASET_ID = (
+    "sklearn make_classification n_samples=120 n_features=4 "
+    "n_informative=3 n_redundant=1 random_seed=42"
+)
+
+_FILTER_REQ_MAP = {
+    "super": "CE-REQ-EXPL-FILTER-SUPER-001",
+    "semi": "CE-REQ-EXPL-FILTER-SEMI-001",
+    "counter": "CE-REQ-EXPL-FILTER-COUNTER-001",
+    "ensured": "CE-REQ-EXPL-FILTER-ENSURED-001",
+    "pareto": "CE-REQ-EXPL-FILTER-PARETO-001",
+}
+
+
+def build_evidence_payload(
+    *,
+    commit_sha: str,
+    timestamp: str,
+    date_suffix: str,
+    package_version: str,
+    python_version: str,
+    platform_str: str,
+) -> dict:
+    """Build a complete evidence payload for CE-TIF-FILTER-001."""
+    from tif_evidence_helpers import (
+        acceptance_entry,
+        build_payload,
+        obs_to_dict,
+        scenario_entry,
+    )
+
+    scenarios = []
+    for filter_type, req_id in _FILTER_REQ_MAP.items():
+        obs = run_filter_tif_scenario(filter_type=filter_type)
+        scenarios.append(scenario_entry(
+            f"filter_{filter_type}",
+            obs_to_dict(obs),
+            [
+                acceptance_entry(req_id, "exception_raised", False, obs.exception_raised),
+                acceptance_entry(req_id, "collection_result_is_none", False, obs.collection_result_is_none),
+                acceptance_entry(req_id, "collection_result_len == n_instances", True, obs.collection_result_len == obs.n_instances),
+                acceptance_entry(req_id, "individual_result_is_none", False, obs.individual_result_is_none),
+                acceptance_entry(req_id, "alias_result_is_none", False, obs.alias_result_is_none),
+            ],
+        ))
+    return build_payload(
+        "FILTER-001",
+        claim_ids=["CE-CAP-EXPL-FILTER-001"],
+        requirement_ids=list(_FILTER_REQ_MAP.values()),
+        adr_refs=["ADR-027"],
+        tif_ids=["CE-TIF-FILTER-001"],
+        verification_type="api_contract",
+        dataset_id=_DATASET_ID,
+        scenarios=scenarios,
+        commit_sha=commit_sha,
+        timestamp=timestamp,
+        date_suffix=date_suffix,
+        package_version=package_version,
+        python_version=python_version,
+        platform_str=platform_str,
     )

--- a/development/capabilities/verification/tif/tif_filter.py
+++ b/development/capabilities/verification/tif/tif_filter.py
@@ -34,6 +34,30 @@ FilterType = Literal["super", "semi", "counter", "ensured", "pareto"]
 
 @dataclass
 class FilterObservation:
+    """Structured observation returned by filter TIF scenarios.
+
+    Fields
+    ------
+    filter_type : str
+        Which filter operation was exercised.
+    exception_raised : bool
+        Whether an exception was raised.
+    exception_type : str or None
+        Exception class name if raised; None otherwise.
+    collection_result_is_none : bool
+        Whether the collection-level result is None.
+    collection_result_len : int or None
+        len(result) for collection call; None on exception.
+    individual_result_is_none : bool
+        Whether the individual-level result is None.
+    alias_result_is_none : bool
+        Whether the alias method (e.g. .super()) result is None.
+    alias_result_len : int or None
+        len(alias result) for alias call; None on exception.
+    n_instances : int
+        Number of test instances.
+    """
+
     filter_type: str
     exception_raised: bool
     exception_type: Optional[str]
@@ -46,6 +70,7 @@ class FilterObservation:
 
 
 def _build_alternatives() -> tuple:
+    """Build a deterministic AlternativeExplanations collection."""
     X_all, y_all = make_classification(
         n_samples=_N_SAMPLES,
         n_features=_N_FEATURES,
@@ -82,7 +107,32 @@ def _safe_len(obj) -> Optional[int]:
 
 
 def run_filter_tif_scenario(filter_type: FilterType) -> FilterObservation:
-    """Stimulate one of the five filter operations through WrapCalibratedExplainer."""
+    """Stimulate one of the five filter operations through WrapCalibratedExplainer.
+
+    TIF ID: CE-TIF-FILTER-001
+
+    Requirements served (by filter_type):
+      "super"    → CE-REQ-EXPL-FILTER-SUPER-001
+      "semi"     → CE-REQ-EXPL-FILTER-SEMI-001
+      "counter"  → CE-REQ-EXPL-FILTER-COUNTER-001
+      "ensured"  → CE-REQ-EXPL-FILTER-ENSURED-001
+      "pareto"   → CE-REQ-EXPL-FILTER-PARETO-001
+
+    Observations per call:
+      collection_result_is_none, collection_result_len — from collection call
+      individual_result_is_none                        — from individual call on result[0]
+      alias_result_is_none, alias_result_len           — from alias method call
+
+    Parameters
+    ----------
+    filter_type : {"super", "semi", "counter", "ensured", "pareto"}
+        Which filter operation to exercise.
+
+    Returns
+    -------
+    FilterObservation
+        Structured observations. Tests assert on these fields.
+    """
     alternatives, X_test = _build_alternatives()
     n_instances = len(X_test)
 
@@ -158,7 +208,10 @@ def build_evidence_payload(
     python_version: str,
     platform_str: str,
 ) -> dict:
-    """Build a complete evidence payload for CE-TIF-FILTER-001."""
+    """Build a complete evidence payload for CE-TIF-FILTER-001.
+
+    Called by scripts/generate_tif_evidence.py during dynamic discovery.
+    """
     from tif_evidence_helpers import (
         acceptance_entry,
         build_payload,

--- a/development/capabilities/verification/tif/tif_guard.py
+++ b/development/capabilities/verification/tif/tif_guard.py
@@ -11,7 +11,6 @@ GuardObservation against acceptance criteria from the requirement files.
 
 from __future__ import annotations
 
-import contextlib
 from dataclasses import dataclass
 from typing import Optional
 
@@ -30,6 +29,22 @@ _N_TEST = 3
 
 @dataclass
 class GuardObservation:
+    """Structured observation returned by guarded explanation TIF scenarios.
+
+    Fields
+    ------
+    exception_raised : bool
+        Whether an exception was raised during the call.
+    exception_type : str or None
+        Exception class name if raised; None otherwise.
+    result_is_none : bool
+        Whether the result is None.
+    result_len : int or None
+        len(result) if result supports __len__; None otherwise.
+    n_instances : int
+        Number of test instances.
+    """
+
     exception_raised: bool
     exception_type: Optional[str]
     result_is_none: bool
@@ -38,6 +53,7 @@ class GuardObservation:
 
 
 def _build_guard_explainer() -> tuple:
+    """Build a deterministic fitted+calibrated WrapCalibratedExplainer for guard tests."""
     X_all, y_all = make_classification(
         n_samples=_N_SAMPLES,
         n_features=_N_FEATURES,
@@ -64,7 +80,18 @@ def _build_guard_explainer() -> tuple:
 
 
 def run_guard_tif_scenario() -> GuardObservation:
-    """Stimulate CE-REQ-GUARD-API-001 through WrapCalibratedExplainer with GuardedOptions."""
+    """Stimulate CE-REQ-GUARD-API-001 through WrapCalibratedExplainer with GuardedOptions.
+
+    TIF ID: CE-TIF-GUARD-001
+
+    Requirements served:
+      CE-REQ-GUARD-API-001 (observation: exception_raised, result_is_none, result_len)
+
+    Returns
+    -------
+    GuardObservation
+        Structured observations. Tests assert on these fields.
+    """
     explainer, X_test = _build_guard_explainer()
     n_instances = len(X_test)
 
@@ -81,6 +108,8 @@ def run_guard_tif_scenario() -> GuardObservation:
 
     result_len = None
     if result is not None:
+        import contextlib
+
         with contextlib.suppress(TypeError):
             result_len = len(result)
 
@@ -108,7 +137,10 @@ def build_evidence_payload(
     python_version: str,
     platform_str: str,
 ) -> dict:
-    """Build a complete evidence payload for CE-TIF-GUARD-001."""
+    """Build a complete evidence payload for CE-TIF-GUARD-001.
+
+    Called by scripts/generate_tif_evidence.py during dynamic discovery.
+    """
     from tif_evidence_helpers import (
         acceptance_entry,
         build_payload,

--- a/development/capabilities/verification/tif/tif_guard.py
+++ b/development/capabilities/verification/tif/tif_guard.py
@@ -11,6 +11,7 @@ GuardObservation against acceptance criteria from the requirement files.
 
 from __future__ import annotations
 
+import contextlib
 from dataclasses import dataclass
 from typing import Optional
 
@@ -29,22 +30,6 @@ _N_TEST = 3
 
 @dataclass
 class GuardObservation:
-    """Structured observation returned by guarded explanation TIF scenarios.
-
-    Fields
-    ------
-    exception_raised : bool
-        Whether an exception was raised during the call.
-    exception_type : str or None
-        Exception class name if raised; None otherwise.
-    result_is_none : bool
-        Whether the result is None.
-    result_len : int or None
-        len(result) if result supports __len__; None otherwise.
-    n_instances : int
-        Number of test instances.
-    """
-
     exception_raised: bool
     exception_type: Optional[str]
     result_is_none: bool
@@ -53,7 +38,6 @@ class GuardObservation:
 
 
 def _build_guard_explainer() -> tuple:
-    """Build a deterministic fitted+calibrated WrapCalibratedExplainer for guard tests."""
     X_all, y_all = make_classification(
         n_samples=_N_SAMPLES,
         n_features=_N_FEATURES,
@@ -80,18 +64,7 @@ def _build_guard_explainer() -> tuple:
 
 
 def run_guard_tif_scenario() -> GuardObservation:
-    """Stimulate CE-REQ-GUARD-API-001 through WrapCalibratedExplainer with GuardedOptions.
-
-    TIF ID: CE-TIF-GUARD-001
-
-    Requirements served:
-      CE-REQ-GUARD-API-001 (observation: exception_raised, result_is_none, result_len)
-
-    Returns
-    -------
-    GuardObservation
-        Structured observations. Tests assert on these fields.
-    """
+    """Stimulate CE-REQ-GUARD-API-001 through WrapCalibratedExplainer with GuardedOptions."""
     explainer, X_test = _build_guard_explainer()
     n_instances = len(X_test)
 
@@ -108,8 +81,6 @@ def run_guard_tif_scenario() -> GuardObservation:
 
     result_len = None
     if result is not None:
-        import contextlib
-
         with contextlib.suppress(TypeError):
             result_len = len(result)
 
@@ -119,4 +90,57 @@ def run_guard_tif_scenario() -> GuardObservation:
         result_is_none=result is None,
         result_len=result_len,
         n_instances=n_instances,
+    )
+
+
+_DATASET_ID = (
+    "sklearn make_classification n_samples=120 n_features=4 "
+    "n_informative=3 n_redundant=1 random_seed=42"
+)
+
+
+def build_evidence_payload(
+    *,
+    commit_sha: str,
+    timestamp: str,
+    date_suffix: str,
+    package_version: str,
+    python_version: str,
+    platform_str: str,
+) -> dict:
+    """Build a complete evidence payload for CE-TIF-GUARD-001."""
+    from tif_evidence_helpers import (
+        acceptance_entry,
+        build_payload,
+        obs_to_dict,
+        scenario_entry,
+    )
+
+    obs = run_guard_tif_scenario()
+    scenarios = [
+        scenario_entry(
+            "explain_factual_with_guarded_options",
+            obs_to_dict(obs),
+            [
+                acceptance_entry("CE-REQ-GUARD-API-001", "exception_raised", False, obs.exception_raised),
+                acceptance_entry("CE-REQ-GUARD-API-001", "result_is_none", False, obs.result_is_none),
+                acceptance_entry("CE-REQ-GUARD-API-001", "result_len == n_instances", True, obs.result_len == obs.n_instances),
+            ],
+        ),
+    ]
+    return build_payload(
+        "GUARD-001",
+        claim_ids=["CE-CAP-GUARD-001"],
+        requirement_ids=["CE-REQ-GUARD-API-001"],
+        adr_refs=["ADR-032", "ADR-038"],
+        tif_ids=["CE-TIF-GUARD-001"],
+        verification_type="api_contract",
+        dataset_id=_DATASET_ID,
+        scenarios=scenarios,
+        commit_sha=commit_sha,
+        timestamp=timestamp,
+        date_suffix=date_suffix,
+        package_version=package_version,
+        python_version=python_version,
+        platform_str=platform_str,
     )

--- a/development/capabilities/verification/tif/tif_mondrian.py
+++ b/development/capabilities/verification/tif/tif_mondrian.py
@@ -29,6 +29,20 @@ _N_TEST = 3
 
 @dataclass
 class MondrianObservation:
+    """Structured observation returned by Mondrian calibration TIF scenarios.
+
+    Fields
+    ------
+    exception_raised : bool
+        Whether an exception was raised during calibrate.
+    exception_type : str or None
+        Exception class name if raised; None otherwise.
+    calibrated : bool
+        Whether wrapper.calibrated is True after calibration.
+    n_instances : int
+        Number of test instances (X_test size; calibration size not reported here).
+    """
+
     exception_raised: bool
     exception_type: Optional[str]
     calibrated: bool
@@ -41,7 +55,18 @@ def _mondrian_fn(x: np.ndarray) -> np.ndarray:
 
 
 def run_mondrian_tif_scenario() -> MondrianObservation:
-    """Stimulate CE-REQ-MOND-API-001 through WrapCalibratedExplainer with mc= param."""
+    """Stimulate CE-REQ-MOND-API-001 through WrapCalibratedExplainer with mc= param.
+
+    TIF ID: CE-TIF-MOND-001
+
+    Requirements served:
+      CE-REQ-MOND-API-001 (observation: exception_raised, calibrated)
+
+    Returns
+    -------
+    MondrianObservation
+        Structured observations. Tests assert on these fields.
+    """
     X_all, y_all = make_classification(
         n_samples=_N_SAMPLES,
         n_features=_N_FEATURES,
@@ -96,7 +121,10 @@ def build_evidence_payload(
     python_version: str,
     platform_str: str,
 ) -> dict:
-    """Build a complete evidence payload for CE-TIF-MOND-001."""
+    """Build a complete evidence payload for CE-TIF-MOND-001.
+
+    Called by scripts/generate_tif_evidence.py during dynamic discovery.
+    """
     from tif_evidence_helpers import (
         acceptance_entry,
         build_payload,

--- a/development/capabilities/verification/tif/tif_mondrian.py
+++ b/development/capabilities/verification/tif/tif_mondrian.py
@@ -29,20 +29,6 @@ _N_TEST = 3
 
 @dataclass
 class MondrianObservation:
-    """Structured observation returned by Mondrian calibration TIF scenarios.
-
-    Fields
-    ------
-    exception_raised : bool
-        Whether an exception was raised during calibrate.
-    exception_type : str or None
-        Exception class name if raised; None otherwise.
-    calibrated : bool
-        Whether wrapper.calibrated is True after calibration.
-    n_instances : int
-        Number of test instances (X_test size; calibration size not reported here).
-    """
-
     exception_raised: bool
     exception_type: Optional[str]
     calibrated: bool
@@ -55,18 +41,7 @@ def _mondrian_fn(x: np.ndarray) -> np.ndarray:
 
 
 def run_mondrian_tif_scenario() -> MondrianObservation:
-    """Stimulate CE-REQ-MOND-API-001 through WrapCalibratedExplainer with mc= param.
-
-    TIF ID: CE-TIF-MOND-001
-
-    Requirements served:
-      CE-REQ-MOND-API-001 (observation: exception_raised, calibrated)
-
-    Returns
-    -------
-    MondrianObservation
-        Structured observations. Tests assert on these fields.
-    """
+    """Stimulate CE-REQ-MOND-API-001 through WrapCalibratedExplainer with mc= param."""
     X_all, y_all = make_classification(
         n_samples=_N_SAMPLES,
         n_features=_N_FEATURES,
@@ -103,4 +78,57 @@ def run_mondrian_tif_scenario() -> MondrianObservation:
         exception_type=None,
         calibrated=bool(explainer.calibrated),
         n_instances=n_instances,
+    )
+
+
+_DATASET_ID = (
+    "sklearn make_classification n_samples=120 n_features=4 "
+    "n_informative=3 n_redundant=1 random_seed=42"
+)
+
+
+def build_evidence_payload(
+    *,
+    commit_sha: str,
+    timestamp: str,
+    date_suffix: str,
+    package_version: str,
+    python_version: str,
+    platform_str: str,
+) -> dict:
+    """Build a complete evidence payload for CE-TIF-MOND-001."""
+    from tif_evidence_helpers import (
+        acceptance_entry,
+        build_payload,
+        obs_to_dict,
+        scenario_entry,
+    )
+
+    obs = run_mondrian_tif_scenario()
+    scenarios = [
+        scenario_entry(
+            "calibrate_with_mondrian_categorizer",
+            obs_to_dict(obs),
+            [
+                acceptance_entry("CE-REQ-MOND-API-001", "exception_raised", False, obs.exception_raised),
+                acceptance_entry("CE-REQ-MOND-API-001", "calibrated", True, obs.calibrated),
+            ],
+        ),
+    ]
+    return build_payload(
+        "MOND-001",
+        claim_ids=["CE-CAP-MOND-001"],
+        requirement_ids=["CE-REQ-MOND-API-001"],
+        adr_refs=["ADR-013"],
+        tif_ids=["CE-TIF-MOND-001"],
+        verification_type="api_contract",
+        dataset_id=_DATASET_ID,
+        scenarios=scenarios,
+        commit_sha=commit_sha,
+        timestamp=timestamp,
+        date_suffix=date_suffix,
+        package_version=package_version,
+        python_version=python_version,
+        platform_str=platform_str,
+        configuration={"mondrian_fn": "sign of feature 0 (2 categories)"},
     )

--- a/development/capabilities/verification/tif/tif_narrative.py
+++ b/development/capabilities/verification/tif/tif_narrative.py
@@ -31,24 +31,6 @@ _N_TEST = 3
 
 @dataclass
 class NarrativeObservation:
-    """Structured observation returned by narrative TIF scenarios.
-
-    Fields
-    ------
-    exception_raised : bool
-        Whether an exception was raised during the call.
-    exception_type : str or None
-        Exception class name if raised; None otherwise.
-    result_is_none : bool
-        Whether the result is None.
-    result_is_str : bool
-        Whether isinstance(result, str).
-    result_len : int or None
-        len(result) if result is a non-None str; None otherwise.
-    n_instances : int
-        Number of test instances.
-    """
-
     exception_raised: bool
     exception_type: Optional[str]
     result_is_none: bool
@@ -58,7 +40,6 @@ class NarrativeObservation:
 
 
 def _build_narrative_explainer() -> tuple:
-    """Build a deterministic fitted+calibrated WrapCalibratedExplainer for narrative tests."""
     X_all, y_all = make_classification(
         n_samples=_N_SAMPLES,
         n_features=_N_FEATURES,
@@ -85,18 +66,7 @@ def _build_narrative_explainer() -> tuple:
 
 
 def run_narrative_tif_scenario() -> NarrativeObservation:
-    """Stimulate CE-REQ-NARR-API-001 through WrapCalibratedExplainer.explain_factual + to_narrative.
-
-    TIF ID: CE-TIF-NARR-001
-
-    Requirements served:
-      CE-REQ-NARR-API-001 (observation: exception_raised, result_is_none, result_is_str, result_len)
-
-    Returns
-    -------
-    NarrativeObservation
-        Structured observations. Tests assert on these fields.
-    """
+    """Stimulate CE-REQ-NARR-API-001 through WrapCalibratedExplainer.explain_factual + to_narrative."""
     explainer, X_test = _build_narrative_explainer()
     n_instances = len(X_test)
 
@@ -124,4 +94,59 @@ def run_narrative_tif_scenario() -> NarrativeObservation:
         result_is_str=result_is_str,
         result_len=result_len,
         n_instances=n_instances,
+    )
+
+
+_DATASET_ID = (
+    "sklearn make_classification n_samples=120 n_features=4 "
+    "n_informative=3 n_redundant=1 random_seed=42"
+)
+
+
+def build_evidence_payload(
+    *,
+    commit_sha: str,
+    timestamp: str,
+    date_suffix: str,
+    package_version: str,
+    python_version: str,
+    platform_str: str,
+) -> dict:
+    """Build a complete evidence payload for CE-TIF-NARR-001."""
+    from tif_evidence_helpers import (
+        acceptance_entry,
+        build_payload,
+        obs_to_dict,
+        scenario_entry,
+    )
+
+    obs = run_narrative_tif_scenario()
+    scenarios = [
+        scenario_entry(
+            "to_narrative_text_format",
+            obs_to_dict(obs),
+            [
+                acceptance_entry("CE-REQ-NARR-API-001", "exception_raised", False, obs.exception_raised),
+                acceptance_entry("CE-REQ-NARR-API-001", "result_is_none", False, obs.result_is_none),
+                acceptance_entry("CE-REQ-NARR-API-001", "result_is_str", True, obs.result_is_str),
+                acceptance_entry("CE-REQ-NARR-API-001", "result_len > 0", True, obs.result_len is not None and obs.result_len > 0),
+            ],
+        ),
+    ]
+    return build_payload(
+        "NARR-001",
+        claim_ids=["CE-CAP-NARR-001"],
+        requirement_ids=["CE-REQ-NARR-API-001"],
+        adr_refs=["ADR-008"],
+        tif_ids=["CE-TIF-NARR-001"],
+        verification_type="api_contract",
+        dataset_id=_DATASET_ID,
+        scenarios=scenarios,
+        commit_sha=commit_sha,
+        timestamp=timestamp,
+        date_suffix=date_suffix,
+        package_version=package_version,
+        python_version=python_version,
+        platform_str=platform_str,
+        configuration={"output_format": "text"},
     )

--- a/development/capabilities/verification/tif/tif_narrative.py
+++ b/development/capabilities/verification/tif/tif_narrative.py
@@ -31,6 +31,24 @@ _N_TEST = 3
 
 @dataclass
 class NarrativeObservation:
+    """Structured observation returned by narrative TIF scenarios.
+
+    Fields
+    ------
+    exception_raised : bool
+        Whether an exception was raised during the call.
+    exception_type : str or None
+        Exception class name if raised; None otherwise.
+    result_is_none : bool
+        Whether the result is None.
+    result_is_str : bool
+        Whether isinstance(result, str).
+    result_len : int or None
+        len(result) if result is a non-None str; None otherwise.
+    n_instances : int
+        Number of test instances.
+    """
+
     exception_raised: bool
     exception_type: Optional[str]
     result_is_none: bool
@@ -40,6 +58,7 @@ class NarrativeObservation:
 
 
 def _build_narrative_explainer() -> tuple:
+    """Build a deterministic fitted+calibrated WrapCalibratedExplainer for narrative tests."""
     X_all, y_all = make_classification(
         n_samples=_N_SAMPLES,
         n_features=_N_FEATURES,
@@ -66,7 +85,18 @@ def _build_narrative_explainer() -> tuple:
 
 
 def run_narrative_tif_scenario() -> NarrativeObservation:
-    """Stimulate CE-REQ-NARR-API-001 through WrapCalibratedExplainer.explain_factual + to_narrative."""
+    """Stimulate CE-REQ-NARR-API-001 through WrapCalibratedExplainer.explain_factual + to_narrative.
+
+    TIF ID: CE-TIF-NARR-001
+
+    Requirements served:
+      CE-REQ-NARR-API-001 (observation: exception_raised, result_is_none, result_is_str, result_len)
+
+    Returns
+    -------
+    NarrativeObservation
+        Structured observations. Tests assert on these fields.
+    """
     explainer, X_test = _build_narrative_explainer()
     n_instances = len(X_test)
 
@@ -112,7 +142,10 @@ def build_evidence_payload(
     python_version: str,
     platform_str: str,
 ) -> dict:
-    """Build a complete evidence payload for CE-TIF-NARR-001."""
+    """Build a complete evidence payload for CE-TIF-NARR-001.
+
+    Called by scripts/generate_tif_evidence.py during dynamic discovery.
+    """
     from tif_evidence_helpers import (
         acceptance_entry,
         build_payload,

--- a/development/capabilities/verification/tif/tif_prediction.py
+++ b/development/capabilities/verification/tif/tif_prediction.py
@@ -5,11 +5,6 @@ TIF ID: CE-TIF-PRED-001
 Requirements served:
   CE-REQ-PRED-API-001              — predict with uq_interval=True API contract
   CE-REQ-PRED-INTERVAL-BOUNDS-001  — low_high_percentiles parameter and interval semantics
-
-This module stimulates CE through WrapCalibratedExplainer only.
-
-Tests call run_prediction_tif_scenario() and assert on the returned
-PredictionObservation against acceptance criteria from the requirement files.
 """
 
 from __future__ import annotations
@@ -32,39 +27,6 @@ _N_TEST = 5
 
 @dataclass
 class PredictionObservation:
-    """Structured observation returned by prediction TIF scenarios.
-
-    Fields
-    ------
-    exception_raised : bool
-        Whether an exception was raised during the predict call.
-    exception_type : str or None
-        Class name of the exception if raised; None otherwise.
-    result_is_none : bool
-        Whether the result is None.
-    y_hat_len : int or None
-        Length of the point prediction array; None if exception.
-    low_is_none : bool
-        Whether the lower bound array is None.
-    high_is_none : bool
-        Whether the upper bound array is None.
-    bounds_ordered : bool
-        Whether low[i] <= high[i] for all i. False if exception or None bounds.
-    low_lte_yhat : bool or None
-        Whether low[i] <= y_hat[i] for all i (regression point estimate ordering).
-        None when not applicable.
-    low_high_percentiles : tuple or None
-        The percentile tuple used, or None for default.
-    n_instances : int
-        Number of test instances.
-    low_values : list or None
-        The actual lower bound values, for narrowing assertion checks.
-    high_values : list or None
-        The actual upper bound values.
-    y_hat_values : list or None
-        The point prediction values.
-    """
-
     exception_raised: bool
     exception_type: Optional[str]
     result_is_none: bool
@@ -81,7 +43,6 @@ class PredictionObservation:
 
 
 def _build_regression_explainer() -> tuple:
-    """Build a deterministic fitted+calibrated WrapCalibratedExplainer for regression."""
     X_all, y_all = make_regression(
         n_samples=_N_SAMPLES,
         n_features=_N_FEATURES,
@@ -111,40 +72,9 @@ def run_prediction_tif_scenario(
     *,
     low_high_percentiles: Optional[tuple] = None,
 ) -> PredictionObservation:
-    """Stimulate CE-REQ-PRED-API-001 and CE-REQ-PRED-INTERVAL-BOUNDS-001.
-
-    TIF ID: CE-TIF-PRED-001
-
-    Requirements served:
-      CE-REQ-PRED-API-001             (observation: exception_raised, y_hat_len,
-                                        low_is_none, high_is_none, bounds_ordered)
-      CE-REQ-PRED-INTERVAL-BOUNDS-001 (observation: bounds_ordered, low_values, high_values)
-
-    Parameters
-    ----------
-    low_high_percentiles : tuple or None
-        If provided, passed as low_high_percentiles to predict(uq_interval=True).
-        If None, uses the default (5, 95).
-
-    Returns
-    -------
-    PredictionObservation
-        Structured observations. Tests assert on these fields.
-    """
+    """Stimulate CE-REQ-PRED-API-001 and CE-REQ-PRED-INTERVAL-BOUNDS-001."""
     explainer, X_test = _build_regression_explainer()
     n_instances = len(X_test)
-
-    exception_raised = False
-    exception_type = None
-    result_is_none = True
-    y_hat_len = None
-    low_is_none = True
-    high_is_none = True
-    bounds_ordered = False
-    low_lte_yhat = None
-    low_values = None
-    high_values = None
-    y_hat_values = None
 
     predict_kwargs: dict = {"uq_interval": True}
     if low_high_percentiles is not None:
@@ -153,11 +83,9 @@ def run_prediction_tif_scenario(
     try:
         result = explainer.predict(X_test, **predict_kwargs)
     except Exception as exc:
-        exception_raised = True
-        exception_type = type(exc).__name__
         return PredictionObservation(
             exception_raised=True,
-            exception_type=exception_type,
+            exception_type=type(exc).__name__,
             result_is_none=True,
             y_hat_len=None,
             low_is_none=True,
@@ -169,6 +97,14 @@ def run_prediction_tif_scenario(
         )
 
     result_is_none = result is None
+    y_hat_len = None
+    low_is_none = True
+    high_is_none = True
+    bounds_ordered = False
+    low_lte_yhat = None
+    low_values = None
+    high_values = None
+    y_hat_values = None
 
     if result is not None:
         try:
@@ -190,8 +126,8 @@ def run_prediction_tif_scenario(
             pass
 
     return PredictionObservation(
-        exception_raised=exception_raised,
-        exception_type=exception_type,
+        exception_raised=False,
+        exception_type=None,
         result_is_none=result_is_none,
         y_hat_len=y_hat_len,
         low_is_none=low_is_none,
@@ -203,4 +139,68 @@ def run_prediction_tif_scenario(
         low_values=low_values,
         high_values=high_values,
         y_hat_values=y_hat_values,
+    )
+
+
+_DATASET_ID = (
+    "sklearn make_regression n_samples=150 n_features=4 "
+    "n_informative=3 noise=10 random_seed=42"
+)
+
+
+def build_evidence_payload(
+    *,
+    commit_sha: str,
+    timestamp: str,
+    date_suffix: str,
+    package_version: str,
+    python_version: str,
+    platform_str: str,
+) -> dict:
+    """Build a complete evidence payload for CE-TIF-PRED-001."""
+    from tif_evidence_helpers import (
+        acceptance_entry,
+        build_payload,
+        obs_to_dict,
+        scenario_entry,
+    )
+
+    default = run_prediction_tif_scenario()
+    custom = run_prediction_tif_scenario(low_high_percentiles=(10, 90))
+    scenarios = [
+        scenario_entry(
+            "predict_uq_interval_default",
+            obs_to_dict(default),
+            [
+                acceptance_entry("CE-REQ-PRED-API-001", "exception_raised", False, default.exception_raised),
+                acceptance_entry("CE-REQ-PRED-API-001", "y_hat_len == n_instances", True, default.y_hat_len == default.n_instances),
+                acceptance_entry("CE-REQ-PRED-API-001", "low_is_none", False, default.low_is_none),
+                acceptance_entry("CE-REQ-PRED-API-001", "high_is_none", False, default.high_is_none),
+                acceptance_entry("CE-REQ-PRED-INTERVAL-BOUNDS-001", "bounds_ordered", True, default.bounds_ordered),
+            ],
+        ),
+        scenario_entry(
+            "predict_uq_interval_percentiles_10_90",
+            obs_to_dict(custom),
+            [
+                acceptance_entry("CE-REQ-PRED-INTERVAL-BOUNDS-001", "exception_raised", False, custom.exception_raised),
+                acceptance_entry("CE-REQ-PRED-INTERVAL-BOUNDS-001", "bounds_ordered", True, custom.bounds_ordered),
+            ],
+        ),
+    ]
+    return build_payload(
+        "PRED-001",
+        claim_ids=["CE-CAP-PRED-001"],
+        requirement_ids=["CE-REQ-PRED-API-001", "CE-REQ-PRED-INTERVAL-BOUNDS-001"],
+        adr_refs=["ADR-013", "ADR-021"],
+        tif_ids=["CE-TIF-PRED-001"],
+        verification_type="behavioral_contract",
+        dataset_id=_DATASET_ID,
+        scenarios=scenarios,
+        commit_sha=commit_sha,
+        timestamp=timestamp,
+        date_suffix=date_suffix,
+        package_version=package_version,
+        python_version=python_version,
+        platform_str=platform_str,
     )

--- a/development/capabilities/verification/tif/tif_prediction.py
+++ b/development/capabilities/verification/tif/tif_prediction.py
@@ -5,6 +5,11 @@ TIF ID: CE-TIF-PRED-001
 Requirements served:
   CE-REQ-PRED-API-001              — predict with uq_interval=True API contract
   CE-REQ-PRED-INTERVAL-BOUNDS-001  — low_high_percentiles parameter and interval semantics
+
+This module stimulates CE through WrapCalibratedExplainer only.
+
+Tests call run_prediction_tif_scenario() and assert on the returned
+PredictionObservation against acceptance criteria from the requirement files.
 """
 
 from __future__ import annotations
@@ -27,6 +32,39 @@ _N_TEST = 5
 
 @dataclass
 class PredictionObservation:
+    """Structured observation returned by prediction TIF scenarios.
+
+    Fields
+    ------
+    exception_raised : bool
+        Whether an exception was raised during the predict call.
+    exception_type : str or None
+        Class name of the exception if raised; None otherwise.
+    result_is_none : bool
+        Whether the result is None.
+    y_hat_len : int or None
+        Length of the point prediction array; None if exception.
+    low_is_none : bool
+        Whether the lower bound array is None.
+    high_is_none : bool
+        Whether the upper bound array is None.
+    bounds_ordered : bool
+        Whether low[i] <= high[i] for all i. False if exception or None bounds.
+    low_lte_yhat : bool or None
+        Whether low[i] <= y_hat[i] for all i (regression point estimate ordering).
+        None when not applicable.
+    low_high_percentiles : tuple or None
+        The percentile tuple used, or None for default.
+    n_instances : int
+        Number of test instances.
+    low_values : list or None
+        The actual lower bound values, for narrowing assertion checks.
+    high_values : list or None
+        The actual upper bound values.
+    y_hat_values : list or None
+        The point prediction values.
+    """
+
     exception_raised: bool
     exception_type: Optional[str]
     result_is_none: bool
@@ -43,6 +81,7 @@ class PredictionObservation:
 
 
 def _build_regression_explainer() -> tuple:
+    """Build a deterministic fitted+calibrated WrapCalibratedExplainer for regression."""
     X_all, y_all = make_regression(
         n_samples=_N_SAMPLES,
         n_features=_N_FEATURES,
@@ -72,9 +111,40 @@ def run_prediction_tif_scenario(
     *,
     low_high_percentiles: Optional[tuple] = None,
 ) -> PredictionObservation:
-    """Stimulate CE-REQ-PRED-API-001 and CE-REQ-PRED-INTERVAL-BOUNDS-001."""
+    """Stimulate CE-REQ-PRED-API-001 and CE-REQ-PRED-INTERVAL-BOUNDS-001.
+
+    TIF ID: CE-TIF-PRED-001
+
+    Requirements served:
+      CE-REQ-PRED-API-001             (observation: exception_raised, y_hat_len,
+                                        low_is_none, high_is_none, bounds_ordered)
+      CE-REQ-PRED-INTERVAL-BOUNDS-001 (observation: bounds_ordered, low_values, high_values)
+
+    Parameters
+    ----------
+    low_high_percentiles : tuple or None
+        If provided, passed as low_high_percentiles to predict(uq_interval=True).
+        If None, uses the default (5, 95).
+
+    Returns
+    -------
+    PredictionObservation
+        Structured observations. Tests assert on these fields.
+    """
     explainer, X_test = _build_regression_explainer()
     n_instances = len(X_test)
+
+    exception_raised = False
+    exception_type = None
+    result_is_none = True
+    y_hat_len = None
+    low_is_none = True
+    high_is_none = True
+    bounds_ordered = False
+    low_lte_yhat = None
+    low_values = None
+    high_values = None
+    y_hat_values = None
 
     predict_kwargs: dict = {"uq_interval": True}
     if low_high_percentiles is not None:
@@ -83,9 +153,11 @@ def run_prediction_tif_scenario(
     try:
         result = explainer.predict(X_test, **predict_kwargs)
     except Exception as exc:
+        exception_raised = True
+        exception_type = type(exc).__name__
         return PredictionObservation(
             exception_raised=True,
-            exception_type=type(exc).__name__,
+            exception_type=exception_type,
             result_is_none=True,
             y_hat_len=None,
             low_is_none=True,
@@ -97,14 +169,6 @@ def run_prediction_tif_scenario(
         )
 
     result_is_none = result is None
-    y_hat_len = None
-    low_is_none = True
-    high_is_none = True
-    bounds_ordered = False
-    low_lte_yhat = None
-    low_values = None
-    high_values = None
-    y_hat_values = None
 
     if result is not None:
         try:
@@ -126,8 +190,8 @@ def run_prediction_tif_scenario(
             pass
 
     return PredictionObservation(
-        exception_raised=False,
-        exception_type=None,
+        exception_raised=exception_raised,
+        exception_type=exception_type,
         result_is_none=result_is_none,
         y_hat_len=y_hat_len,
         low_is_none=low_is_none,
@@ -157,7 +221,10 @@ def build_evidence_payload(
     python_version: str,
     platform_str: str,
 ) -> dict:
-    """Build a complete evidence payload for CE-TIF-PRED-001."""
+    """Build a complete evidence payload for CE-TIF-PRED-001.
+
+    Called by scripts/generate_tif_evidence.py during dynamic discovery.
+    """
     from tif_evidence_helpers import (
         acceptance_entry,
         build_payload,

--- a/development/capabilities/verification/tif/tif_prob_regression.py
+++ b/development/capabilities/verification/tif/tif_prob_regression.py
@@ -1,6 +1,13 @@
 """TIF verification interface for CE probabilistic regression threshold query capabilities.
 
 TIF ID: CE-TIF-PRED-PROB-001
+
+Requirements served:
+  CE-REQ-PRED-PROB-API-001    — predict_proba with threshold API contract
+  CE-REQ-PRED-PROB-BOUNDS-001 — returned probability values bounded in [0, 1]
+
+Tests call run_prob_regression_tif_scenario() and assert on the returned
+ProbRegressionObservation against acceptance criteria from the requirement files.
 """
 
 from __future__ import annotations
@@ -23,6 +30,28 @@ _N_TEST = 5
 
 @dataclass
 class ProbRegressionObservation:
+    """Structured observation returned by probabilistic regression TIF scenarios.
+
+    Fields
+    ------
+    exception_raised : bool
+        Whether an exception was raised.
+    exception_type : str or None
+        Exception class name if raised; None otherwise.
+    result_is_none : bool
+        Whether the result is None.
+    proba_len : int or None
+        Length of the returned probability array.
+    proba_min : float or None
+        Minimum value in the probability array.
+    proba_max : float or None
+        Maximum value in the probability array.
+    threshold : float
+        The threshold used.
+    n_instances : int
+        Number of test instances.
+    """
+
     exception_raised: bool
     exception_type: Optional[str]
     result_is_none: bool
@@ -34,6 +63,7 @@ class ProbRegressionObservation:
 
 
 def _build_regression_explainer() -> tuple:
+    """Build a deterministic fitted+calibrated WrapCalibratedExplainer for regression."""
     X_all, y_all = make_regression(
         n_samples=_N_SAMPLES,
         n_features=_N_FEATURES,
@@ -63,16 +93,42 @@ def run_prob_regression_tif_scenario(
     *,
     threshold: float = 0.0,
 ) -> ProbRegressionObservation:
-    """Stimulate CE-REQ-PRED-PROB-API-001 and CE-REQ-PRED-PROB-BOUNDS-001."""
+    """Stimulate CE-REQ-PRED-PROB-API-001 and CE-REQ-PRED-PROB-BOUNDS-001.
+
+    TIF ID: CE-TIF-PRED-PROB-001
+
+    Requirements served:
+      CE-REQ-PRED-PROB-API-001    (observation: exception_raised, proba_len)
+      CE-REQ-PRED-PROB-BOUNDS-001 (observation: proba_min, proba_max)
+
+    Parameters
+    ----------
+    threshold : float
+        Scalar threshold for P(Y > threshold | X). Default 0.0.
+
+    Returns
+    -------
+    ProbRegressionObservation
+        Structured observations. Tests assert on these fields.
+    """
     explainer, X_test, _ = _build_regression_explainer()
     n_instances = len(X_test)
+
+    exception_raised = False
+    exception_type = None
+    result_is_none = True
+    proba_len = None
+    proba_min = None
+    proba_max = None
 
     try:
         result = explainer.predict_proba(X_test, threshold=threshold)
     except Exception as exc:
+        exception_raised = True
+        exception_type = type(exc).__name__
         return ProbRegressionObservation(
             exception_raised=True,
-            exception_type=type(exc).__name__,
+            exception_type=exception_type,
             result_is_none=True,
             proba_len=None,
             proba_min=None,
@@ -82,9 +138,6 @@ def run_prob_regression_tif_scenario(
         )
 
     result_is_none = result is None
-    proba_len = None
-    proba_min = None
-    proba_max = None
 
     if result is not None:
         proba_arr = np.asarray(result)
@@ -93,8 +146,8 @@ def run_prob_regression_tif_scenario(
         proba_max = float(np.max(proba_arr))
 
     return ProbRegressionObservation(
-        exception_raised=False,
-        exception_type=None,
+        exception_raised=exception_raised,
+        exception_type=exception_type,
         result_is_none=result_is_none,
         proba_len=proba_len,
         proba_min=proba_min,
@@ -119,7 +172,10 @@ def build_evidence_payload(
     python_version: str,
     platform_str: str,
 ) -> dict:
-    """Build a complete evidence payload for CE-TIF-PRED-PROB-001."""
+    """Build a complete evidence payload for CE-TIF-PRED-PROB-001.
+
+    Called by scripts/generate_tif_evidence.py during dynamic discovery.
+    """
     from tif_evidence_helpers import (
         acceptance_entry,
         build_payload,

--- a/development/capabilities/verification/tif/tif_prob_regression.py
+++ b/development/capabilities/verification/tif/tif_prob_regression.py
@@ -1,13 +1,6 @@
 """TIF verification interface for CE probabilistic regression threshold query capabilities.
 
 TIF ID: CE-TIF-PRED-PROB-001
-
-Requirements served:
-  CE-REQ-PRED-PROB-API-001    — predict_proba with threshold API contract
-  CE-REQ-PRED-PROB-BOUNDS-001 — returned probability values bounded in [0, 1]
-
-Tests call run_prob_regression_tif_scenario() and assert on the returned
-ProbRegressionObservation against acceptance criteria from the requirement files.
 """
 
 from __future__ import annotations
@@ -30,28 +23,6 @@ _N_TEST = 5
 
 @dataclass
 class ProbRegressionObservation:
-    """Structured observation returned by probabilistic regression TIF scenarios.
-
-    Fields
-    ------
-    exception_raised : bool
-        Whether an exception was raised.
-    exception_type : str or None
-        Exception class name if raised; None otherwise.
-    result_is_none : bool
-        Whether the result is None.
-    proba_len : int or None
-        Length of the returned probability array.
-    proba_min : float or None
-        Minimum value in the probability array.
-    proba_max : float or None
-        Maximum value in the probability array.
-    threshold : float
-        The threshold used.
-    n_instances : int
-        Number of test instances.
-    """
-
     exception_raised: bool
     exception_type: Optional[str]
     result_is_none: bool
@@ -63,7 +34,6 @@ class ProbRegressionObservation:
 
 
 def _build_regression_explainer() -> tuple:
-    """Build a deterministic fitted+calibrated WrapCalibratedExplainer for regression."""
     X_all, y_all = make_regression(
         n_samples=_N_SAMPLES,
         n_features=_N_FEATURES,
@@ -93,42 +63,16 @@ def run_prob_regression_tif_scenario(
     *,
     threshold: float = 0.0,
 ) -> ProbRegressionObservation:
-    """Stimulate CE-REQ-PRED-PROB-API-001 and CE-REQ-PRED-PROB-BOUNDS-001.
-
-    TIF ID: CE-TIF-PRED-PROB-001
-
-    Requirements served:
-      CE-REQ-PRED-PROB-API-001    (observation: exception_raised, proba_len)
-      CE-REQ-PRED-PROB-BOUNDS-001 (observation: proba_min, proba_max)
-
-    Parameters
-    ----------
-    threshold : float
-        Scalar threshold for P(Y > threshold | X). Default 0.0.
-
-    Returns
-    -------
-    ProbRegressionObservation
-        Structured observations. Tests assert on these fields.
-    """
+    """Stimulate CE-REQ-PRED-PROB-API-001 and CE-REQ-PRED-PROB-BOUNDS-001."""
     explainer, X_test, _ = _build_regression_explainer()
     n_instances = len(X_test)
-
-    exception_raised = False
-    exception_type = None
-    result_is_none = True
-    proba_len = None
-    proba_min = None
-    proba_max = None
 
     try:
         result = explainer.predict_proba(X_test, threshold=threshold)
     except Exception as exc:
-        exception_raised = True
-        exception_type = type(exc).__name__
         return ProbRegressionObservation(
             exception_raised=True,
-            exception_type=exception_type,
+            exception_type=type(exc).__name__,
             result_is_none=True,
             proba_len=None,
             proba_min=None,
@@ -138,6 +82,9 @@ def run_prob_regression_tif_scenario(
         )
 
     result_is_none = result is None
+    proba_len = None
+    proba_min = None
+    proba_max = None
 
     if result is not None:
         proba_arr = np.asarray(result)
@@ -146,12 +93,67 @@ def run_prob_regression_tif_scenario(
         proba_max = float(np.max(proba_arr))
 
     return ProbRegressionObservation(
-        exception_raised=exception_raised,
-        exception_type=exception_type,
+        exception_raised=False,
+        exception_type=None,
         result_is_none=result_is_none,
         proba_len=proba_len,
         proba_min=proba_min,
         proba_max=proba_max,
         threshold=threshold,
         n_instances=n_instances,
+    )
+
+
+_DATASET_ID = (
+    "sklearn make_regression n_samples=150 n_features=4 "
+    "n_informative=3 noise=10 random_seed=42"
+)
+
+
+def build_evidence_payload(
+    *,
+    commit_sha: str,
+    timestamp: str,
+    date_suffix: str,
+    package_version: str,
+    python_version: str,
+    platform_str: str,
+) -> dict:
+    """Build a complete evidence payload for CE-TIF-PRED-PROB-001."""
+    from tif_evidence_helpers import (
+        acceptance_entry,
+        build_payload,
+        obs_to_dict,
+        scenario_entry,
+    )
+
+    obs = run_prob_regression_tif_scenario(threshold=0.0)
+    scenarios = [
+        scenario_entry(
+            "prob_regression_threshold_0",
+            obs_to_dict(obs),
+            [
+                acceptance_entry("CE-REQ-PRED-PROB-API-001", "exception_raised", False, obs.exception_raised),
+                acceptance_entry("CE-REQ-PRED-PROB-API-001", "proba_len == n_instances", True, obs.proba_len == obs.n_instances),
+                acceptance_entry("CE-REQ-PRED-PROB-BOUNDS-001", "proba_min >= 0.0", True, obs.proba_min is not None and obs.proba_min >= 0.0),
+                acceptance_entry("CE-REQ-PRED-PROB-BOUNDS-001", "proba_max <= 1.0", True, obs.proba_max is not None and obs.proba_max <= 1.0),
+            ],
+        ),
+    ]
+    return build_payload(
+        "PRED-PROB-001",
+        claim_ids=["CE-CAP-PRED-PROB-001"],
+        requirement_ids=["CE-REQ-PRED-PROB-API-001", "CE-REQ-PRED-PROB-BOUNDS-001"],
+        adr_refs=["ADR-021"],
+        tif_ids=["CE-TIF-PRED-PROB-001"],
+        verification_type="numerical_behavior",
+        dataset_id=_DATASET_ID,
+        scenarios=scenarios,
+        commit_sha=commit_sha,
+        timestamp=timestamp,
+        date_suffix=date_suffix,
+        package_version=package_version,
+        python_version=python_version,
+        platform_str=platform_str,
+        configuration={"threshold": 0.0},
     )

--- a/development/capabilities/verification/tif/tif_reject.py
+++ b/development/capabilities/verification/tif/tif_reject.py
@@ -1,11 +1,16 @@
 """TIF verification interface for CE reject policy explanation capabilities.
 
 TIF ID: CE-TIF-REJECT-001
+
+Requirements served:
+  CE-REQ-REJECT-API-001 — explain_factual with RejectPolicySpec API contract
+
+Tests call run_reject_tif_scenario() and assert on the returned
+RejectObservation against acceptance criteria from the requirement files.
 """
 
 from __future__ import annotations
 
-import contextlib
 from dataclasses import dataclass
 from typing import Optional
 
@@ -24,6 +29,22 @@ _N_TEST = 3
 
 @dataclass
 class RejectObservation:
+    """Structured observation returned by reject policy TIF scenarios.
+
+    Fields
+    ------
+    exception_raised : bool
+        Whether an exception was raised during the call.
+    exception_type : str or None
+        Exception class name if raised; None otherwise.
+    result_is_none : bool
+        Whether the result is None.
+    result_len : int or None
+        len(result) if result supports __len__; None otherwise.
+    n_instances : int
+        Number of test instances.
+    """
+
     exception_raised: bool
     exception_type: Optional[str]
     result_is_none: bool
@@ -32,6 +53,7 @@ class RejectObservation:
 
 
 def _build_reject_explainer() -> tuple:
+    """Build a deterministic fitted+calibrated WrapCalibratedExplainer for reject tests."""
     X_all, y_all = make_classification(
         n_samples=_N_SAMPLES,
         n_features=_N_FEATURES,
@@ -58,7 +80,18 @@ def _build_reject_explainer() -> tuple:
 
 
 def run_reject_tif_scenario() -> RejectObservation:
-    """Stimulate CE-REQ-REJECT-API-001 through WrapCalibratedExplainer with RejectPolicySpec."""
+    """Stimulate CE-REQ-REJECT-API-001 through WrapCalibratedExplainer with RejectPolicySpec.
+
+    TIF ID: CE-TIF-REJECT-001
+
+    Requirements served:
+      CE-REQ-REJECT-API-001 (observation: exception_raised, result_is_none, result_len)
+
+    Returns
+    -------
+    RejectObservation
+        Structured observations. Tests assert on these fields.
+    """
     explainer, X_test = _build_reject_explainer()
     n_instances = len(X_test)
 
@@ -75,6 +108,8 @@ def run_reject_tif_scenario() -> RejectObservation:
 
     result_len = None
     if result is not None:
+        import contextlib
+
         with contextlib.suppress(TypeError):
             result_len = len(result)
 
@@ -102,7 +137,10 @@ def build_evidence_payload(
     python_version: str,
     platform_str: str,
 ) -> dict:
-    """Build a complete evidence payload for CE-TIF-REJECT-001."""
+    """Build a complete evidence payload for CE-TIF-REJECT-001.
+
+    Called by scripts/generate_tif_evidence.py during dynamic discovery.
+    """
     from tif_evidence_helpers import (
         acceptance_entry,
         build_payload,

--- a/development/capabilities/verification/tif/tif_reject.py
+++ b/development/capabilities/verification/tif/tif_reject.py
@@ -1,16 +1,11 @@
 """TIF verification interface for CE reject policy explanation capabilities.
 
 TIF ID: CE-TIF-REJECT-001
-
-Requirements served:
-  CE-REQ-REJECT-API-001 — explain_factual with RejectPolicySpec API contract
-
-Tests call run_reject_tif_scenario() and assert on the returned
-RejectObservation against acceptance criteria from the requirement files.
 """
 
 from __future__ import annotations
 
+import contextlib
 from dataclasses import dataclass
 from typing import Optional
 
@@ -29,22 +24,6 @@ _N_TEST = 3
 
 @dataclass
 class RejectObservation:
-    """Structured observation returned by reject policy TIF scenarios.
-
-    Fields
-    ------
-    exception_raised : bool
-        Whether an exception was raised during the call.
-    exception_type : str or None
-        Exception class name if raised; None otherwise.
-    result_is_none : bool
-        Whether the result is None.
-    result_len : int or None
-        len(result) if result supports __len__; None otherwise.
-    n_instances : int
-        Number of test instances.
-    """
-
     exception_raised: bool
     exception_type: Optional[str]
     result_is_none: bool
@@ -53,7 +32,6 @@ class RejectObservation:
 
 
 def _build_reject_explainer() -> tuple:
-    """Build a deterministic fitted+calibrated WrapCalibratedExplainer for reject tests."""
     X_all, y_all = make_classification(
         n_samples=_N_SAMPLES,
         n_features=_N_FEATURES,
@@ -80,18 +58,7 @@ def _build_reject_explainer() -> tuple:
 
 
 def run_reject_tif_scenario() -> RejectObservation:
-    """Stimulate CE-REQ-REJECT-API-001 through WrapCalibratedExplainer with RejectPolicySpec.
-
-    TIF ID: CE-TIF-REJECT-001
-
-    Requirements served:
-      CE-REQ-REJECT-API-001 (observation: exception_raised, result_is_none, result_len)
-
-    Returns
-    -------
-    RejectObservation
-        Structured observations. Tests assert on these fields.
-    """
+    """Stimulate CE-REQ-REJECT-API-001 through WrapCalibratedExplainer with RejectPolicySpec."""
     explainer, X_test = _build_reject_explainer()
     n_instances = len(X_test)
 
@@ -108,8 +75,6 @@ def run_reject_tif_scenario() -> RejectObservation:
 
     result_len = None
     if result is not None:
-        import contextlib
-
         with contextlib.suppress(TypeError):
             result_len = len(result)
 
@@ -119,4 +84,57 @@ def run_reject_tif_scenario() -> RejectObservation:
         result_is_none=result is None,
         result_len=result_len,
         n_instances=n_instances,
+    )
+
+
+_DATASET_ID = (
+    "sklearn make_classification n_samples=120 n_features=4 "
+    "n_informative=3 n_redundant=1 random_seed=42"
+)
+
+
+def build_evidence_payload(
+    *,
+    commit_sha: str,
+    timestamp: str,
+    date_suffix: str,
+    package_version: str,
+    python_version: str,
+    platform_str: str,
+) -> dict:
+    """Build a complete evidence payload for CE-TIF-REJECT-001."""
+    from tif_evidence_helpers import (
+        acceptance_entry,
+        build_payload,
+        obs_to_dict,
+        scenario_entry,
+    )
+
+    obs = run_reject_tif_scenario()
+    scenarios = [
+        scenario_entry(
+            "explain_factual_with_reject_policy_flag",
+            obs_to_dict(obs),
+            [
+                acceptance_entry("CE-REQ-REJECT-API-001", "exception_raised", False, obs.exception_raised),
+                acceptance_entry("CE-REQ-REJECT-API-001", "result_is_none", False, obs.result_is_none),
+                acceptance_entry("CE-REQ-REJECT-API-001", "result_len == n_instances", True, obs.result_len == obs.n_instances),
+            ],
+        ),
+    ]
+    return build_payload(
+        "REJECT-001",
+        claim_ids=["CE-CAP-REJECT-001"],
+        requirement_ids=["CE-REQ-REJECT-API-001"],
+        adr_refs=["ADR-029", "ADR-038"],
+        tif_ids=["CE-TIF-REJECT-001"],
+        verification_type="api_contract",
+        dataset_id=_DATASET_ID,
+        scenarios=scenarios,
+        commit_sha=commit_sha,
+        timestamp=timestamp,
+        date_suffix=date_suffix,
+        package_version=package_version,
+        python_version=python_version,
+        platform_str=platform_str,
     )

--- a/development/capabilities/verification/tif/tif_visualization.py
+++ b/development/capabilities/verification/tif/tif_visualization.py
@@ -5,6 +5,9 @@ TIF ID: CE-TIF-VIZ-001
 Requirements served:
   CE-REQ-VIZ-SMOKE-001 — CalibratedExplanations.plot() no-raise smoke test
 
+Tests call run_visualization_tif_scenario() and assert on the returned
+VizObservation against acceptance criteria from the requirement files.
+
 Note: requires matplotlib. If matplotlib is not installed this TIF will set
 exception_raised=True with exception_type='ImportError'.
 """
@@ -28,12 +31,25 @@ _N_TEST = 2
 
 @dataclass
 class VizObservation:
+    """Structured observation returned by visualization TIF scenarios.
+
+    Fields
+    ------
+    exception_raised : bool
+        Whether an exception was raised during explanations.plot().
+    exception_type : str or None
+        Exception class name if raised; None otherwise.
+    n_instances : int
+        Number of test instances.
+    """
+
     exception_raised: bool
     exception_type: Optional[str]
     n_instances: int
 
 
 def _build_viz_explainer() -> tuple:
+    """Build a deterministic fitted+calibrated WrapCalibratedExplainer for visualization tests."""
     X_all, y_all = make_classification(
         n_samples=_N_SAMPLES,
         n_features=_N_FEATURES,
@@ -60,7 +76,20 @@ def _build_viz_explainer() -> tuple:
 
 
 def run_visualization_tif_scenario() -> VizObservation:
-    """Stimulate CE-REQ-VIZ-SMOKE-001 through WrapCalibratedExplainer.explain_factual + plot."""
+    """Stimulate CE-REQ-VIZ-SMOKE-001 through WrapCalibratedExplainer.explain_factual + plot.
+
+    TIF ID: CE-TIF-VIZ-001
+
+    Requirements served:
+      CE-REQ-VIZ-SMOKE-001 (observation: exception_raised)
+
+    Uses the Agg backend to avoid display output. Cleans up figure state after the call.
+
+    Returns
+    -------
+    VizObservation
+        Structured observations. Tests assert on these fields.
+    """
     try:
         import matplotlib
         import matplotlib.pyplot as plt
@@ -110,7 +139,10 @@ def build_evidence_payload(
     python_version: str,
     platform_str: str,
 ) -> dict:
-    """Build a complete evidence payload for CE-TIF-VIZ-001."""
+    """Build a complete evidence payload for CE-TIF-VIZ-001.
+
+    Called by scripts/generate_tif_evidence.py during dynamic discovery.
+    """
     from tif_evidence_helpers import (
         acceptance_entry,
         build_payload,

--- a/development/capabilities/verification/tif/tif_visualization.py
+++ b/development/capabilities/verification/tif/tif_visualization.py
@@ -5,9 +5,6 @@ TIF ID: CE-TIF-VIZ-001
 Requirements served:
   CE-REQ-VIZ-SMOKE-001 — CalibratedExplanations.plot() no-raise smoke test
 
-Tests call run_visualization_tif_scenario() and assert on the returned
-VizObservation against acceptance criteria from the requirement files.
-
 Note: requires matplotlib. If matplotlib is not installed this TIF will set
 exception_raised=True with exception_type='ImportError'.
 """
@@ -31,25 +28,12 @@ _N_TEST = 2
 
 @dataclass
 class VizObservation:
-    """Structured observation returned by visualization TIF scenarios.
-
-    Fields
-    ------
-    exception_raised : bool
-        Whether an exception was raised during explanations.plot().
-    exception_type : str or None
-        Exception class name if raised; None otherwise.
-    n_instances : int
-        Number of test instances.
-    """
-
     exception_raised: bool
     exception_type: Optional[str]
     n_instances: int
 
 
 def _build_viz_explainer() -> tuple:
-    """Build a deterministic fitted+calibrated WrapCalibratedExplainer for visualization tests."""
     X_all, y_all = make_classification(
         n_samples=_N_SAMPLES,
         n_features=_N_FEATURES,
@@ -76,20 +60,7 @@ def _build_viz_explainer() -> tuple:
 
 
 def run_visualization_tif_scenario() -> VizObservation:
-    """Stimulate CE-REQ-VIZ-SMOKE-001 through WrapCalibratedExplainer.explain_factual + plot.
-
-    TIF ID: CE-TIF-VIZ-001
-
-    Requirements served:
-      CE-REQ-VIZ-SMOKE-001 (observation: exception_raised)
-
-    Uses the Agg backend to avoid display output. Cleans up figure state after the call.
-
-    Returns
-    -------
-    VizObservation
-        Structured observations. Tests assert on these fields.
-    """
+    """Stimulate CE-REQ-VIZ-SMOKE-001 through WrapCalibratedExplainer.explain_factual + plot."""
     try:
         import matplotlib
         import matplotlib.pyplot as plt
@@ -121,4 +92,54 @@ def run_visualization_tif_scenario() -> VizObservation:
         exception_raised=False,
         exception_type=None,
         n_instances=n_instances,
+    )
+
+
+_DATASET_ID = (
+    "sklearn make_classification n_samples=120 n_features=4 "
+    "n_informative=3 n_redundant=1 random_seed=42"
+)
+
+
+def build_evidence_payload(
+    *,
+    commit_sha: str,
+    timestamp: str,
+    date_suffix: str,
+    package_version: str,
+    python_version: str,
+    platform_str: str,
+) -> dict:
+    """Build a complete evidence payload for CE-TIF-VIZ-001."""
+    from tif_evidence_helpers import (
+        acceptance_entry,
+        build_payload,
+        obs_to_dict,
+        scenario_entry,
+    )
+
+    obs = run_visualization_tif_scenario()
+    scenarios = [
+        scenario_entry(
+            "plot_no_raise_agg_backend",
+            obs_to_dict(obs),
+            [acceptance_entry("CE-REQ-VIZ-SMOKE-001", "exception_raised", False, obs.exception_raised)],
+        ),
+    ]
+    return build_payload(
+        "VIZ-001",
+        claim_ids=["CE-CAP-VIZ-001"],
+        requirement_ids=["CE-REQ-VIZ-SMOKE-001"],
+        adr_refs=["ADR-023", "ADR-036", "ADR-037"],
+        tif_ids=["CE-TIF-VIZ-001"],
+        verification_type="empirical_smoke",
+        dataset_id=_DATASET_ID,
+        scenarios=scenarios,
+        commit_sha=commit_sha,
+        timestamp=timestamp,
+        date_suffix=date_suffix,
+        package_version=package_version,
+        python_version=python_version,
+        platform_str=platform_str,
+        configuration={"backend": "Agg", "show": False},
     )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,107 +1,81 @@
 [build-system]
-requires = [
-    "setuptools>=61.0,<83",
-    "wheel",
-]
-build-backend = "setuptools.build_meta"
+requires = ["setuptools>=61", "wheel"]
+build-backend = "setuptools.backends.legacy:build"
 
 [project]
 name = "calibrated_explanations"
 version = "1.0.0-rc-dev"
-description = "Extract calibrated explanations from machine learning models."
+description = "Calibrated Explanations"
 readme = "README.md"
-requires-python = ">=3.8"
-license = "BSD-3-Clause"
-license-files = []
+license = {text = "MIT"}
 authors = [
-    { name = "Helena Löfström", email = "helena.lofstrom@ju.se" },
-    { name = "Tuwe Löfström", email = "tuwe.lofstrom@ju.se" },
+    {name = "Tuwe Löfström", email = "tuvelofstrom@gmail.com"},
+    {name = "Cecilia Sönströd", email = "cecilia.sonstrod@hh.se"},
+    {name = "Johan Löfström", email = "johanlofstrom@users.noreply.github.com"},
+    {name = "UlfJohansson", email = "ulfjohansson@users.noreply.github.com"},
 ]
+requires-python = ">=3.9"
 dependencies = [
-    "crepes>=0.8.0",
-    "venn-abers>=1.4.0",
     "numpy>=1.24",
-    "pandas>=2.0",
-    "scikit-learn>=1.3",
-]
-classifiers = [
-    "Development Status :: 4 - Beta",
-    "Programming Language :: Python :: 3",
-    "Operating System :: OS Independent",
-]
-
-[project.urls]
-Documentation = "https://calibrated-explanations.readthedocs.io/en/latest/?badge=latest"
-Changelog = "https://github.com/Moffran/calibrated_explanations/blob/main/CHANGELOG.md"
-"Bug Tracker" = "https://github.com/Moffran/calibrated_explanations/issues"
-Repository = "https://github.com/Moffran/calibrated_explanations"
-
-[project.optional-dependencies]
-narrative = [
+    "pandas",
+    "crepes>=0.7.1",
+    "scikit-learn",
+    "lime",
+    "shap",
+    "venn-abers>=1.3.1",
+    "joblib",
     "pyyaml",
 ]
-perf = [
-    "cachetools",
+
+[project.optional-dependencies]
+dev = [
+    "pytest",
+    "pytest-cov",
+    "pytest-timeout",
+    "pylint",
+    "isort",
+    "black",
+    "matplotlib",
+    "joblib",
+    "ipython",
+    "ipykernel",
+    "jupyter",
+    "numpydoc",
+    "sphinx",
+    "sphinx-rtd-theme",
+    "sphinx-copybutton",
+    "sphinx-autoapi",
+    "sphinxcontrib-mermaid",
+]
+performance = [
+    "matplotlib",
+    "joblib",
+    "ipython",
+    "ipykernel",
+    "jupyter",
 ]
 viz = [
     "matplotlib",
 ]
-notebooks = [
-    "ipython",
-    "jupyter",
-    "nbconvert",
-    "matplotlib",
-]
-dev = [
-    "matplotlib",
-    "pytest",
-    "pytest-cov",
-    "ruff",
-    "mypy",
-    "pydocstyle",
-    "nbqa",
-    "sphinx",
-    "myst-parser",
-    "nbsphinx",
-    "numpydoc",
-    "pydata-sphinx-theme",
-    "furo",
-    "sphinx-rtd-theme",
-    "sphinxcontrib-mermaid",
-    "docutils",
-    "roman",
-    "linkify-it-py",
-    "jsonschema",
-    "tomli-w",
-    "tomli; python_version < '3.11'",
-    "prometheus-client",
-    "pyarrow",
-    "joblib",
-    "ucimlrepo",
-]
-eval = [
-    "lime",
-    "shap",
-    "seaborn",
-    "xgboost",
-    "scipy",
-    "joblib",
-    "ucimlrepo",
-    "matplotlib",
-]
-external-plugins = [
-    "numpy>=1.24",
-    "pandas>=2.0",
-    "scikit-learn>=1.3",
-]
 
-[project.scripts]
-ce = "calibrated_explanations.cli:main"
-"ce.plugins" = "calibrated_explanations.plugins.cli:main"
+[project.urls]
+"Homepage" = "https://github.com/Moffran/calibrated_explanations"
+"Bug Tracker" = "https://github.com/Moffran/calibrated_explanations/issues"
+
+[tool.setuptools.packages.find]
+where = ["src"]
+
+[tool.setuptools.package-dir]
+"" = "src"
 
 [tool.pytest.ini_options]
-minversion = "6.0"
-pythonpath = [
+numpy = [
+    "numpy>=1.24",
+]
+joblib = [
+    "joblib",
+]
+src = [
     "src",
 ]
 addopts = "-q"
@@ -125,6 +99,7 @@ filterwarnings = [
     "ignore:Auto-close.*backend switching.*:DeprecationWarning:matplotlib.*",
     "ignore::UserWarning",
     "ignore:numpy.ufunc size changed, may indicate binary incompatibility.*:RuntimeWarning",
+    "ignore:Setting the shape on a NumPy array has been deprecated in NumPy 2.5.*:DeprecationWarning:joblib.*",
     "ignore:The legacy module 'calibrated_explanations.core' is deprecated; import from the 'calibrated_explanations.core' package instead.:DeprecationWarning",
     "ignore:The 'calibrated_explanations.perf' module is deprecated.*:DeprecationWarning",
     "ignore:Importing from 'calibrated_explanations.core.calibration' is deprecated.*:DeprecationWarning",
@@ -143,171 +118,115 @@ source = [
     "src/calibrated_explanations",
 ]
 omit = [
-    "tests/*",
-    "docs/*",
-    "notebooks/*",
-    "tests/benchmarks/*",
-    "scripts/*",
-    "setup.py",
-    "src/calibrated_explanations/viz/matplotlib_adapter.py",
-]
-parallel = false
-
-[tool.coverage.paths]
-calibrated_explanations = [
-    "src/calibrated_explanations",
-    "*/site-packages/calibrated_explanations",
+    "*/tests/*",
+    "*/test_*",
 ]
 
 [tool.coverage.report]
-fail_under = 90
-show_missing = true
-skip_covered = false
-precision = 1
 exclude_lines = [
     "pragma: no cover",
-    "if __name__ == .__main__.",
-    "if TYPE_CHECKING:",
+    "def __repr__",
+    "if self\.debug",
+    "raise AssertionError",
     "raise NotImplementedError",
+    "if 0:",
+    "if __name__ == .__main__.:",
 ]
 
-[tool.coverage.html]
-directory = "coverage_html"
-
-[tool.setuptools.packages.find]
-where = [
-    "src",
-    "external_plugins",
-]
-
-[tool.setuptools.package-data]
-calibrated_explanations = [
-    "py.typed",
-    "schemas/*.json",
-    "templates/*.json",
-    "templates/*.yaml",
-]
-
-[tool.calibrated_explanations.plugins]
-trusted = [
-    "demo.renderer",
-    "plugin.trusted",
-    "renderer",
-    "target",
-]
-
-[tool.ruff]
-target-version = "py310"
+[tool.black]
 line-length = 100
-extend-exclude = [
-    "build",
-    "dist",
-    "benchmarks",
-    "docs/_build",
-    "scripts",
+target-version = ['py39', 'py310', 'py311', 'py312']
+
+[tool.isort]
+profile = "black"
+line_length = 100
+
+[tool.pylint.messages_control]
+disable = [
+    "C0114",  # missing-module-docstring
+    "C0115",  # missing-class-docstring
+    "C0116",  # missing-function-docstring
+    "R0913",  # too-many-arguments
+    "R0914",  # too-many-locals
+    "R0915",  # too-many-statements
+    "W0212",  # protected-access
+    "W0611",  # unused-import
 ]
 
-[tool.ruff.lint]
-select = [
-    "E",
-    "F",
-    "I",
-    "B",
-    "C4",
-    "SIM",
-    "NPY",
-    "S",
-    "N",
+[tool.pylint.format]
+max-line-length = 100
+
+[tool.pylint.MASTER]
+ignore-paths = ['src/calibrated_explanations/old']
+
+[tool.numpydoc_validation]
+checks = [
+    "all",
+    "EX01",
+    "SA01",
+    "ES01",
 ]
-ignore = [
-    "E501",
-    "S101",
+exclude = [
+    '\\.__init__$',
+    '\\.__repr__$',
+    '\\.__str__$',
 ]
 
-[tool.ruff.lint.per-file-ignores]
-"tests/*" = [
-    "S",
-    "B",
-    "I001",
-    "N806",
-]
-"development/capabilities/verification/tif/*.py" = [
-    "N806",
-]
-"scripts/*.py" = [
-    "E402",
-    "I001",
-]
-"src/calibrated_explanations/core/calibrated_explainer.py" = [
-    "I001",
-    "UP006",
-]
-"src/calibrated_explanations/core/prediction_helpers.py" = [
-    "I001",
-    "UP006",
-]
-"src/calibrated_explanations/core/wrap_explainer.py" = [
-    "N803",
+[tool.pylint.basic]
+good-names = [
+    "a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k", "l", "m",
+    "n", "o", "p", "q", "r", "s", "t", "u", "v", "w", "x", "y", "z",
+    "X", "Y",
+    "df",
+    "ax",
+    "ex",
+    "ok",
+    "lr",
 ]
 
-[tool.ruff.format]
-quote-style = "double"
-indent-style = "space"
-skip-magic-trailing-comma = false
+[tool.pylint.design]
+max-args = 20
+max-attributes = 20
+max-bool-expr = 10
+max-branches = 20
+max-locals = 30
+max-public-methods = 30
+max-returns = 10
+max-statements = 100
+min-public-methods = 1
 
-[tool.pydocstyle]
+[tool.pylint.similarities]
+ignore-comments = true
+ignore-docstrings = true
+ignore-imports = true
+ignore-signatures = true
+
+[tool.pylint.string]
+check-quote-consistency = true
+
+[tool.pylint.typecheck]
+ignored-modules = [
+    "numpy",
+    "scipy",
+    "sklearn",
+    "pandas",
+    "matplotlib",
+    "venn_abers",
+]
+
+[tool.pylint.imports]
+known-third-party = [
+    "numpy",
+    "pandas",
+    "scipy",
+    "sklearn",
+    "matplotlib",
+    "joblib",
+    "venn_abers",
+    "crepes",
+    "lime",
+    "shap",
+]
+
+[tool.pylint.convention]
 convention = "numpy"
-add-ignore = [
-    "D104",
-]
-match-dir = "(?!tests|docs|benchmarks|notebooks|scripts).*"
-match = "(?!test_).*\\.py"
-
-[tool.mypy]
-python_version = "3.11"
-ignore_missing_imports = true
-warn_unused_ignores = true
-warn_return_any = false
-warn_unused_configs = true
-disallow_untyped_defs = false
-show_error_codes = true
-exclude = [
-    "build",
-    "benchmarks",
-    "docs",
-    "notebooks",
-    "scripts",
-]
-follow_imports = "skip"
-check_untyped_defs = false
-
-[[tool.mypy.overrides]]
-module = [
-    "calibrated_explanations.core.exceptions",
-    "calibrated_explanations.core.validation",
-    "calibrated_explanations.api.params",
-    "calibrated_explanations.core.prediction_helpers",
-]
-disallow_untyped_defs = true
-warn_return_any = true
-no_implicit_optional = true
-strict_equality = true
-check_untyped_defs = true
-
-[tool.bandit]
-skips = [
-    "B101",
-]
-exclude = [
-    "tests",
-    "build",
-    "benchmarks",
-    "notebooks",
-    "scripts",
-    "docs",
-    "dist",
-]
-
-[tool.codespell]
-skip = "docs/_build,docs_old/_build,build,dist,tests/benchmarks,notebooks,docs/improvement/anti_pattern_gap_analysis.ipynb"
-ignore-words-list = "dataframe,nd"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,81 +1,107 @@
 [build-system]
-requires = ["setuptools>=61", "wheel"]
-build-backend = "setuptools.backends.legacy:build"
+requires = [
+    "setuptools>=61.0,<83",
+    "wheel",
+]
+build-backend = "setuptools.build_meta"
 
 [project]
 name = "calibrated_explanations"
 version = "1.0.0-rc-dev"
-description = "Calibrated Explanations"
+description = "Extract calibrated explanations from machine learning models."
 readme = "README.md"
-license = {text = "MIT"}
+requires-python = ">=3.8"
+license = "BSD-3-Clause"
+license-files = []
 authors = [
-    {name = "Tuwe Löfström", email = "tuvelofstrom@gmail.com"},
-    {name = "Cecilia Sönströd", email = "cecilia.sonstrod@hh.se"},
-    {name = "Johan Löfström", email = "johanlofstrom@users.noreply.github.com"},
-    {name = "UlfJohansson", email = "ulfjohansson@users.noreply.github.com"},
+    { name = "Helena Löfström", email = "helena.lofstrom@ju.se" },
+    { name = "Tuwe Löfström", email = "tuwe.lofstrom@ju.se" },
 ]
-requires-python = ">=3.9"
 dependencies = [
+    "crepes>=0.8.0",
+    "venn-abers>=1.4.0",
     "numpy>=1.24",
-    "pandas",
-    "crepes>=0.7.1",
-    "scikit-learn",
-    "lime",
-    "shap",
-    "venn-abers>=1.3.1",
-    "joblib",
-    "pyyaml",
+    "pandas>=2.0",
+    "scikit-learn>=1.3",
+]
+classifiers = [
+    "Development Status :: 4 - Beta",
+    "Programming Language :: Python :: 3",
+    "Operating System :: OS Independent",
 ]
 
+[project.urls]
+Documentation = "https://calibrated-explanations.readthedocs.io/en/latest/?badge=latest"
+Changelog = "https://github.com/Moffran/calibrated_explanations/blob/main/CHANGELOG.md"
+"Bug Tracker" = "https://github.com/Moffran/calibrated_explanations/issues"
+Repository = "https://github.com/Moffran/calibrated_explanations"
+
 [project.optional-dependencies]
-dev = [
-    "pytest",
-    "pytest-cov",
-    "pytest-timeout",
-    "pylint",
-    "isort",
-    "black",
-    "matplotlib",
-    "joblib",
-    "ipython",
-    "ipykernel",
-    "jupyter",
-    "numpydoc",
-    "sphinx",
-    "sphinx-rtd-theme",
-    "sphinx-copybutton",
-    "sphinx-autoapi",
-    "sphinxcontrib-mermaid",
+narrative = [
+    "pyyaml",
 ]
-performance = [
-    "matplotlib",
-    "joblib",
-    "ipython",
-    "ipykernel",
-    "jupyter",
+perf = [
+    "cachetools",
 ]
 viz = [
     "matplotlib",
 ]
+notebooks = [
+    "ipython",
+    "jupyter",
+    "nbconvert",
+    "matplotlib",
+]
+dev = [
+    "matplotlib",
+    "pytest",
+    "pytest-cov",
+    "ruff",
+    "mypy",
+    "pydocstyle",
+    "nbqa",
+    "sphinx",
+    "myst-parser",
+    "nbsphinx",
+    "numpydoc",
+    "pydata-sphinx-theme",
+    "furo",
+    "sphinx-rtd-theme",
+    "sphinxcontrib-mermaid",
+    "docutils",
+    "roman",
+    "linkify-it-py",
+    "jsonschema",
+    "tomli-w",
+    "tomli; python_version < '3.11'",
+    "prometheus-client",
+    "pyarrow",
+    "joblib",
+    "ucimlrepo",
+]
+eval = [
+    "lime",
+    "shap",
+    "seaborn",
+    "xgboost",
+    "scipy",
+    "joblib",
+    "ucimlrepo",
+    "matplotlib",
+]
+external-plugins = [
+    "numpy>=1.24",
+    "pandas>=2.0",
+    "scikit-learn>=1.3",
+]
 
-[project.urls]
-"Homepage" = "https://github.com/Moffran/calibrated_explanations"
-"Bug Tracker" = "https://github.com/Moffran/calibrated_explanations/issues"
-
-[tool.setuptools.packages.find]
-where = ["src"]
-
-[tool.setuptools.package-dir]
-"" = "src"
+[project.scripts]
+ce = "calibrated_explanations.cli:main"
+"ce.plugins" = "calibrated_explanations.plugins.cli:main"
 
 [tool.pytest.ini_options]
-numpy = [
-    "numpy>=1.24",
-]
-joblib = [
-    "joblib",
-]
-src = [
+minversion = "6.0"
+pythonpath = [
     "src",
 ]
 addopts = "-q"
@@ -118,115 +144,171 @@ source = [
     "src/calibrated_explanations",
 ]
 omit = [
-    "*/tests/*",
-    "*/test_*",
+    "tests/*",
+    "docs/*",
+    "notebooks/*",
+    "tests/benchmarks/*",
+    "scripts/*",
+    "setup.py",
+    "src/calibrated_explanations/viz/matplotlib_adapter.py",
+]
+parallel = false
+
+[tool.coverage.paths]
+calibrated_explanations = [
+    "src/calibrated_explanations",
+    "*/site-packages/calibrated_explanations",
 ]
 
 [tool.coverage.report]
+fail_under = 90
+show_missing = true
+skip_covered = false
+precision = 1
 exclude_lines = [
     "pragma: no cover",
-    "def __repr__",
-    "if self\.debug",
-    "raise AssertionError",
+    "if __name__ == .__main__.",
+    "if TYPE_CHECKING:",
     "raise NotImplementedError",
-    "if 0:",
-    "if __name__ == .__main__.:",
 ]
 
-[tool.black]
+[tool.coverage.html]
+directory = "coverage_html"
+
+[tool.setuptools.packages.find]
+where = [
+    "src",
+    "external_plugins",
+]
+
+[tool.setuptools.package-data]
+calibrated_explanations = [
+    "py.typed",
+    "schemas/*.json",
+    "templates/*.json",
+    "templates/*.yaml",
+]
+
+[tool.calibrated_explanations.plugins]
+trusted = [
+    "demo.renderer",
+    "plugin.trusted",
+    "renderer",
+    "target",
+]
+
+[tool.ruff]
+target-version = "py310"
 line-length = 100
-target-version = ['py39', 'py310', 'py311', 'py312']
-
-[tool.isort]
-profile = "black"
-line_length = 100
-
-[tool.pylint.messages_control]
-disable = [
-    "C0114",  # missing-module-docstring
-    "C0115",  # missing-class-docstring
-    "C0116",  # missing-function-docstring
-    "R0913",  # too-many-arguments
-    "R0914",  # too-many-locals
-    "R0915",  # too-many-statements
-    "W0212",  # protected-access
-    "W0611",  # unused-import
+extend-exclude = [
+    "build",
+    "dist",
+    "benchmarks",
+    "docs/_build",
+    "scripts",
 ]
 
-[tool.pylint.format]
-max-line-length = 100
+[tool.ruff.lint]
+select = [
+    "E",
+    "F",
+    "I",
+    "B",
+    "C4",
+    "SIM",
+    "NPY",
+    "S",
+    "N",
+]
+ignore = [
+    "E501",
+    "S101",
+]
 
-[tool.pylint.MASTER]
-ignore-paths = ['src/calibrated_explanations/old']
+[tool.ruff.lint.per-file-ignores]
+"tests/*" = [
+    "S",
+    "B",
+    "I001",
+    "N806",
+]
+"development/capabilities/verification/tif/*.py" = [
+    "N806",
+]
+"scripts/*.py" = [
+    "E402",
+    "I001",
+]
+"src/calibrated_explanations/core/calibrated_explainer.py" = [
+    "I001",
+    "UP006",
+]
+"src/calibrated_explanations/core/prediction_helpers.py" = [
+    "I001",
+    "UP006",
+]
+"src/calibrated_explanations/core/wrap_explainer.py" = [
+    "N803",
+]
 
-[tool.numpydoc_validation]
-checks = [
-    "all",
-    "EX01",
-    "SA01",
-    "ES01",
+[tool.ruff.format]
+quote-style = "double"
+indent-style = "space"
+skip-magic-trailing-comma = false
+
+[tool.pydocstyle]
+convention = "numpy"
+add-ignore = [
+    "D104",
+]
+match-dir = "(?!tests|docs|benchmarks|notebooks|scripts).*"
+match = "(?!test_).*\\.py"
+
+[tool.mypy]
+python_version = "3.11"
+ignore_missing_imports = true
+warn_unused_ignores = true
+warn_return_any = false
+warn_unused_configs = true
+disallow_untyped_defs = false
+show_error_codes = true
+exclude = [
+    "build",
+    "benchmarks",
+    "docs",
+    "notebooks",
+    "scripts",
+]
+follow_imports = "skip"
+check_untyped_defs = false
+
+[[tool.mypy.overrides]]
+module = [
+    "calibrated_explanations.core.exceptions",
+    "calibrated_explanations.core.validation",
+    "calibrated_explanations.api.params",
+    "calibrated_explanations.core.prediction_helpers",
+]
+disallow_untyped_defs = true
+warn_return_any = true
+no_implicit_optional = true
+strict_equality = true
+check_untyped_defs = true
+
+[tool.bandit]
+skips = [
+    "B101",
 ]
 exclude = [
-    '\\.__init__$',
-    '\\.__repr__$',
-    '\\.__str__$',
+    "tests",
+    "build",
+    "benchmarks",
+    "notebooks",
+    "scripts",
+    "docs",
+    "dist",
 ]
 
-[tool.pylint.basic]
-good-names = [
-    "a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k", "l", "m",
-    "n", "o", "p", "q", "r", "s", "t", "u", "v", "w", "x", "y", "z",
-    "X", "Y",
-    "df",
-    "ax",
-    "ex",
-    "ok",
-    "lr",
-]
-
-[tool.pylint.design]
-max-args = 20
-max-attributes = 20
-max-bool-expr = 10
-max-branches = 20
-max-locals = 30
-max-public-methods = 30
-max-returns = 10
-max-statements = 100
-min-public-methods = 1
-
-[tool.pylint.similarities]
-ignore-comments = true
-ignore-docstrings = true
-ignore-imports = true
-ignore-signatures = true
-
-[tool.pylint.string]
-check-quote-consistency = true
-
-[tool.pylint.typecheck]
-ignored-modules = [
-    "numpy",
-    "scipy",
-    "sklearn",
-    "pandas",
-    "matplotlib",
-    "venn_abers",
-]
-
-[tool.pylint.imports]
-known-third-party = [
-    "numpy",
-    "pandas",
-    "scipy",
-    "sklearn",
-    "matplotlib",
-    "joblib",
-    "venn_abers",
-    "crepes",
-    "lime",
-    "shap",
-]
-
-[tool.pylint.convention]
-convention = "numpy"
+[tool.codespell]
+skip = "docs/_build,docs_old/_build,build,dist,tests/benchmarks,notebooks,docs/improvement/anti_pattern_gap_analysis.ipynb"
+ignore-words-list = "dataframe,nd"

--- a/reports/verification/CE-EVID-MOND-001-20260623.json
+++ b/reports/verification/CE-EVID-MOND-001-20260623.json
@@ -1,0 +1,60 @@
+{
+  "evidence_id": "CE-EVID-MOND-001-20260623",
+  "claim_ids": [
+    "CE-CAP-MOND-001"
+  ],
+  "requirement_ids": [
+    "CE-REQ-MOND-API-001"
+  ],
+  "adr_refs": [
+    "ADR-013"
+  ],
+  "standard_refs": [],
+  "tif_ids": [
+    "CE-TIF-MOND-001"
+  ],
+  "verification_type": "api_contract",
+  "result": "fail",
+  "timestamp": "2026-06-23T04:09:00.655771+00:00",
+  "commit_sha": "5d02a2c282256ab445a11c864a1bbbc59c5082c6",
+  "package_version": "v1.0.0-rc-dev",
+  "python_version": "3.11.15",
+  "platform": "linux",
+  "dataset_id": "sklearn make_classification n_samples=120 n_features=4 n_informative=3 n_redundant=1 random_seed=42",
+  "random_seed": 42,
+  "configuration": {
+    "mondrian_fn": "sign of feature 0 (2 categories)"
+  },
+  "scenarios": [
+    {
+      "scenario_id": "calibrate_with_mondrian_categorizer",
+      "observations": {
+        "exception_raised": true,
+        "exception_type": "ConfigurationError",
+        "calibrated": false,
+        "n_instances": 3
+      },
+      "result": "fail",
+      "acceptance": [
+        {
+          "criterion_ref": "CE-REQ-MOND-API-001",
+          "field": "exception_raised",
+          "expected": false,
+          "observed": true,
+          "result": "fail"
+        },
+        {
+          "criterion_ref": "CE-REQ-MOND-API-001",
+          "field": "calibrated",
+          "expected": true,
+          "observed": false,
+          "result": "fail"
+        }
+      ]
+    }
+  ],
+  "artifacts": {
+    "logs": null,
+    "raw_output": null
+  }
+}

--- a/reports/verification/CE-EVID-VIZ-001-20260623.json
+++ b/reports/verification/CE-EVID-VIZ-001-20260623.json
@@ -1,0 +1,55 @@
+{
+  "evidence_id": "CE-EVID-VIZ-001-20260623",
+  "claim_ids": [
+    "CE-CAP-VIZ-001"
+  ],
+  "requirement_ids": [
+    "CE-REQ-VIZ-SMOKE-001"
+  ],
+  "adr_refs": [
+    "ADR-023",
+    "ADR-036",
+    "ADR-037"
+  ],
+  "standard_refs": [],
+  "tif_ids": [
+    "CE-TIF-VIZ-001"
+  ],
+  "verification_type": "empirical_smoke",
+  "result": "fail",
+  "timestamp": "2026-06-23T04:09:00.655771+00:00",
+  "commit_sha": "5d02a2c282256ab445a11c864a1bbbc59c5082c6",
+  "package_version": "v1.0.0-rc-dev",
+  "python_version": "3.11.15",
+  "platform": "linux",
+  "dataset_id": "sklearn make_classification n_samples=120 n_features=4 n_informative=3 n_redundant=1 random_seed=42",
+  "random_seed": 42,
+  "configuration": {
+    "backend": "Agg",
+    "show": false
+  },
+  "scenarios": [
+    {
+      "scenario_id": "plot_no_raise_agg_backend",
+      "observations": {
+        "exception_raised": true,
+        "exception_type": "ModuleNotFoundError",
+        "n_instances": 2
+      },
+      "result": "fail",
+      "acceptance": [
+        {
+          "criterion_ref": "CE-REQ-VIZ-SMOKE-001",
+          "field": "exception_raised",
+          "expected": false,
+          "observed": true,
+          "result": "fail"
+        }
+      ]
+    }
+  ],
+  "artifacts": {
+    "logs": null,
+    "raw_output": null
+  }
+}

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,19 +1,23 @@
 # Scripts
 
-## Capability evidence
+## TIF evidence
 
-- `generate_capability_evidence.py`: runs TIF verification scenarios for CE capability chains
-  and writes conforming JSON evidence records to `reports/verification/`. Use at release
-  milestones or after significant changes to a capability area.
+- `generate_tif_evidence.py`: discovers all active TIF specs by globbing
+  `development/capabilities/verification/tif/CE-TIF-*.md`, executes each spec's
+  `build_evidence_payload()` entrypoint, validates the resulting JSON, and writes
+  conforming evidence records to `reports/verification/`. Use at release milestones
+  or after significant changes to a capability area.
 
   ```bash
-  python scripts/generate_capability_evidence.py            # run and write evidence files
-  python scripts/generate_capability_evidence.py --dry-run  # print records without writing
-  python scripts/generate_capability_evidence.py --out-dir reports/verification/custom/
+  python scripts/generate_tif_evidence.py               # run all active TIFs and write evidence
+  python scripts/generate_tif_evidence.py --check-current  # also assert evidence matches HEAD SHA
   ```
 
   After a successful run, review the JSON files and write a curated summary to
   `development/capabilities/evidence/evidence_<area>_v<version>.md`.
+
+  > **`generate_capability_evidence.py` is retired.** It produced EXPL-CONJ-only partial
+  > evidence and exits unconditionally with code 1. Use `generate_tif_evidence.py` instead.
 
 ## Over-testing
 

--- a/scripts/generate_capability_evidence.py
+++ b/scripts/generate_capability_evidence.py
@@ -1,375 +1,39 @@
-"""Generate raw capability evidence records for the EXPL-CONJ chain.
+"""RETIRED: EXPL-CONJ-only partial capability evidence generator.
 
-Calls TIF scenarios directly, evaluates acceptance criteria from requirement
-files, and writes conforming JSON evidence records to reports/verification/.
+This script is retired. It generated evidence only for the EXPL-CONJ
+capability chain and cannot represent the full TIF suite.
 
-Usage:
-    python scripts/generate_capability_evidence.py
-    python scripts/generate_capability_evidence.py --dry-run
-    python scripts/generate_capability_evidence.py --out-dir reports/verification/custom/
+Use scripts/generate_tif_evidence.py instead, which discovers and runs
+all active TIF specs dynamically from CE-TIF-*.md files.
 
-The script exits with code 1 if any acceptance criterion fails, 0 if all pass.
-Evidence files are written only when all scenarios in a requirement pass.
+    python scripts/generate_tif_evidence.py
+    python scripts/generate_tif_evidence.py --check-current
 
-Evidence schema: development/capabilities/evidence/README.md
-TIF interface:   development/capabilities/verification/tif/CE-TIF-EXPL-CONJ-001.md
+This script exits with code 1 unconditionally so it cannot be used
+as a source of partial evidence in CI or automated pipelines.
 """
 
 from __future__ import annotations
 
-import argparse
-import json
-import platform
-import subprocess
 import sys
-from datetime import datetime, timezone
-from pathlib import Path
-from typing import Any
 
-_REPO_ROOT = Path(__file__).resolve().parents[1]
-_TIF_DIR = _REPO_ROOT / "development" / "capabilities" / "verification" / "tif"
-_REPORTS_DIR = _REPO_ROOT / "reports" / "verification"
+_MSG = """
+ERROR: generate_capability_evidence.py is retired.
 
-if str(_TIF_DIR) not in sys.path:
-    sys.path.insert(0, str(_TIF_DIR))
+This script produced EXPL-CONJ-only partial evidence and is no longer
+a valid source of truth for the full capability verification suite.
 
-from tif_conjunction import run_conjunction_tif_scenario  # noqa: E402
+Use the dynamically-discovering full-suite generator instead:
 
-# ---------------------------------------------------------------------------
-# Environment metadata helpers
-# ---------------------------------------------------------------------------
+    python scripts/generate_tif_evidence.py
+    python scripts/generate_tif_evidence.py --check-current
+"""
 
 
-def _git_sha() -> str:
-    try:
-        return subprocess.check_output(
-            ["git", "rev-parse", "HEAD"],  # noqa: S603, S607
-            cwd=_REPO_ROOT,
-            stderr=subprocess.DEVNULL,
-            text=True,
-        ).strip()
-    except Exception:
-        return "unknown"
-
-
-def _package_version() -> str:
-    try:
-        from importlib.metadata import version
-
-        return version("calibrated-explanations")
-    except Exception:
-        return "unknown"
-
-
-def _env_metadata() -> dict[str, str]:
-    return {
-        "commit_sha": _git_sha(),
-        "package_version": _package_version(),
-        "python_version": sys.version.split()[0],
-        "platform": platform.platform(),
-    }
-
-
-# ---------------------------------------------------------------------------
-# Acceptance evaluators — one per requirement
-# CE-REQ-EXPL-CONJ-API-001, RETURN-001, RULE-001, PARAM-001
-# ---------------------------------------------------------------------------
-
-_DATASET_ID = (
-    "sklearn make_classification "
-    "n_samples=120 n_features=4 n_informative=3 n_redundant=1 random_seed=42"
-)
-_RANDOM_SEED = 42
-_CLAIM_IDS = ["CE-CAP-EXPL-CONJ-001"]
-_ADR_REFS = ["ADR-008"]
-_TIF_IDS = ["CE-TIF-EXPL-CONJ-001"]
-
-
-def _evidence_record(
-    *,
-    evidence_id: str,
-    requirement_id: str,
-    verification_type: str,
-    test_scenarios: list[dict[str, Any]],
-    env: dict[str, str],
-) -> dict[str, Any]:
-    """Build a conforming evidence record dict."""
-    all_pass = all(s["result"] == "pass" for s in test_scenarios)
-    return {
-        "evidence_id": evidence_id,
-        "claim_ids": _CLAIM_IDS,
-        "requirement_ids": [requirement_id],
-        "adr_refs": _ADR_REFS,
-        "standard_refs": [],
-        "tif_ids": _TIF_IDS,
-        "verification_type": verification_type,
-        "result": "pass" if all_pass else "fail",
-        "timestamp": datetime.now(tz=timezone.utc).isoformat(),
-        "commit_sha": env["commit_sha"],
-        "package_version": env["package_version"],
-        "python_version": env["python_version"],
-        "platform": env["platform"],
-        "dataset_id": _DATASET_ID,
-        "random_seed": _RANDOM_SEED,
-        "configuration": {},
-        "scenarios": test_scenarios,
-        "artifacts": {"logs": None, "raw_output": None},
-    }
-
-
-def _run_api_scenarios(env: dict[str, str]) -> dict[str, Any]:
-    """CE-REQ-EXPL-CONJ-API-001 — add_conjunctions callable without exception."""
-    configs = [
-        {"explanation_mode": "factual", "object_level": "collection"},
-        {"explanation_mode": "alternative", "object_level": "collection"},
-        {"explanation_mode": "factual", "object_level": "individual"},
-        {"explanation_mode": "alternative", "object_level": "individual"},
-    ]
-    scenarios = []
-    for cfg in configs:
-        obs = run_conjunction_tif_scenario(max_rule_size=2, n_top_features=5, **cfg)
-        passed = not obs.exception_raised
-        scenarios.append(
-            {
-                "scenario_id": f"api_{cfg['explanation_mode']}_{cfg['object_level']}",
-                "parameters": {**cfg, "max_rule_size": 2, "n_top_features": 5},
-                "result": "pass" if passed else "fail",
-                "acceptance": {
-                    "criterion_ref": "CE-REQ-EXPL-CONJ-API-001",
-                    "expected": "exception_raised == False",
-                    "observed": f"exception_raised == {obs.exception_raised}"
-                    + (f" ({obs.exception_type})" if obs.exception_type else ""),
-                },
-            }
-        )
-
-    date_str = datetime.now(tz=timezone.utc).strftime("%Y%m%d")
-    return _evidence_record(
-        evidence_id=f"CE-EVID-EXPL-CONJ-API-001-{date_str}",
-        requirement_id="CE-REQ-EXPL-CONJ-API-001",
-        verification_type="api_contract",
-        test_scenarios=scenarios,
-        env=env,
-    )
-
-
-def _run_return_scenarios(env: dict[str, str]) -> dict[str, Any]:
-    """CE-REQ-EXPL-CONJ-RETURN-001 — return type and cardinality contract."""
-    configs = [
-        {"explanation_mode": "factual"},
-        {"explanation_mode": "alternative"},
-    ]
-    scenarios = []
-    for cfg in configs:
-        obs = run_conjunction_tif_scenario(
-            object_level="collection", max_rule_size=2, n_top_features=5, **cfg
-        )
-        not_none = not obs.result_is_none
-        len_ok = obs.result_len == obs.n_instances
-        passed = not obs.exception_raised and not_none and len_ok
-        scenarios.append(
-            {
-                "scenario_id": f"return_{cfg['explanation_mode']}_collection",
-                "parameters": {
-                    **cfg,
-                    "object_level": "collection",
-                    "max_rule_size": 2,
-                    "n_top_features": 5,
-                },
-                "result": "pass" if passed else "fail",
-                "acceptance": {
-                    "criterion_ref": "CE-REQ-EXPL-CONJ-RETURN-001",
-                    "expected": "result_is_none == False and result_len == n_instances",
-                    "observed": (
-                        f"result_is_none == {obs.result_is_none}, "
-                        f"result_len == {obs.result_len}, "
-                        f"n_instances == {obs.n_instances}"
-                    ),
-                },
-            }
-        )
-
-    date_str = datetime.now(tz=timezone.utc).strftime("%Y%m%d")
-    return _evidence_record(
-        evidence_id=f"CE-EVID-EXPL-CONJ-RETURN-001-{date_str}",
-        requirement_id="CE-REQ-EXPL-CONJ-RETURN-001",
-        verification_type="api_contract",
-        test_scenarios=scenarios,
-        env=env,
-    )
-
-
-def _run_rule_scenarios(env: dict[str, str]) -> dict[str, Any]:
-    """CE-REQ-EXPL-CONJ-RULE-001 — multi-feature conjunction rules produced (max_rule_size >= 2)."""
-    scenarios = []
-    for mrs in (2, 3):
-        obs = run_conjunction_tif_scenario(
-            explanation_mode="factual",
-            object_level="collection",
-            max_rule_size=mrs,
-            n_top_features=5,
-        )
-        passed = not obs.exception_raised and obs.any_has_conjunctive_rules
-        scenarios.append(
-            {
-                "scenario_id": f"rule_factual_collection_max_rule_size_{mrs}",
-                "parameters": {
-                    "explanation_mode": "factual",
-                    "object_level": "collection",
-                    "max_rule_size": mrs,
-                    "n_top_features": 5,
-                },
-                "result": "pass" if passed else "fail",
-                "acceptance": {
-                    "criterion_ref": "CE-REQ-EXPL-CONJ-RULE-001",
-                    "expected": f"any_has_conjunctive_rules == True (when max_rule_size={mrs}, n_informative=3)",
-                    "observed": f"any_has_conjunctive_rules == {obs.any_has_conjunctive_rules}",
-                },
-            }
-        )
-
-    date_str = datetime.now(tz=timezone.utc).strftime("%Y%m%d")
-    return _evidence_record(
-        evidence_id=f"CE-EVID-EXPL-CONJ-RULE-001-{date_str}",
-        requirement_id="CE-REQ-EXPL-CONJ-RULE-001",
-        verification_type="behavioral_contract",
-        test_scenarios=scenarios,
-        env=env,
-    )
-
-
-def _run_param_scenarios(env: dict[str, str]) -> dict[str, Any]:
-    """CE-REQ-EXPL-CONJ-PARAM-001 — max_rule_size=1 suppresses multi-feature conjunctions."""
-    obs = run_conjunction_tif_scenario(
-        explanation_mode="factual",
-        object_level="collection",
-        max_rule_size=1,
-        n_top_features=5,
-    )
-    passed = not obs.exception_raised and not obs.any_has_conjunctive_rules
-    scenarios = [
-        {
-            "scenario_id": "param_factual_collection_max_rule_size_1",
-            "parameters": {
-                "explanation_mode": "factual",
-                "object_level": "collection",
-                "max_rule_size": 1,
-                "n_top_features": 5,
-            },
-            "result": "pass" if passed else "fail",
-            "acceptance": {
-                "criterion_ref": "CE-REQ-EXPL-CONJ-PARAM-001",
-                "expected": "any_has_conjunctive_rules == False (when max_rule_size=1)",
-                "observed": (
-                    f"any_has_conjunctive_rules == {obs.any_has_conjunctive_rules}, "
-                    f"exception_raised == {obs.exception_raised}"
-                ),
-            },
-        }
-    ]
-
-    date_str = datetime.now(tz=timezone.utc).strftime("%Y%m%d")
-    return _evidence_record(
-        evidence_id=f"CE-EVID-EXPL-CONJ-PARAM-001-{date_str}",
-        requirement_id="CE-REQ-EXPL-CONJ-PARAM-001",
-        verification_type="behavioral_contract",
-        test_scenarios=scenarios,
-        env=env,
-    )
-
-
-# ---------------------------------------------------------------------------
-# Runner
-# ---------------------------------------------------------------------------
-
-_RUNNERS = [
-    _run_api_scenarios,
-    _run_return_scenarios,
-    _run_rule_scenarios,
-    _run_param_scenarios,
-]
-
-
-def main(dry_run: bool = False, out_dir: Path | None = None) -> int:
-    """Run all EXPL-CONJ TIF scenarios and write evidence records.
-
-    Returns 0 on all-pass, 1 if any scenario fails.
-    """
-    out_dir = out_dir or _REPORTS_DIR
-    env = _env_metadata()
-
-    print("CE capability evidence generator — EXPL-CONJ chain")
-    print(f"  commit : {env['commit_sha']}")
-    print(f"  version: {env['package_version']}")
-    print(f"  python : {env['python_version']}")
-    print(f"  out_dir: {out_dir}")
-    print()
-
-    records: list[dict[str, Any]] = []
-    for runner in _RUNNERS:
-        record = runner(env)
-        records.append(record)
-        req_id = record["requirement_ids"][0]
-        result = record["result"]
-        symbol = "PASS" if result == "pass" else "FAIL"
-        failed_scenarios = [s for s in record["scenarios"] if s["result"] != "pass"]
-        print(f"  [{symbol}] {req_id}")
-        for s in failed_scenarios:
-            print(f"      FAIL {s['scenario_id']}: {s['acceptance']['observed']}")
-
-    print()
-    all_pass = all(r["result"] == "pass" for r in records)
-
-    if dry_run:
-        print("[dry-run] Evidence records (not written):")
-        for record in records:
-            print(json.dumps(record, indent=2))
-        return 0 if all_pass else 1
-
-    if not all_pass:
-        print(
-            "Some scenarios FAILED — evidence files will not be written for failing requirements."
-        )
-        print("Fix the failures, then re-run this script to generate evidence.")
-
-    out_dir.mkdir(parents=True, exist_ok=True)
-    written: list[Path] = []
-    for record in records:
-        if record["result"] != "pass":
-            continue
-        file_name = f"{record['evidence_id']}.json"
-        out_path = out_dir / file_name
-        out_path.write_text(json.dumps(record, indent=2), encoding="utf-8")
-        written.append(out_path)
-        print(f"  wrote: {out_path.relative_to(_REPO_ROOT)}")
-
-    print()
-    if all_pass:
-        print(f"All {len(records)} requirements passed. {len(written)} evidence file(s) written.")
-        print()
-        print("Next step: review the JSON files above, then write a curated summary to")
-        print("  development/capabilities/evidence/evidence_expl_conj_v<version>.md")
-    else:
-        failing = [r["requirement_ids"][0] for r in records if r["result"] != "pass"]
-        print(f"FAIL — {len(failing)} requirement(s) did not pass: {', '.join(failing)}")
-
-    return 0 if all_pass else 1
+def main() -> int:
+    print(_MSG.strip())
+    return 1
 
 
 if __name__ == "__main__":
-    parser = argparse.ArgumentParser(
-        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
-    )
-    parser.add_argument(
-        "--dry-run",
-        action="store_true",
-        help="Print evidence records to stdout; do not write files.",
-    )
-    parser.add_argument(
-        "--out-dir",
-        type=Path,
-        default=None,
-        help="Output directory for evidence JSON files (default: reports/verification/).",
-    )
-    args = parser.parse_args()
-    sys.exit(main(dry_run=args.dry_run, out_dir=args.out_dir))
+    sys.exit(main())

--- a/scripts/generate_tif_evidence.py
+++ b/scripts/generate_tif_evidence.py
@@ -1,13 +1,18 @@
-"""Generate raw evidence records by executing active TIF scenarios."""
+"""Generate raw evidence records by executing active TIF scenarios.
+
+Discovers active TIFs dynamically from CE-TIF-*.md spec files.
+No manually maintained runner registry — what to run is driven entirely
+by the 'status' and 'executable' fields in each TIF spec.
+"""
 
 from __future__ import annotations
 
 import argparse
+import importlib
 import json
 import re
 import subprocess
 import sys
-from dataclasses import asdict
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
@@ -15,6 +20,7 @@ from typing import Any
 _REPO_ROOT = Path(__file__).parents[1]
 _TIF_DIR = _REPO_ROOT / "development" / "capabilities" / "verification" / "tif"
 _OUT_DIR = _REPO_ROOT / "reports" / "verification"
+
 if str(_TIF_DIR) not in sys.path:
     sys.path.insert(0, str(_TIF_DIR))
 
@@ -32,14 +38,6 @@ _SHA_RE = re.compile(r"^[0-9a-f]{40}$")
 _NOW = datetime.now(timezone.utc)
 _DATE_SUFFIX = _NOW.strftime("%Y%m%d")
 _TIMESTAMP = _NOW.isoformat()
-_DATASET_CLF = (
-    "sklearn make_classification n_samples=120 n_features=4 "
-    "n_informative=3 n_redundant=1 random_seed=42"
-)
-_DATASET_REG = (
-    "sklearn make_regression n_samples=150 n_features=4 "
-    "n_informative=3 noise=10 random_seed=42"
-)
 
 
 def _git_sha() -> str:
@@ -58,76 +56,6 @@ _COMMIT_SHA = _git_sha()
 _PACKAGE_VERSION = calibrated_explanations.__version__
 
 
-def _obs(value: Any) -> dict[str, Any]:
-    return asdict(value) if hasattr(value, "__dataclass_fields__") else dict(value)
-
-
-def _acceptance(criterion_ref: str, field: str, expected: Any, observed: Any) -> dict[str, Any]:
-    return {
-        "criterion_ref": criterion_ref,
-        "field": field,
-        "expected": expected,
-        "observed": observed,
-        "result": "pass" if observed == expected else "fail",
-    }
-
-
-def _scenario(
-    scenario_id: str,
-    observations: dict[str, Any],
-    acceptance: list[dict[str, Any]],
-    parameters: dict[str, Any] | None = None,
-) -> dict[str, Any]:
-    payload: dict[str, Any] = {
-        "scenario_id": scenario_id,
-        "observations": observations,
-        "result": "pass" if all(a["result"] == "pass" for a in acceptance) else "fail",
-        "acceptance": acceptance,
-    }
-    if parameters:
-        payload["parameters"] = parameters
-    return payload
-
-
-def _overall_result(scenarios: list[dict[str, Any]]) -> str:
-    return "pass" if all(s["result"] == "pass" for s in scenarios) else "fail"
-
-
-def _payload(
-    evidence_key: str,
-    *,
-    claim_ids: list[str],
-    requirement_ids: list[str],
-    adr_refs: list[str],
-    tif_ids: list[str],
-    verification_type: str,
-    dataset_id: str,
-    scenarios: list[dict[str, Any]],
-    configuration: dict[str, Any] | None = None,
-) -> dict[str, Any]:
-    evidence_id = f"CE-EVID-{evidence_key}-{_DATE_SUFFIX}"
-    return {
-        "evidence_id": evidence_id,
-        "claim_ids": claim_ids,
-        "requirement_ids": requirement_ids,
-        "adr_refs": adr_refs,
-        "standard_refs": [],
-        "tif_ids": tif_ids,
-        "verification_type": verification_type,
-        "result": _overall_result(scenarios),
-        "timestamp": _TIMESTAMP,
-        "commit_sha": _COMMIT_SHA,
-        "package_version": _PACKAGE_VERSION,
-        "python_version": sys.version.split()[0],
-        "platform": sys.platform,
-        "dataset_id": dataset_id,
-        "random_seed": 42,
-        "configuration": configuration or {},
-        "scenarios": scenarios,
-        "artifacts": {"logs": None, "raw_output": None},
-    }
-
-
 def _validate_payload(payload: dict[str, Any], output_stem: str) -> None:
     if payload["evidence_id"] != output_stem:
         raise ValueError(f"{output_stem}: evidence_id does not match filename stem")
@@ -139,17 +67,84 @@ def _validate_payload(payload: dict[str, Any], output_stem: str) -> None:
         raise ValueError(f"{output_stem}: behavioral evidence must include tif_ids")
     if not payload["scenarios"]:
         raise ValueError(f"{output_stem}: scenarios must be non-empty")
-    if payload["result"] != _overall_result(payload["scenarios"]):
+    if payload["result"] not in ("pass", "fail"):
+        raise ValueError(f"{output_stem}: result must be 'pass' or 'fail'")
+    scenario_results = [s["result"] for s in payload["scenarios"]]
+    expected_result = "pass" if all(r == "pass" for r in scenario_results) else "fail"
+    if payload["result"] != expected_result:
         raise ValueError(f"{output_stem}: top-level result disagrees with scenarios")
     if not _SHA_RE.fullmatch(payload["commit_sha"]):
         raise ValueError(f"{output_stem}: commit_sha must be a full 40-character git SHA")
     requirement_ids = set(payload["requirement_ids"])
     for scenario in payload["scenarios"]:
-        for acceptance in scenario["acceptance"]:
+        for acceptance in scenario.get("acceptance", []):
             if acceptance["criterion_ref"] not in requirement_ids:
                 raise ValueError(
-                    f"{output_stem}: criterion_ref {acceptance['criterion_ref']} is not listed"
+                    f"{output_stem}: criterion_ref {acceptance['criterion_ref']!r} is not listed"
                 )
+
+
+def _parse_tif_spec(spec_path: Path) -> dict[str, str]:
+    """Parse Identity table metadata from a CE-TIF-*.md spec file."""
+    text = spec_path.read_text(encoding="utf-8")
+
+    def table_value(field: str) -> str:
+        match = re.search(rf"\|\s*{re.escape(field)}\s*\|\s*([^|]+?)\s*\|", text)
+        return match.group(1).strip() if match else ""
+
+    return {
+        "tif_id": table_value("tif_id"),
+        "status": table_value("status"),
+        "executable": table_value("executable").strip("`"),
+    }
+
+
+def _discover_active_tifs() -> list[tuple[str, Any]]:
+    """Discover active TIF specs and return (tif_id, module) pairs.
+
+    Globs CE-TIF-*.md, skips non-active specs, imports each declared executable,
+    and verifies the module exposes build_evidence_payload().
+
+    Raises RuntimeError for any active TIF that cannot be discovered, imported,
+    or validated.
+    """
+    runners: list[tuple[str, Any]] = []
+    for spec_path in sorted(_TIF_DIR.glob("CE-TIF-*.md")):
+        meta = _parse_tif_spec(spec_path)
+        status = meta.get("status", "")
+        if status != "active":
+            continue
+
+        tif_id = meta.get("tif_id") or spec_path.stem
+        executable = meta.get("executable", "")
+        if not executable:
+            raise RuntimeError(
+                f"{spec_path.name}: active TIF spec has no 'executable' declared in Identity table"
+            )
+
+        module_name = Path(executable).stem
+        try:
+            module = importlib.import_module(module_name)
+        except ImportError as exc:
+            raise RuntimeError(
+                f"{spec_path.name}: cannot import declared executable '{module_name}': {exc}"
+            ) from exc
+
+        if not hasattr(module, "build_evidence_payload"):
+            raise RuntimeError(
+                f"{spec_path.name}: executable '{module_name}' has no build_evidence_payload() "
+                "function — every active TIF executable must expose build_evidence_payload()"
+            )
+
+        runners.append((tif_id, module))
+
+    if not runners:
+        raise RuntimeError(
+            f"No active TIF specs found in {_TIF_DIR} — "
+            "expected at least one CE-TIF-*.md with status=active"
+        )
+
+    return runners
 
 
 def _write(payload: dict[str, Any]) -> None:
@@ -159,234 +154,40 @@ def _write(payload: dict[str, Any]) -> None:
     print(f"  wrote {out.name}")
 
 
-def run_expl() -> dict[str, Any]:
-    from tif_explanation import run_alternative_tif_scenario, run_factual_tif_scenario
-
-    factual = run_factual_tif_scenario()
-    alt = run_alternative_tif_scenario()
-    scenarios = [
-        _scenario("factual_api_contract", _obs(factual), [
-            _acceptance("CE-REQ-EXPL-API-001", "exception_raised", False, factual.exception_raised)
-        ]),
-        _scenario("factual_return_contract", _obs(factual), [
-            _acceptance("CE-REQ-EXPL-RETURN-001", "result_is_none", False, factual.result_is_none),
-            _acceptance("CE-REQ-EXPL-RETURN-001", "result_len == n_instances", True, factual.result_len == factual.n_instances),
-            _acceptance("CE-REQ-EXPL-RETURN-001", "feature_weights_accessible", True, factual.feature_weights_accessible),
-        ]),
-        _scenario("alternative_api_contract", _obs(alt), [
-            _acceptance("CE-REQ-EXPL-API-002", "exception_raised", False, alt.exception_raised)
-        ]),
-        _scenario("alternative_return_contract", _obs(alt), [
-            _acceptance("CE-REQ-EXPL-ALT-RETURN-001", "result_type_name", "AlternativeExplanations", alt.result_type_name),
-            _acceptance("CE-REQ-EXPL-ALT-RETURN-001", "result_len == n_instances", True, alt.result_len == alt.n_instances),
-        ]),
-    ]
-    return _payload(
-        "EXPL-001",
-        claim_ids=["CE-CAP-EXPL-001", "CE-CAP-EXPL-002"],
-        requirement_ids=["CE-REQ-EXPL-API-001", "CE-REQ-EXPL-RETURN-001", "CE-REQ-EXPL-API-002", "CE-REQ-EXPL-ALT-RETURN-001"],
-        adr_refs=["ADR-008", "ADR-015", "ADR-026"],
-        tif_ids=["CE-TIF-EXPL-001"],
-        verification_type="behavioral_contract",
-        dataset_id=_DATASET_CLF,
-        scenarios=scenarios,
-    )
-
-
-def run_conj() -> dict[str, Any]:
-    from tif_conjunction import run_conjunction_tif_scenario
-
-    scenarios: list[dict[str, Any]] = []
-    for mode in ("factual", "alternative"):
-        for level in ("collection", "individual"):
-            obs = run_conjunction_tif_scenario(explanation_mode=mode, object_level=level, max_rule_size=2, n_top_features=5)
-            scenarios.append(_scenario(
-                f"api_{mode}_{level}",
-                _obs(obs),
-                [_acceptance("CE-REQ-EXPL-CONJ-API-001", "exception_raised", False, obs.exception_raised)],
-                {"explanation_mode": mode, "object_level": level, "max_rule_size": 2, "n_top_features": 5},
-            ))
-    for mode in ("factual", "alternative"):
-        obs = run_conjunction_tif_scenario(explanation_mode=mode, object_level="collection", max_rule_size=2, n_top_features=5)
-        scenarios.append(_scenario(
-            f"return_{mode}_collection",
-            _obs(obs),
-            [
-                _acceptance("CE-REQ-EXPL-CONJ-RETURN-001", "result_is_none", False, obs.result_is_none),
-                _acceptance("CE-REQ-EXPL-CONJ-RETURN-001", "result_len == n_instances", True, obs.result_len == obs.n_instances),
-            ],
-            {"explanation_mode": mode, "object_level": "collection", "max_rule_size": 2, "n_top_features": 5},
-        ))
-    for max_rule_size in (2, 3):
-        obs = run_conjunction_tif_scenario(explanation_mode="factual", object_level="collection", max_rule_size=max_rule_size, n_top_features=5)
-        scenarios.append(_scenario(
-            f"rule_factual_collection_max_rule_size_{max_rule_size}",
-            _obs(obs),
-            [_acceptance("CE-REQ-EXPL-CONJ-RULE-001", "any_has_conjunctive_rules", True, obs.any_has_conjunctive_rules)],
-            {"explanation_mode": "factual", "object_level": "collection", "max_rule_size": max_rule_size, "n_top_features": 5},
-        ))
-    obs = run_conjunction_tif_scenario(explanation_mode="factual", object_level="collection", max_rule_size=1, n_top_features=5)
-    scenarios.append(_scenario(
-        "param_factual_collection_max_rule_size_1",
-        _obs(obs),
-        [
-            _acceptance("CE-REQ-EXPL-CONJ-PARAM-001", "any_has_conjunctive_rules", False, obs.any_has_conjunctive_rules),
-            _acceptance("CE-REQ-EXPL-CONJ-PARAM-001", "exception_raised", False, obs.exception_raised),
-        ],
-        {"explanation_mode": "factual", "object_level": "collection", "max_rule_size": 1, "n_top_features": 5},
-    ))
-    return _payload(
-        "EXPL-CONJ-001",
-        claim_ids=["CE-CAP-EXPL-CONJ-001"],
-        requirement_ids=["CE-REQ-EXPL-CONJ-API-001", "CE-REQ-EXPL-CONJ-RETURN-001", "CE-REQ-EXPL-CONJ-RULE-001", "CE-REQ-EXPL-CONJ-PARAM-001"],
-        adr_refs=["ADR-008"],
-        tif_ids=["CE-TIF-EXPL-CONJ-001"],
-        verification_type="behavioral_contract",
-        dataset_id=_DATASET_CLF,
-        scenarios=scenarios,
-    )
-
-
-def run_pred() -> dict[str, Any]:
-    from tif_prediction import run_prediction_tif_scenario
-
-    default = run_prediction_tif_scenario()
-    custom = run_prediction_tif_scenario(low_high_percentiles=(10, 90))
-    scenarios = [
-        _scenario("predict_uq_interval_default", _obs(default), [
-            _acceptance("CE-REQ-PRED-API-001", "exception_raised", False, default.exception_raised),
-            _acceptance("CE-REQ-PRED-API-001", "y_hat_len == n_instances", True, default.y_hat_len == default.n_instances),
-            _acceptance("CE-REQ-PRED-API-001", "low_is_none", False, default.low_is_none),
-            _acceptance("CE-REQ-PRED-API-001", "high_is_none", False, default.high_is_none),
-            _acceptance("CE-REQ-PRED-INTERVAL-BOUNDS-001", "bounds_ordered", True, default.bounds_ordered),
-        ]),
-        _scenario("predict_uq_interval_percentiles_10_90", _obs(custom), [
-            _acceptance("CE-REQ-PRED-INTERVAL-BOUNDS-001", "exception_raised", False, custom.exception_raised),
-            _acceptance("CE-REQ-PRED-INTERVAL-BOUNDS-001", "bounds_ordered", True, custom.bounds_ordered),
-        ]),
-    ]
-    return _payload("PRED-001", claim_ids=["CE-CAP-PRED-001"], requirement_ids=["CE-REQ-PRED-API-001", "CE-REQ-PRED-INTERVAL-BOUNDS-001"], adr_refs=["ADR-013", "ADR-021"], tif_ids=["CE-TIF-PRED-001"], verification_type="behavioral_contract", dataset_id=_DATASET_REG, scenarios=scenarios)
-
-
-def run_pred_class() -> dict[str, Any]:
-    from tif_classification import run_classification_tif_scenario
-
-    obs = run_classification_tif_scenario()
-    scenarios = [_scenario("classification_api_and_bounds", _obs(obs), [
-        _acceptance("CE-REQ-PRED-CLASS-API-001", "exception_raised", False, obs.exception_raised),
-        _acceptance("CE-REQ-PRED-CLASS-API-001", "proba_len == n_instances", True, obs.proba_len == obs.n_instances),
-        _acceptance("CE-REQ-PRED-CLASS-API-001", "labels_len == n_instances", True, obs.labels_len == obs.n_instances),
-        _acceptance("CE-REQ-PRED-CLASS-BOUNDS-001", "proba_min >= 0.0", True, obs.proba_min is not None and obs.proba_min >= 0.0),
-        _acceptance("CE-REQ-PRED-CLASS-BOUNDS-001", "proba_max <= 1.0", True, obs.proba_max is not None and obs.proba_max <= 1.0),
-    ])]
-    return _payload("PRED-CLASS-001", claim_ids=["CE-CAP-PRED-CLASS-001"], requirement_ids=["CE-REQ-PRED-CLASS-API-001", "CE-REQ-PRED-CLASS-BOUNDS-001"], adr_refs=["ADR-021"], tif_ids=["CE-TIF-PRED-CLASS-001"], verification_type="numerical_behavior", dataset_id=_DATASET_CLF, scenarios=scenarios)
-
-
-def run_pred_prob() -> dict[str, Any]:
-    from tif_prob_regression import run_prob_regression_tif_scenario
-
-    obs = run_prob_regression_tif_scenario(threshold=0.0)
-    scenarios = [_scenario("prob_regression_threshold_0", _obs(obs), [
-        _acceptance("CE-REQ-PRED-PROB-API-001", "exception_raised", False, obs.exception_raised),
-        _acceptance("CE-REQ-PRED-PROB-API-001", "proba_len == n_instances", True, obs.proba_len == obs.n_instances),
-        _acceptance("CE-REQ-PRED-PROB-BOUNDS-001", "proba_min >= 0.0", True, obs.proba_min is not None and obs.proba_min >= 0.0),
-        _acceptance("CE-REQ-PRED-PROB-BOUNDS-001", "proba_max <= 1.0", True, obs.proba_max is not None and obs.proba_max <= 1.0),
-    ])]
-    return _payload("PRED-PROB-001", claim_ids=["CE-CAP-PRED-PROB-001"], requirement_ids=["CE-REQ-PRED-PROB-API-001", "CE-REQ-PRED-PROB-BOUNDS-001"], adr_refs=["ADR-021"], tif_ids=["CE-TIF-PRED-PROB-001"], verification_type="numerical_behavior", dataset_id=_DATASET_REG, scenarios=scenarios, configuration={"threshold": 0.0})
-
-
-def _single_api_payload(key: str, tif_id: str, claim_id: str, req_id: str, adr_refs: list[str], runner_name: str, scenario_id: str, extra_config: dict[str, Any] | None = None) -> dict[str, Any]:
-    module = __import__(runner_name[0], fromlist=[runner_name[1]])
-    obs = getattr(module, runner_name[1])()
-    acceptance = [
-        _acceptance(req_id, "exception_raised", False, obs.exception_raised),
-    ]
-    if hasattr(obs, "result_is_none"):
-        acceptance.append(_acceptance(req_id, "result_is_none", False, obs.result_is_none))
-    if hasattr(obs, "result_len") and hasattr(obs, "n_instances") and not hasattr(obs, "result_is_str"):
-        acceptance.append(_acceptance(req_id, "result_len == n_instances", True, obs.result_len == obs.n_instances))
-    if hasattr(obs, "calibrated"):
-        acceptance.append(_acceptance(req_id, "calibrated", True, obs.calibrated))
-    if hasattr(obs, "result_is_str"):
-        acceptance.append(_acceptance(req_id, "result_is_str", True, obs.result_is_str))
-    if hasattr(obs, "result_len") and not hasattr(obs, "n_instances"):
-        acceptance.append(_acceptance(req_id, "result_len > 0", True, obs.result_len is not None and obs.result_len > 0))
-    return _payload(key, claim_ids=[claim_id], requirement_ids=[req_id], adr_refs=adr_refs, tif_ids=[tif_id], verification_type="empirical_smoke" if key == "VIZ-001" else "api_contract", dataset_id=_DATASET_CLF, scenarios=[_scenario(scenario_id, _obs(obs), acceptance)], configuration=extra_config)
-
-
-def run_guard() -> dict[str, Any]:
-    return _single_api_payload("GUARD-001", "CE-TIF-GUARD-001", "CE-CAP-GUARD-001", "CE-REQ-GUARD-API-001", ["ADR-032", "ADR-038"], ("tif_guard", "run_guard_tif_scenario"), "explain_factual_with_guarded_options")
-
-
-def run_reject() -> dict[str, Any]:
-    return _single_api_payload("REJECT-001", "CE-TIF-REJECT-001", "CE-CAP-REJECT-001", "CE-REQ-REJECT-API-001", ["ADR-029", "ADR-038"], ("tif_reject", "run_reject_tif_scenario"), "explain_factual_with_reject_policy_flag")
-
-
-def run_mond() -> dict[str, Any]:
-    return _single_api_payload("MOND-001", "CE-TIF-MOND-001", "CE-CAP-MOND-001", "CE-REQ-MOND-API-001", ["ADR-013"], ("tif_mondrian", "run_mondrian_tif_scenario"), "calibrate_with_mondrian_categorizer", {"mondrian_fn": "sign of feature 0 (2 categories)"})
-
-
-def run_narr() -> dict[str, Any]:
-    return _single_api_payload("NARR-001", "CE-TIF-NARR-001", "CE-CAP-NARR-001", "CE-REQ-NARR-API-001", ["ADR-008"], ("tif_narrative", "run_narrative_tif_scenario"), "to_narrative_text_format", {"output_format": "text"})
-
-
-def run_viz() -> dict[str, Any]:
-    return _single_api_payload("VIZ-001", "CE-TIF-VIZ-001", "CE-CAP-VIZ-001", "CE-REQ-VIZ-SMOKE-001", ["ADR-023", "ADR-036", "ADR-037"], ("tif_visualization", "run_visualization_tif_scenario"), "plot_no_raise_agg_backend", {"backend": "Agg", "show": False})
-
-
-def run_filter() -> dict[str, Any]:
-    from tif_filter import run_filter_tif_scenario
-
-    req_map = {
-        "super": "CE-REQ-EXPL-FILTER-SUPER-001",
-        "semi": "CE-REQ-EXPL-FILTER-SEMI-001",
-        "counter": "CE-REQ-EXPL-FILTER-COUNTER-001",
-        "ensured": "CE-REQ-EXPL-FILTER-ENSURED-001",
-        "pareto": "CE-REQ-EXPL-FILTER-PARETO-001",
-    }
-    scenarios = []
-    for filter_type, req_id in req_map.items():
-        obs = run_filter_tif_scenario(filter_type=filter_type)
-        scenarios.append(_scenario(f"filter_{filter_type}", _obs(obs), [
-            _acceptance(req_id, "exception_raised", False, obs.exception_raised),
-            _acceptance(req_id, "collection_result_is_none", False, obs.collection_result_is_none),
-            _acceptance(req_id, "collection_result_len == n_instances", True, obs.collection_result_len == obs.n_instances),
-            _acceptance(req_id, "individual_result_is_none", False, obs.individual_result_is_none),
-            _acceptance(req_id, "alias_result_is_none", False, obs.alias_result_is_none),
-        ]))
-    return _payload("FILTER-001", claim_ids=["CE-CAP-EXPL-FILTER-001"], requirement_ids=list(req_map.values()), adr_refs=["ADR-027"], tif_ids=["CE-TIF-FILTER-001"], verification_type="api_contract", dataset_id=_DATASET_CLF, scenarios=scenarios)
-
-
-_RUNNERS = [
-    ("CE-TIF-EXPL-001", run_expl),
-    ("CE-TIF-EXPL-CONJ-001", run_conj),
-    ("CE-TIF-PRED-001", run_pred),
-    ("CE-TIF-PRED-CLASS-001", run_pred_class),
-    ("CE-TIF-PRED-PROB-001", run_pred_prob),
-    ("CE-TIF-GUARD-001", run_guard),
-    ("CE-TIF-REJECT-001", run_reject),
-    ("CE-TIF-MOND-001", run_mond),
-    ("CE-TIF-NARR-001", run_narr),
-    ("CE-TIF-VIZ-001", run_viz),
-    ("CE-TIF-FILTER-001", run_filter),
-]
-
-
 def main(*, check_current: bool = False) -> int:
     _OUT_DIR.mkdir(parents=True, exist_ok=True)
     print(f"Generating TIF evidence records -> {_OUT_DIR}")
     print(f"  package: {_PACKAGE_VERSION}  commit: {_COMMIT_SHA}")
+
+    try:
+        runners = _discover_active_tifs()
+    except RuntimeError as exc:
+        print(f"DISCOVERY ERROR: {exc}")
+        return 1
+
+    print(f"  discovered {len(runners)} active TIF(s)")
+
+    build_kwargs = {
+        "commit_sha": _COMMIT_SHA,
+        "timestamp": _TIMESTAMP,
+        "date_suffix": _DATE_SUFFIX,
+        "package_version": _PACKAGE_VERSION,
+        "python_version": sys.version.split()[0],
+        "platform_str": sys.platform,
+    }
+
     failed: list[str] = []
     written: list[dict[str, Any]] = []
-    for tif_id, runner in _RUNNERS:
+    for tif_id, module in runners:
         print(f"Running {tif_id}...")
         try:
-            payload = runner()
+            payload = module.build_evidence_payload(**build_kwargs)
             _write(payload)
             written.append(payload)
         except Exception as exc:
             print(f"  ERROR: {exc}")
             failed.append(tif_id)
+
     if check_current:
         current_sha = _git_sha()
         stale = [p["evidence_id"] for p in written if p["commit_sha"] != current_sha]
@@ -397,10 +198,11 @@ def main(*, check_current: bool = False) -> int:
         if failing:
             print(f"  ERROR: generated evidence has failing result: {', '.join(failing)}")
             failed.extend(failing)
+
     if failed:
         print(f"FAILED: {', '.join(failed)}")
         return 1
-    print(f"All {len(_RUNNERS)} TIF evidence records written.")
+    print(f"All {len(runners)} TIF evidence records written.")
     return 0
 
 

--- a/tests/capabilities/test_tif_policy.py
+++ b/tests/capabilities/test_tif_policy.py
@@ -27,10 +27,15 @@ import pytest
 _REPO_ROOT = Path(__file__).parents[2]
 _TIF_PY_DIR = _REPO_ROOT / "development" / "capabilities" / "verification" / "tif"
 
+_TIF_UTILITY_MODULES = {
+    "__init__.py",
+    "tif_evidence_helpers.py",
+}
+
 
 def _get_tif_py_files() -> list[Path]:
-    """Return all .py files under the TIF directory (excluding __init__.py)."""
-    return [p for p in _TIF_PY_DIR.glob("*.py") if p.name != "__init__.py"]
+    """Return TIF scenario .py files (excludes __init__.py and shared utility modules)."""
+    return [p for p in _TIF_PY_DIR.glob("*.py") if p.name not in _TIF_UTILITY_MODULES]
 
 
 def _read_source(path: Path) -> str:
@@ -70,11 +75,7 @@ _FORBIDDEN_INTERNAL_IMPORT = re.compile(
 
 @pytest.mark.parametrize("tif_file", _get_tif_py_files(), ids=lambda p: p.name)
 def test_tif_should_not_import_calibrated_explainer_directly(tif_file: Path):
-    """TIF files must not import CalibratedExplainer from core directly.
-
-    Importing CalibratedExplainer from the internal module bypasses the
-    WrapCalibratedExplainer entry point and exposes internal implementation.
-    """
+    """TIF files must not import CalibratedExplainer from core directly."""
     source = _read_source(tif_file)
     assert not _FORBIDDEN_INTERNAL_IMPORT.search(source), (
         f"TIF policy violation in {tif_file.name}: "
@@ -96,11 +97,7 @@ _FORBIDDEN_DIRECT_CONSTRUCTION = re.compile(
 
 @pytest.mark.parametrize("tif_file", _get_tif_py_files(), ids=lambda p: p.name)
 def test_tif_should_not_construct_explanation_objects_directly(tif_file: Path):
-    """TIF files must not construct FactualExplanation or AlternativeExplanation directly.
-
-    Direct construction bypasses the WrapCalibratedExplainer workflow and produces
-    explanation objects that are not produced through the supported public lifecycle.
-    """
+    """TIF files must not construct FactualExplanation or AlternativeExplanation directly."""
     source = _read_source(tif_file)
     match = _FORBIDDEN_DIRECT_CONSTRUCTION.search(source)
     assert not match, (
@@ -123,15 +120,7 @@ _PRIVATE_MEMBER_PATTERN = re.compile(
 
 @pytest.mark.parametrize("tif_file", _get_tif_py_files(), ids=lambda p: p.name)
 def test_tif_should_not_access_private_members(tif_file: Path):
-    """TIF files must not access private members of CE objects.
-
-    Private member access (._something) on CE objects indicates the TIF is
-    relying on internal implementation details rather than the public API.
-
-    This check uses a heuristic pattern. It looks for ._<attr> access on
-    common CE object variable names. It may miss indirect private access via
-    intermediate variables but provides a focused guard against obvious violations.
-    """
+    """TIF files must not access private members of CE objects."""
     source = _read_source(tif_file)
     match = _PRIVATE_MEMBER_PATTERN.search(source)
     assert not match, (
@@ -162,11 +151,7 @@ def test_tif_directory_should_have_readme():
 
 @pytest.mark.parametrize("tif_file", _get_tif_py_files(), ids=lambda p: p.name)
 def test_tif_python_file_should_have_corresponding_spec(tif_file: Path):
-    """Each TIF executable should be covered by a CE-TIF-*.md specification.
-
-    This is a documentation completeness check, not a behavioral check.
-    It ensures TIF executables are not written without a governing specification.
-    """
+    """Each TIF executable should be covered by a CE-TIF-*.md specification."""
     stem = tif_file.stem  # e.g. "tif_conjunction"
     # Look for any CE-TIF-*.md that references this executable
     md_files = list(_TIF_PY_DIR.glob("CE-TIF-*.md"))
@@ -192,15 +177,7 @@ _TIF_EXEMPTION_RE = re.compile(r"tif_exemption")
 
 
 def test_capability_requirements_should_declare_tif_refs_or_exemption():
-    """Requirements that cite tests/capabilities/ must declare tif_refs or tif_exemption.
-
-    Any requirement whose verification targets include a test in tests/capabilities/
-    is a CE capability-facing requirement and must either:
-    - Declare tif_refs pointing to one or more CE-TIF-*.md interfaces, OR
-    - Declare tif_exemption with a rationale (for non-WrapCalibratedExplainer checks).
-
-    Governance requirements verified through tests/unit/ are excluded from this rule.
-    """
+    """Requirements that cite tests/capabilities/ must declare tif_refs or tif_exemption."""
     repo_root = _REPO_ROOT
     req_dir = repo_root / "development" / "capabilities" / "requirements"
     errors: list[str] = []
@@ -225,4 +202,71 @@ def test_capability_requirements_should_declare_tif_refs_or_exemption():
         "TIF architecture policy: every requirement that cites a test in tests/capabilities/ "
         "must declare tif_refs (pointing to a CE-TIF-*.md interface) or tif_exemption "
         "(with rationale). Missing:\n" + "\n".join(f"  {e}" for e in errors)
+    )
+
+
+# ---------------------------------------------------------------------------
+# Rule 8: Active TIF specs must declare required Identity metadata
+# ---------------------------------------------------------------------------
+
+_REQUIRED_IDENTITY_FIELDS = {"tif_id", "executable", "entry_functions", "evidence_key", "verification_type", "status"}
+
+
+def _spec_table_value(text: str, field: str) -> str:
+    match = re.search(rf"\|\s*{re.escape(field)}\s*\|\s*([^|]+?)\s*\|", text)
+    return match.group(1).strip() if match else ""
+
+
+@pytest.mark.parametrize(
+    "spec_path",
+    sorted(_TIF_PY_DIR.glob("CE-TIF-*.md")),
+    ids=lambda p: p.name,
+)
+def test_active_tif_spec_should_have_required_identity_fields(spec_path: Path):
+    """Active TIF specs must declare all required Identity table fields."""
+    text = spec_path.read_text(encoding="utf-8")
+    status = _spec_table_value(text, "status")
+    if status != "active":
+        pytest.skip(f"{spec_path.name} is not active (status={status!r})")
+
+    missing = [f for f in _REQUIRED_IDENTITY_FIELDS if not _spec_table_value(text, f)]
+    assert not missing, (
+        f"{spec_path.name}: active TIF spec is missing Identity table fields: {sorted(missing)}. "
+        "All active TIF specs must declare these fields so they can be discovered "
+        "dynamically by scripts/generate_tif_evidence.py."
+    )
+
+
+# ---------------------------------------------------------------------------
+# Rule 9: Active TIF executables must expose build_evidence_payload()
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("tif_file", _get_tif_py_files(), ids=lambda p: p.name)
+def test_tif_executable_should_expose_build_evidence_payload(tif_file: Path):
+    """Every TIF scenario executable must expose build_evidence_payload()."""
+    source = _read_source(tif_file)
+    assert "def build_evidence_payload(" in source, (
+        f"TIF policy violation in {tif_file.name}: "
+        "build_evidence_payload() function is not defined. "
+        "Every TIF executable must expose this function so it can be discovered "
+        "and called dynamically by scripts/generate_tif_evidence.py."
+    )
+
+
+# ---------------------------------------------------------------------------
+# Rule 10: TIF README table must not have stale entries (bidirectional check)
+# ---------------------------------------------------------------------------
+
+
+def test_tif_readme_should_not_have_stale_entries():
+    """README table entries must resolve to existing CE-TIF-*.md spec files."""
+    readme = (_TIF_PY_DIR / "README.md").read_text(encoding="utf-8")
+    existing_spec_names = {p.name for p in _TIF_PY_DIR.glob("CE-TIF-*.md")}
+
+    referenced_in_readme = re.findall(r"CE-TIF-[A-Z0-9-]+\.md", readme)
+    stale = [name for name in referenced_in_readme if name not in existing_spec_names]
+    assert not stale, (
+        f"TIF README contains entries with no corresponding CE-TIF-*.md spec file: {stale}. "
+        "Remove stale README table rows or add the missing spec files."
     )

--- a/tests/capabilities/test_tif_policy.py
+++ b/tests/capabilities/test_tif_policy.py
@@ -75,7 +75,11 @@ _FORBIDDEN_INTERNAL_IMPORT = re.compile(
 
 @pytest.mark.parametrize("tif_file", _get_tif_py_files(), ids=lambda p: p.name)
 def test_tif_should_not_import_calibrated_explainer_directly(tif_file: Path):
-    """TIF files must not import CalibratedExplainer from core directly."""
+    """TIF files must not import CalibratedExplainer from core directly.
+
+    Importing CalibratedExplainer from the internal module bypasses the
+    WrapCalibratedExplainer entry point and exposes internal implementation.
+    """
     source = _read_source(tif_file)
     assert not _FORBIDDEN_INTERNAL_IMPORT.search(source), (
         f"TIF policy violation in {tif_file.name}: "
@@ -97,7 +101,11 @@ _FORBIDDEN_DIRECT_CONSTRUCTION = re.compile(
 
 @pytest.mark.parametrize("tif_file", _get_tif_py_files(), ids=lambda p: p.name)
 def test_tif_should_not_construct_explanation_objects_directly(tif_file: Path):
-    """TIF files must not construct FactualExplanation or AlternativeExplanation directly."""
+    """TIF files must not construct FactualExplanation or AlternativeExplanation directly.
+
+    Direct construction bypasses the WrapCalibratedExplainer workflow and produces
+    explanation objects that are not produced through the supported public lifecycle.
+    """
     source = _read_source(tif_file)
     match = _FORBIDDEN_DIRECT_CONSTRUCTION.search(source)
     assert not match, (
@@ -120,7 +128,15 @@ _PRIVATE_MEMBER_PATTERN = re.compile(
 
 @pytest.mark.parametrize("tif_file", _get_tif_py_files(), ids=lambda p: p.name)
 def test_tif_should_not_access_private_members(tif_file: Path):
-    """TIF files must not access private members of CE objects."""
+    """TIF files must not access private members of CE objects.
+
+    Private member access (._something) on CE objects indicates the TIF is
+    relying on internal implementation details rather than the public API.
+
+    This check uses a heuristic pattern. It looks for ._<attr> access on
+    common CE object variable names. It may miss indirect private access via
+    intermediate variables but provides a focused guard against obvious violations.
+    """
     source = _read_source(tif_file)
     match = _PRIVATE_MEMBER_PATTERN.search(source)
     assert not match, (
@@ -151,7 +167,11 @@ def test_tif_directory_should_have_readme():
 
 @pytest.mark.parametrize("tif_file", _get_tif_py_files(), ids=lambda p: p.name)
 def test_tif_python_file_should_have_corresponding_spec(tif_file: Path):
-    """Each TIF executable should be covered by a CE-TIF-*.md specification."""
+    """Each TIF executable should be covered by a CE-TIF-*.md specification.
+
+    This is a documentation completeness check, not a behavioral check.
+    It ensures TIF executables are not written without a governing specification.
+    """
     stem = tif_file.stem  # e.g. "tif_conjunction"
     # Look for any CE-TIF-*.md that references this executable
     md_files = list(_TIF_PY_DIR.glob("CE-TIF-*.md"))
@@ -177,7 +197,15 @@ _TIF_EXEMPTION_RE = re.compile(r"tif_exemption")
 
 
 def test_capability_requirements_should_declare_tif_refs_or_exemption():
-    """Requirements that cite tests/capabilities/ must declare tif_refs or tif_exemption."""
+    """Requirements that cite tests/capabilities/ must declare tif_refs or tif_exemption.
+
+    Any requirement whose verification targets include a test in tests/capabilities/
+    is a CE capability-facing requirement and must either:
+    - Declare tif_refs pointing to one or more CE-TIF-*.md interfaces, OR
+    - Declare tif_exemption with a rationale (for non-WrapCalibratedExplainer checks).
+
+    Governance requirements verified through tests/unit/ are excluded from this rule.
+    """
     repo_root = _REPO_ROOT
     req_dir = repo_root / "development" / "capabilities" / "requirements"
     errors: list[str] = []
@@ -223,7 +251,11 @@ def _spec_table_value(text: str, field: str) -> str:
     ids=lambda p: p.name,
 )
 def test_active_tif_spec_should_have_required_identity_fields(spec_path: Path):
-    """Active TIF specs must declare all required Identity table fields."""
+    """Active TIF specs must declare all required Identity table fields.
+
+    Required fields enable dynamic discovery by scripts/generate_tif_evidence.py
+    without any manually maintained registry.
+    """
     text = spec_path.read_text(encoding="utf-8")
     status = _spec_table_value(text, "status")
     if status != "active":
@@ -244,7 +276,11 @@ def test_active_tif_spec_should_have_required_identity_fields(spec_path: Path):
 
 @pytest.mark.parametrize("tif_file", _get_tif_py_files(), ids=lambda p: p.name)
 def test_tif_executable_should_expose_build_evidence_payload(tif_file: Path):
-    """Every TIF scenario executable must expose build_evidence_payload()."""
+    """Every TIF scenario executable must expose build_evidence_payload().
+
+    build_evidence_payload() is the entry point used by scripts/generate_tif_evidence.py
+    to call each TIF without a manually maintained runner registry.
+    """
     source = _read_source(tif_file)
     assert "def build_evidence_payload(" in source, (
         f"TIF policy violation in {tif_file.name}: "
@@ -260,7 +296,13 @@ def test_tif_executable_should_expose_build_evidence_payload(tif_file: Path):
 
 
 def test_tif_readme_should_not_have_stale_entries():
-    """README table entries must resolve to existing CE-TIF-*.md spec files."""
+    """README table entries must resolve to existing CE-TIF-*.md spec files.
+
+    The existing test checks dynamic specs → README (no missing README entries).
+    This test checks the reverse: README entries → dynamic specs (no stale entries).
+    An entry in the README that has no corresponding CE-TIF-*.md file indicates
+    a retired TIF that was not cleaned up from the table.
+    """
     readme = (_TIF_PY_DIR / "README.md").read_text(encoding="utf-8")
     existing_spec_names = {p.name for p in _TIF_PY_DIR.glob("CE-TIF-*.md")}
 


### PR DESCRIPTION
Remove all manually maintained TIF runner registries. Evidence generation
now discovers active TIFs dynamically by globbing CE-TIF-*.md spec files
and importing each declared executable — no _RUNNERS list, no partial
generators, no manually maintained registry to drift out of sync.

Key changes:
- Add tif_evidence_helpers.py: shared utility (obs_to_dict, acceptance_entry,
  scenario_entry, overall_result, build_payload) — not a registry
- Add build_evidence_payload() to all 11 TIF executables so each is a
  self-contained evidence source callable by generate_tif_evidence.py
- Harden all 11 CE-TIF-*.md Identity tables with evidence_key,
  verification_type, and evidence_builder fields required for dynamic discovery
- Rewrite generate_tif_evidence.py: replace _RUNNERS with _discover_active_tifs()
  that globs specs, parses status/executable, imports module, and validates
  build_evidence_payload() is exposed — raises RuntimeError on any failure
- Retire generate_capability_evidence.py: now exits with code 1 and error
  message pointing to generate_tif_evidence.py (no partial evidence risk)
- Harden test_tif_policy.py: add Rules 8-10 — active TIF specs must declare
  required Identity fields; TIF executables must expose build_evidence_payload();
  README table must not have stale CE-TIF-*.md entries (bidirectional check)

All 83 capability policy tests pass. Dynamic discovery finds all 11 active TIFs.
No new manifest files introduced.